### PR TITLE
refactor: split rh-foundation internals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,7 @@ jobs:
         run: cargo build --workspace --all-features
 
       - name: Build RH CLI
-        run: cargo build --release -p rh
+        run: cargo build --release -p rh-cli
 
   cli:
     name: Test CLI
@@ -186,22 +186,22 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Build RH CLI
-        run: cargo build -p rh
+        run: cargo build -p rh-cli
 
       - name: Test CLI help commands
         run: |
-          cargo run -p rh -- --help
-          cargo run -p rh -- codegen --help
-          cargo run -p rh -- fhirpath --help
-          cargo run -p rh -- download --help
+          cargo run -p rh-cli -- --help
+          cargo run -p rh-cli -- codegen --help
+          cargo run -p rh-cli -- fhirpath --help
+          cargo run -p rh-cli -- download --help
 
       - name: Test fhirpath CLI functionality
         run: |
           # Test FHIRPath parsing
-          cargo run -p rh -- fhirpath parse "Patient.name"
+          cargo run -p rh-cli -- fhirpath parse "Patient.name"
 
           # Test FHIRPath evaluation
-          cargo run -p rh -- fhirpath eval "5 + 3"
+          cargo run -p rh-cli -- fhirpath eval "5 + 3"
 
   conformance:
     name: Conformance Subset

--- a/crates/rh-cql/Cargo.toml
+++ b/crates/rh-cql/Cargo.toml
@@ -7,7 +7,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 authors.workspace = true
-keywords = ["cql", "elm", "fhir", "clinical-quality-language", "healthcare"]
+keywords = ["cql", "elm", "fhir", "quality-measure", "healthcare"]
 categories = ["science", "parser-implementations"]
 readme = "README.md"
 

--- a/crates/rh-cql/src/eval/intervals.rs
+++ b/crates/rh-cql/src/eval/intervals.rs
@@ -304,18 +304,15 @@ pub fn meets_before(a: &Value, b: &Value) -> Result<Value, EvalError> {
                 .ok_or_else(|| EvalError::General("meets: incomparable bounds".to_string()))?;
             Ok(Value::Boolean(match ord {
                 Ordering::Equal => a_hc != b_lc, // one closed, one open → adjacent
-                Ordering::Less => {
+                Ordering::Less
                     // For discrete/minimum-precision types, check if successor(a_high) == b_low.
                     // This handles [1,10] meets [11,20] (successor(10)=11) and decimal/time.
-                    if a_hc && b_lc {
+                    if a_hc && b_lc => {
                         match super::operators::successor(ah) {
                             Ok(succ) => cql_compare(&succ, bl) == Some(Ordering::Equal),
                             Err(_) => false,
                         }
-                    } else {
-                        false
                     }
-                }
                 _ => false,
             }))
         }
@@ -374,12 +371,11 @@ pub fn union_interval(a: &Value, b: &Value) -> Result<Value, EvalError> {
     }
     // Must overlap or meet to form a single interval.
     match overlaps(a, b)? {
-        Value::Boolean(false) => {
+        Value::Boolean(false)
             // Check meets
-            if meets(a, b)? != Value::Boolean(true) {
+            if meets(a, b)? != Value::Boolean(true) => {
                 return Ok(Value::Null);
             }
-        }
         Value::Null => return Ok(Value::Null),
         _ => {}
     }

--- a/crates/rh-cql/src/eval/queries.rs
+++ b/crates/rh-cql/src/eval/queries.rs
@@ -96,16 +96,14 @@ where
             }
 
             match rel_type {
-                "with" => {
-                    if !any_match {
+                "with"
+                    if !any_match => {
                         continue 'row; // no match → skip this row
                     }
-                }
-                "without" => {
-                    if any_match {
+                "without"
+                    if any_match => {
                         continue 'row; // match found → skip this row
                     }
-                }
                 _ => {}
             }
         }

--- a/crates/rh-cql/src/eval/queries.rs
+++ b/crates/rh-cql/src/eval/queries.rs
@@ -96,14 +96,12 @@ where
             }
 
             match rel_type {
-                "with"
-                    if !any_match => {
-                        continue 'row; // no match → skip this row
-                    }
-                "without"
-                    if any_match => {
-                        continue 'row; // match found → skip this row
-                    }
+                "with" if !any_match => {
+                    continue 'row; // no match → skip this row
+                }
+                "without" if any_match => {
+                    continue 'row; // match found → skip this row
+                }
                 _ => {}
             }
         }

--- a/crates/rh-cql/src/modelinfo_xml/type_info.rs
+++ b/crates/rh-cql/src/modelinfo_xml/type_info.rs
@@ -279,12 +279,11 @@ fn parse_profile_info<R: BufRead>(reader: &mut Reader<R>, e: &BytesStart) -> Res
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"element" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"element" => {
                     let elem = parse_class_info_element_attrs(&e)?;
                     info.element.push(elem);
                 }
-            }
             Event::End(e) if e.name().as_ref() == b"typeInfo" => break,
             Event::Eof => break,
             _ => {}
@@ -371,12 +370,11 @@ fn parse_tuple_type_info<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"element" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"element" => {
                     let elem = parse_tuple_type_info_element_attrs(&e)?;
                     info.element.push(elem);
                 }
-            }
             Event::End(e) if e.name().as_ref() == b"typeInfo" => break,
             Event::Eof => break,
             _ => {}
@@ -405,13 +403,12 @@ fn parse_tuple_type_info_element<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"elementTypeSpecifier" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"elementTypeSpecifier" => {
                     if let Some(spec) = parse_type_specifier_attrs(&e)? {
                         elem.element_type_specifier = Some(spec);
                     }
                 }
-            }
             Event::End(e) if e.name().as_ref() == b"element" => break,
             Event::Eof => break,
             _ => {}

--- a/crates/rh-cql/src/modelinfo_xml/type_info.rs
+++ b/crates/rh-cql/src/modelinfo_xml/type_info.rs
@@ -279,11 +279,10 @@ fn parse_profile_info<R: BufRead>(reader: &mut Reader<R>, e: &BytesStart) -> Res
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"element" => {
-                    let elem = parse_class_info_element_attrs(&e)?;
-                    info.element.push(elem);
-                }
+            Event::Empty(e) if e.name().as_ref() == b"element" => {
+                let elem = parse_class_info_element_attrs(&e)?;
+                info.element.push(elem);
+            }
             Event::End(e) if e.name().as_ref() == b"typeInfo" => break,
             Event::Eof => break,
             _ => {}
@@ -370,11 +369,10 @@ fn parse_tuple_type_info<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"element" => {
-                    let elem = parse_tuple_type_info_element_attrs(&e)?;
-                    info.element.push(elem);
-                }
+            Event::Empty(e) if e.name().as_ref() == b"element" => {
+                let elem = parse_tuple_type_info_element_attrs(&e)?;
+                info.element.push(elem);
+            }
             Event::End(e) if e.name().as_ref() == b"typeInfo" => break,
             Event::Eof => break,
             _ => {}
@@ -403,12 +401,11 @@ fn parse_tuple_type_info_element<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"elementTypeSpecifier" => {
-                    if let Some(spec) = parse_type_specifier_attrs(&e)? {
-                        elem.element_type_specifier = Some(spec);
-                    }
+            Event::Empty(e) if e.name().as_ref() == b"elementTypeSpecifier" => {
+                if let Some(spec) = parse_type_specifier_attrs(&e)? {
+                    elem.element_type_specifier = Some(spec);
                 }
+            }
             Event::End(e) if e.name().as_ref() == b"element" => break,
             Event::Eof => break,
             _ => {}

--- a/crates/rh-cql/src/modelinfo_xml/type_specifier.rs
+++ b/crates/rh-cql/src/modelinfo_xml/type_specifier.rs
@@ -134,13 +134,12 @@ pub(super) fn parse_list_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"elementTypeSpecifier" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"elementTypeSpecifier" => {
                     if let Some(inner) = parse_type_specifier_attrs(&e)? {
                         spec.element_type_specifier = Some(Box::new(inner));
                     }
                 }
-            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -188,13 +187,12 @@ pub(super) fn parse_interval_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"pointTypeSpecifier" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"pointTypeSpecifier" => {
                     if let Some(inner) = parse_type_specifier_attrs(&e)? {
                         spec.point_type_specifier = Some(Box::new(inner));
                     }
                 }
-            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -234,13 +232,12 @@ pub(super) fn parse_choice_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"choice" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"choice" => {
                     if let Some(inner) = parse_type_specifier_attrs(&e)? {
                         spec.choice.push(inner);
                     }
                 }
-            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -277,12 +274,11 @@ pub(super) fn parse_tuple_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"element" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"element" => {
                     let elem = parse_tuple_element_attrs(&e)?;
                     spec.element.push(elem.into());
                 }
-            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -321,13 +317,12 @@ pub(super) fn parse_tuple_element_definition<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e) => {
-                if e.name().as_ref() == b"elementTypeSpecifier" {
+            Event::Empty(e)
+                if e.name().as_ref() == b"elementTypeSpecifier" => {
                     if let Some(spec) = parse_type_specifier_attrs(&e)? {
                         elem.element_type_specifier = Some(spec);
                     }
                 }
-            }
             Event::End(e) if e.name().as_ref() == b"element" => break,
             Event::Eof => break,
             _ => {}

--- a/crates/rh-cql/src/modelinfo_xml/type_specifier.rs
+++ b/crates/rh-cql/src/modelinfo_xml/type_specifier.rs
@@ -134,12 +134,11 @@ pub(super) fn parse_list_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"elementTypeSpecifier" => {
-                    if let Some(inner) = parse_type_specifier_attrs(&e)? {
-                        spec.element_type_specifier = Some(Box::new(inner));
-                    }
+            Event::Empty(e) if e.name().as_ref() == b"elementTypeSpecifier" => {
+                if let Some(inner) = parse_type_specifier_attrs(&e)? {
+                    spec.element_type_specifier = Some(Box::new(inner));
                 }
+            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -187,12 +186,11 @@ pub(super) fn parse_interval_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"pointTypeSpecifier" => {
-                    if let Some(inner) = parse_type_specifier_attrs(&e)? {
-                        spec.point_type_specifier = Some(Box::new(inner));
-                    }
+            Event::Empty(e) if e.name().as_ref() == b"pointTypeSpecifier" => {
+                if let Some(inner) = parse_type_specifier_attrs(&e)? {
+                    spec.point_type_specifier = Some(Box::new(inner));
                 }
+            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -232,12 +230,11 @@ pub(super) fn parse_choice_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"choice" => {
-                    if let Some(inner) = parse_type_specifier_attrs(&e)? {
-                        spec.choice.push(inner);
-                    }
+            Event::Empty(e) if e.name().as_ref() == b"choice" => {
+                if let Some(inner) = parse_type_specifier_attrs(&e)? {
+                    spec.choice.push(inner);
                 }
+            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -274,11 +271,10 @@ pub(super) fn parse_tuple_type_specifier<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"element" => {
-                    let elem = parse_tuple_element_attrs(&e)?;
-                    spec.element.push(elem.into());
-                }
+            Event::Empty(e) if e.name().as_ref() == b"element" => {
+                let elem = parse_tuple_element_attrs(&e)?;
+                spec.element.push(elem.into());
+            }
             Event::End(e) => {
                 let name = e.name();
                 if name.as_ref() == b"elementTypeSpecifier"
@@ -317,12 +313,11 @@ pub(super) fn parse_tuple_element_definition<R: BufRead>(
                     skip_element(reader)?;
                 }
             }
-            Event::Empty(e)
-                if e.name().as_ref() == b"elementTypeSpecifier" => {
-                    if let Some(spec) = parse_type_specifier_attrs(&e)? {
-                        elem.element_type_specifier = Some(spec);
-                    }
+            Event::Empty(e) if e.name().as_ref() == b"elementTypeSpecifier" => {
+                if let Some(spec) = parse_type_specifier_attrs(&e)? {
+                    elem.element_type_specifier = Some(spec);
                 }
+            }
             Event::End(e) if e.name().as_ref() == b"element" => break,
             Event::Eof => break,
             _ => {}

--- a/crates/rh-foundation/src/loader/archive.rs
+++ b/crates/rh-foundation/src/loader/archive.rs
@@ -1,0 +1,32 @@
+use std::fs;
+use std::path::Path;
+
+use flate2::read::GzDecoder;
+use tar::Archive;
+
+use super::{LoaderError, LoaderResult, PackageDist};
+
+pub(super) fn verify_tarball_checksum(
+    _tarball_data: &[u8],
+    _dist: &PackageDist,
+) -> LoaderResult<()> {
+    tracing::debug!("Checksum verification not yet implemented");
+    Ok(())
+}
+
+pub(super) fn extract_tarball(tarball_data: &[u8], extract_to: &Path) -> LoaderResult<()> {
+    tracing::debug!("Extracting tarball to: {}", extract_to.display());
+
+    fs::create_dir_all(extract_to)?;
+
+    let tar_decoder = GzDecoder::new(tarball_data);
+    let mut archive = Archive::new(tar_decoder);
+
+    archive
+        .unpack(extract_to)
+        .map_err(|e| LoaderError::ArchiveError {
+            message: format!("Failed to extract tarball: {e}"),
+        })?;
+
+    Ok(())
+}

--- a/crates/rh-foundation/src/loader/error.rs
+++ b/crates/rh-foundation/src/loader/error.rs
@@ -1,0 +1,55 @@
+use thiserror::Error;
+
+use crate::FoundationError;
+
+/// Errors that can occur during package loading operations.
+///
+/// This error type extends FoundationError with domain-specific
+/// error variants for package loading and management.
+#[derive(Error, Debug)]
+pub enum LoaderError {
+    /// Package not found in registry.
+    #[error("Package not found: {package}@{version}")]
+    PackageNotFound { package: String, version: String },
+
+    /// Invalid package manifest structure or content.
+    #[error("Invalid package manifest: {message}")]
+    InvalidManifest { message: String },
+
+    /// Archive extraction failed.
+    #[error("Archive extraction failed: {message}")]
+    ArchiveError { message: String },
+
+    /// Package already exists at target location.
+    #[error(
+        "Package already exists: {package}@{version} at {path}. Use --overwrite to replace it."
+    )]
+    PackageExists {
+        package: String,
+        version: String,
+        path: String,
+    },
+
+    /// Foundation error (covers IO, JSON, HTTP, URL parsing, Authentication).
+    #[error(transparent)]
+    Foundation(#[from] FoundationError),
+
+    /// URL parsing error.
+    #[error("URL parsing failed: {0}")]
+    UrlParse(#[from] url::ParseError),
+}
+
+impl From<std::io::Error> for LoaderError {
+    fn from(err: std::io::Error) -> Self {
+        Self::Foundation(FoundationError::Io(err))
+    }
+}
+
+impl From<serde_json::Error> for LoaderError {
+    fn from(err: serde_json::Error) -> Self {
+        Self::Foundation(FoundationError::Serialization(err))
+    }
+}
+
+/// Result type for loader operations.
+pub type LoaderResult<T> = std::result::Result<T, LoaderError>;

--- a/crates/rh-foundation/src/loader/mod.rs
+++ b/crates/rh-foundation/src/loader/mod.rs
@@ -15,162 +15,51 @@
 //! # Example
 //!
 //! ```rust,no_run
-//! use rh_foundation::loader::{PackageLoader, LoaderConfig};
-//! use std::path::Path;
+//! use rh_foundation::loader::{LoaderConfig, PackageLoader};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let config = LoaderConfig::default();
 //!     let loader = PackageLoader::new(config)?;
 //!
-//!     // Download a FHIR package to the default packages directory
 //!     let packages_dir = PackageLoader::get_default_packages_dir()?;
-//!     loader.download_package(
-//!         "hl7.fhir.r4.core",
-//!         "4.0.1",
-//!         &packages_dir
-//!     ).await?;
+//!     loader
+//!         .download_package("hl7.fhir.r4.core", "4.0.1", &packages_dir)
+//!         .await?;
 //!     Ok(())
 //! }
 //! ```
 
-use std::collections::HashMap;
-use std::env;
-use std::fs;
+mod archive;
+mod error;
+mod models;
+mod package_path;
+mod registry;
+
 use std::path::{Path, PathBuf};
+use std::time::Duration;
 
-use flate2::read::GzDecoder;
+pub use error::{LoaderError, LoaderResult};
+pub use models::{LoaderConfig, PackageDist, PackageManifest, RegistryResponse};
 
-use serde::Deserialize;
-use tar::Archive;
-use thiserror::Error;
+use archive::{extract_tarball, verify_tarball_checksum};
+use package_path::{default_packages_dir, package_directory};
+use registry::{
+    fetch_registry_response, latest_version as resolve_latest_version, package_manifest,
+    sorted_versions,
+};
 
-use url::Url;
-
-use crate::FoundationError;
-
-/// Errors that can occur during package loading operations.
-///
-/// This error type extends FoundationError with domain-specific
-/// error variants for package loading and management.
-#[derive(Error, Debug)]
-pub enum LoaderError {
-    /// Package not found in registry
-    #[error("Package not found: {package}@{version}")]
-    PackageNotFound { package: String, version: String },
-
-    /// Invalid package manifest structure or content
-    #[error("Invalid package manifest: {message}")]
-    InvalidManifest { message: String },
-
-    /// Archive extraction failed
-    #[error("Archive extraction failed: {message}")]
-    ArchiveError { message: String },
-
-    /// Package already exists at target location
-    #[error(
-        "Package already exists: {package}@{version} at {path}. Use --overwrite to replace it."
-    )]
-    PackageExists {
-        package: String,
-        version: String,
-        path: String,
-    },
-
-    /// Foundation error (covers IO, JSON, HTTP, URL parsing, Authentication)
-    #[error(transparent)]
-    Foundation(#[from] FoundationError),
-
-    /// URL parsing error
-    #[error("URL parsing failed: {0}")]
-    UrlParse(#[from] url::ParseError),
-}
-
-impl From<std::io::Error> for LoaderError {
-    fn from(err: std::io::Error) -> Self {
-        LoaderError::Foundation(FoundationError::Io(err))
-    }
-}
-
-impl From<serde_json::Error> for LoaderError {
-    fn from(err: serde_json::Error) -> Self {
-        LoaderError::Foundation(FoundationError::Serialization(err))
-    }
-}
-
-/// Result type for loader operations
-pub type LoaderResult<T> = std::result::Result<T, LoaderError>;
-
-/// NPM-style package manifest structure
-#[derive(Debug, Clone, Deserialize)]
-pub struct PackageManifest {
-    pub name: String,
-    pub version: String,
-    pub description: Option<String>,
-    pub dist: PackageDist,
-    pub dependencies: Option<HashMap<String, String>>,
-    pub keywords: Option<Vec<String>>,
-}
-
-/// Package distribution information
-#[derive(Debug, Clone, Deserialize)]
-pub struct PackageDist {
-    pub tarball: String,
-    pub shasum: Option<String>,
-    pub integrity: Option<String>,
-}
-
-/// NPM registry response for package versions
-#[derive(Debug, Deserialize)]
-pub struct RegistryResponse {
-    pub name: String,
-    pub description: Option<String>,
-    pub versions: HashMap<String, PackageManifest>,
-    #[serde(rename = "dist-tags")]
-    pub dist_tags: Option<HashMap<String, String>>,
-}
-
-/// Configuration for package loading operations
-#[derive(Debug, Clone)]
-pub struct LoaderConfig {
-    /// Registry URL (defaults to https://packages.fhir.org)
-    pub registry_url: String,
-    /// Optional authentication token
-    pub auth_token: Option<String>,
-    /// HTTP client timeout in seconds
-    pub timeout_seconds: u64,
-    /// Maximum number of retry attempts
-    pub max_retries: u32,
-    /// Whether to verify checksums when available
-    pub verify_checksums: bool,
-    /// Whether to overwrite existing packages (defaults to false)
-    pub overwrite_existing: bool,
-}
-
-impl Default for LoaderConfig {
-    fn default() -> Self {
-        Self {
-            registry_url: "https://packages.fhir.org".to_string(),
-            auth_token: None,
-            timeout_seconds: 30,
-            max_retries: 3,
-            verify_checksums: false,
-            overwrite_existing: false,
-        }
-    }
-}
-
-/// FHIR package loader for downloading from npm-style registries
+/// FHIR package loader for downloading from npm-style registries.
 pub struct PackageLoader {
     http_client: crate::http::HttpClient,
     config: LoaderConfig,
 }
 
 impl PackageLoader {
-    /// Create a new package loader with the given configuration
+    /// Create a new package loader with the given configuration.
     pub fn new(config: LoaderConfig) -> LoaderResult<Self> {
         let mut builder = crate::http::HttpClient::builder()
-            .timeout(std::time::Duration::from_secs(config.timeout_seconds))
+            .timeout(Duration::from_secs(config.timeout_seconds))
             .user_agent("rh-loader/0.1.0")?;
 
         if let Some(token) = &config.auth_token {
@@ -195,7 +84,7 @@ impl PackageLoader {
         Ok(package_dir.exists())
     }
 
-    /// Download a FHIR package and extract it to the specified directory
+    /// Download a FHIR package and extract it to the specified directory.
     pub async fn download_package(
         &self,
         package_name: &str,
@@ -215,7 +104,6 @@ impl PackageLoader {
         tracing::info!("Downloading FHIR package {}@{}", package_name, version);
 
         let manifest = self.get_package_manifest(package_name, version).await?;
-
         let tarball_data = self.download_tarball(&manifest.dist.tarball).await?;
 
         if self.config.verify_checksums {
@@ -234,18 +122,9 @@ impl PackageLoader {
         Ok(manifest)
     }
 
-    /// Get the default FHIR packages directory (~/.fhir/packages)
+    /// Get the default FHIR packages directory (~/.fhir/packages).
     pub fn get_default_packages_dir() -> LoaderResult<PathBuf> {
-        let home_dir = env::var("HOME")
-            .or_else(|_| env::var("USERPROFILE"))
-            .map_err(|_| {
-                LoaderError::Foundation(FoundationError::Io(std::io::Error::new(
-                    std::io::ErrorKind::NotFound,
-                    "Could not determine home directory",
-                )))
-            })?;
-
-        Ok(PathBuf::from(home_dir).join(".fhir").join("packages"))
+        default_packages_dir()
     }
 
     fn get_package_directory(
@@ -254,53 +133,23 @@ impl PackageLoader {
         package_name: &str,
         version: &str,
     ) -> PathBuf {
-        base_path.join(format!("{package_name}#{version}"))
+        package_directory(base_path, package_name, version)
     }
 
-    /// List available versions for a package
+    /// List available versions for a package.
     pub async fn list_versions(&self, package_name: &str) -> LoaderResult<Vec<String>> {
         let registry_response = self.get_registry_response(package_name).await?;
-        let mut versions: Vec<String> = registry_response.versions.keys().cloned().collect();
-        versions.sort();
-        Ok(versions)
+        Ok(sorted_versions(&registry_response))
     }
 
-    /// Get the latest version for a package
+    /// Get the latest version for a package.
     pub async fn get_latest_version(&self, package_name: &str) -> LoaderResult<String> {
         let registry_response = self.get_registry_response(package_name).await?;
-
-        if let Some(dist_tags) = &registry_response.dist_tags {
-            if let Some(latest) = dist_tags.get("latest") {
-                return Ok(latest.clone());
-            }
-        }
-
-        let versions = self.list_versions(package_name).await?;
-        versions
-            .last()
-            .cloned()
-            .ok_or_else(|| LoaderError::PackageNotFound {
-                package: package_name.to_string(),
-                version: "latest".to_string(),
-            })
+        resolve_latest_version(package_name, &registry_response)
     }
 
     async fn get_registry_response(&self, package_name: &str) -> LoaderResult<RegistryResponse> {
-        let registry_url = Url::parse(&self.config.registry_url)?;
-        let package_url = registry_url.join(package_name)?;
-
-        tracing::debug!("Fetching registry response from: {}", package_url);
-
-        let registry_response: RegistryResponse = self
-            .http_client
-            .download_json(package_url.as_str())
-            .await
-            .map_err(|_| LoaderError::PackageNotFound {
-                package: package_name.to_string(),
-                version: "any".to_string(),
-            })?;
-
-        Ok(registry_response)
+        fetch_registry_response(&self.http_client, &self.config.registry_url, package_name).await
     }
 
     async fn get_package_manifest(
@@ -309,15 +158,7 @@ impl PackageLoader {
         version: &str,
     ) -> LoaderResult<PackageManifest> {
         let registry_response = self.get_registry_response(package_name).await?;
-
-        let version_manifest = registry_response.versions.get(version).ok_or_else(|| {
-            LoaderError::PackageNotFound {
-                package: package_name.to_string(),
-                version: version.to_string(),
-            }
-        })?;
-
-        Ok(version_manifest.clone())
+        package_manifest(package_name, version, &registry_response)
     }
 
     async fn download_tarball(&self, tarball_url: &str) -> LoaderResult<Vec<u8>> {
@@ -332,30 +173,12 @@ impl PackageLoader {
         .map_err(LoaderError::Foundation)
     }
 
-    fn verify_tarball_checksum(
-        &self,
-        _tarball_data: &[u8],
-        _dist: &PackageDist,
-    ) -> LoaderResult<()> {
-        tracing::debug!("Checksum verification not yet implemented");
-        Ok(())
+    fn verify_tarball_checksum(&self, tarball_data: &[u8], dist: &PackageDist) -> LoaderResult<()> {
+        verify_tarball_checksum(tarball_data, dist)
     }
 
     fn extract_tarball(&self, tarball_data: &[u8], extract_to: &Path) -> LoaderResult<()> {
-        tracing::debug!("Extracting tarball to: {}", extract_to.display());
-
-        fs::create_dir_all(extract_to)?;
-
-        let tar_decoder = GzDecoder::new(tarball_data);
-        let mut archive = Archive::new(tar_decoder);
-
-        archive
-            .unpack(extract_to)
-            .map_err(|e| LoaderError::ArchiveError {
-                message: format!("Failed to extract tarball: {e}"),
-            })?;
-
-        Ok(())
+        extract_tarball(tarball_data, extract_to)
     }
 }
 
@@ -525,7 +348,6 @@ mod tests {
         let loader = PackageLoader::new(config).unwrap();
 
         let default_dir = PackageLoader::get_default_packages_dir().unwrap();
-
         let package_dir = loader.get_package_directory(&default_dir, "hl7.fhir.r4.core", "4.0.1");
 
         let expected_suffix = if cfg!(windows) {
@@ -544,7 +366,6 @@ mod tests {
         let loader = PackageLoader::new(config).unwrap();
 
         let tar_data = create_test_tarball();
-
         let result = loader.extract_tarball(&tar_data, &temp_dir);
 
         let _ = result;

--- a/crates/rh-foundation/src/loader/models.rs
+++ b/crates/rh-foundation/src/loader/models.rs
@@ -1,0 +1,62 @@
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// NPM-style package manifest structure.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PackageManifest {
+    pub name: String,
+    pub version: String,
+    pub description: Option<String>,
+    pub dist: PackageDist,
+    pub dependencies: Option<HashMap<String, String>>,
+    pub keywords: Option<Vec<String>>,
+}
+
+/// Package distribution information.
+#[derive(Debug, Clone, Deserialize)]
+pub struct PackageDist {
+    pub tarball: String,
+    pub shasum: Option<String>,
+    pub integrity: Option<String>,
+}
+
+/// NPM registry response for package versions.
+#[derive(Debug, Deserialize)]
+pub struct RegistryResponse {
+    pub name: String,
+    pub description: Option<String>,
+    pub versions: HashMap<String, PackageManifest>,
+    #[serde(rename = "dist-tags")]
+    pub dist_tags: Option<HashMap<String, String>>,
+}
+
+/// Configuration for package loading operations.
+#[derive(Debug, Clone)]
+pub struct LoaderConfig {
+    /// Registry URL (defaults to https://packages.fhir.org).
+    pub registry_url: String,
+    /// Optional authentication token.
+    pub auth_token: Option<String>,
+    /// HTTP client timeout in seconds.
+    pub timeout_seconds: u64,
+    /// Maximum number of retry attempts.
+    pub max_retries: u32,
+    /// Whether to verify checksums when available.
+    pub verify_checksums: bool,
+    /// Whether to overwrite existing packages (defaults to false).
+    pub overwrite_existing: bool,
+}
+
+impl Default for LoaderConfig {
+    fn default() -> Self {
+        Self {
+            registry_url: "https://packages.fhir.org".to_string(),
+            auth_token: None,
+            timeout_seconds: 30,
+            max_retries: 3,
+            verify_checksums: false,
+            overwrite_existing: false,
+        }
+    }
+}

--- a/crates/rh-foundation/src/loader/package_path.rs
+++ b/crates/rh-foundation/src/loader/package_path.rs
@@ -1,0 +1,23 @@
+use std::env;
+use std::path::{Path, PathBuf};
+
+use crate::FoundationError;
+
+use super::{LoaderError, LoaderResult};
+
+pub(super) fn default_packages_dir() -> LoaderResult<PathBuf> {
+    let home_dir = env::var("HOME")
+        .or_else(|_| env::var("USERPROFILE"))
+        .map_err(|_| {
+            LoaderError::Foundation(FoundationError::Io(std::io::Error::new(
+                std::io::ErrorKind::NotFound,
+                "Could not determine home directory",
+            )))
+        })?;
+
+    Ok(PathBuf::from(home_dir).join(".fhir").join("packages"))
+}
+
+pub(super) fn package_directory(base_path: &Path, package_name: &str, version: &str) -> PathBuf {
+    base_path.join(format!("{package_name}#{version}"))
+}

--- a/crates/rh-foundation/src/loader/registry.rs
+++ b/crates/rh-foundation/src/loader/registry.rs
@@ -1,0 +1,64 @@
+use url::Url;
+
+use crate::http::HttpClient;
+
+use super::{LoaderError, LoaderResult, PackageManifest, RegistryResponse};
+
+pub(super) async fn fetch_registry_response(
+    http_client: &HttpClient,
+    registry_url: &str,
+    package_name: &str,
+) -> LoaderResult<RegistryResponse> {
+    let registry_url = Url::parse(registry_url)?;
+    let package_url = registry_url.join(package_name)?;
+
+    tracing::debug!("Fetching registry response from: {}", package_url);
+
+    http_client
+        .download_json(package_url.as_str())
+        .await
+        .map_err(|_| LoaderError::PackageNotFound {
+            package: package_name.to_string(),
+            version: "any".to_string(),
+        })
+}
+
+pub(super) fn sorted_versions(response: &RegistryResponse) -> Vec<String> {
+    let mut versions: Vec<String> = response.versions.keys().cloned().collect();
+    versions.sort();
+    versions
+}
+
+pub(super) fn latest_version(
+    package_name: &str,
+    response: &RegistryResponse,
+) -> LoaderResult<String> {
+    if let Some(dist_tags) = &response.dist_tags {
+        if let Some(latest) = dist_tags.get("latest") {
+            return Ok(latest.clone());
+        }
+    }
+
+    sorted_versions(response)
+        .last()
+        .cloned()
+        .ok_or_else(|| LoaderError::PackageNotFound {
+            package: package_name.to_string(),
+            version: "latest".to_string(),
+        })
+}
+
+pub(super) fn package_manifest(
+    package_name: &str,
+    version: &str,
+    response: &RegistryResponse,
+) -> LoaderResult<PackageManifest> {
+    response
+        .versions
+        .get(version)
+        .cloned()
+        .ok_or_else(|| LoaderError::PackageNotFound {
+            package: package_name.to_string(),
+            version: version.to_string(),
+        })
+}

--- a/crates/rh-foundation/src/memory/mod.rs
+++ b/crates/rh-foundation/src/memory/mod.rs
@@ -9,24 +9,25 @@
 //! ```
 //! use rh_foundation::memory::{MemoryStore, MemoryStoreConfig};
 //!
-//! // Create a store with default config
 //! let store: MemoryStore<String> = MemoryStore::new(MemoryStoreConfig::default());
 //!
-//! // Insert and retrieve values
 //! store.insert("key1".to_string(), "value1".to_string());
 //! assert_eq!(store.get(&"key1".to_string()), Some("value1".to_string()));
-//!
-//! // Check if key exists
 //! assert!(store.contains(&"key1".to_string()));
 //!
-//! // Remove a value
 //! store.remove(&"key1".to_string());
 //! assert!(!store.contains(&"key1".to_string()));
 //! ```
 
-use std::collections::HashMap;
+mod state;
+mod stats;
+
 use std::hash::Hash;
 use std::sync::{Arc, RwLock};
+
+use state::StoreState;
+pub use stats::MemoryStoreStats;
+use stats::StatsRecorder;
 
 /// Configuration for a memory store.
 #[derive(Debug, Clone, Default)]
@@ -53,33 +54,6 @@ impl MemoryStoreConfig {
     }
 }
 
-/// Statistics for a memory store.
-#[derive(Debug, Clone, Default)]
-pub struct MemoryStoreStats {
-    /// Number of cache hits.
-    pub hits: u64,
-    /// Number of cache misses.
-    pub misses: u64,
-    /// Number of insertions.
-    pub insertions: u64,
-    /// Number of removals.
-    pub removals: u64,
-    /// Number of evictions due to capacity limits.
-    pub evictions: u64,
-}
-
-impl MemoryStoreStats {
-    /// Calculate the hit rate (0.0 to 1.0).
-    pub fn hit_rate(&self) -> f64 {
-        let total = self.hits + self.misses;
-        if total == 0 {
-            0.0
-        } else {
-            self.hits as f64 / total as f64
-        }
-    }
-}
-
 /// A thread-safe in-memory key-value store.
 ///
 /// This store is designed to be WASM-compatible and can be used to cache
@@ -96,9 +70,9 @@ where
     K: Eq + Hash + Clone,
     V: Clone,
 {
-    data: Arc<RwLock<HashMap<K, V>>>,
+    state: Arc<RwLock<StoreState<K, V>>>,
     config: MemoryStoreConfig,
-    stats: Arc<RwLock<MemoryStoreStats>>,
+    stats: StatsRecorder,
 }
 
 impl<V, K> Clone for MemoryStore<V, K>
@@ -108,9 +82,9 @@ where
 {
     fn clone(&self) -> Self {
         Self {
-            data: Arc::clone(&self.data),
+            state: Arc::clone(&self.state),
             config: self.config.clone(),
-            stats: Arc::clone(&self.stats),
+            stats: self.stats.clone(),
         }
     }
 }
@@ -132,9 +106,9 @@ where
     /// Create a new memory store with the given configuration.
     pub fn new(config: MemoryStoreConfig) -> Self {
         Self {
-            data: Arc::new(RwLock::new(HashMap::new())),
+            state: Arc::new(RwLock::new(StoreState::new(config.max_entries))),
+            stats: StatsRecorder::new(config.track_stats),
             config,
-            stats: Arc::new(RwLock::new(MemoryStoreStats::default())),
         }
     }
 
@@ -143,40 +117,23 @@ where
     /// If the store has a maximum entry limit and is at capacity,
     /// an arbitrary entry will be evicted to make room.
     pub fn insert(&self, key: K, value: V) {
-        let mut data = self.data.write().unwrap();
-
-        // Check capacity and evict if necessary
-        if self.config.max_entries > 0 && data.len() >= self.config.max_entries {
-            // Simple eviction: remove first entry (not LRU, but simple and fast)
-            if let Some(first_key) = data.keys().next().cloned() {
-                data.remove(&first_key);
-                if self.config.track_stats {
-                    self.stats.write().unwrap().evictions += 1;
-                }
-            }
+        let outcome = self.state.write().unwrap().insert(key, value);
+        if outcome.evicted {
+            self.stats.record_eviction();
         }
-
-        data.insert(key, value);
-
-        if self.config.track_stats {
-            self.stats.write().unwrap().insertions += 1;
-        }
+        self.stats.record_insertion();
     }
 
     /// Get a value from the store.
     ///
     /// Returns `Some(value)` if the key exists, `None` otherwise.
     pub fn get(&self, key: &K) -> Option<V> {
-        let data = self.data.read().unwrap();
-        let result = data.get(key).cloned();
+        let result = self.state.read().unwrap().get_cloned(key);
 
-        if self.config.track_stats {
-            let mut stats = self.stats.write().unwrap();
-            if result.is_some() {
-                stats.hits += 1;
-            } else {
-                stats.misses += 1;
-            }
+        if result.is_some() {
+            self.stats.record_hit();
+        } else {
+            self.stats.record_miss();
         }
 
         result
@@ -184,52 +141,50 @@ where
 
     /// Check if a key exists in the store.
     pub fn contains(&self, key: &K) -> bool {
-        self.data.read().unwrap().contains_key(key)
+        self.state.read().unwrap().contains(key)
     }
 
     /// Remove a value from the store.
     ///
     /// Returns the removed value if the key existed.
     pub fn remove(&self, key: &K) -> Option<V> {
-        let result = self.data.write().unwrap().remove(key);
-
-        if self.config.track_stats && result.is_some() {
-            self.stats.write().unwrap().removals += 1;
+        let result = self.state.write().unwrap().remove(key);
+        if result.is_some() {
+            self.stats.record_removal();
         }
-
         result
     }
 
     /// Clear all entries from the store.
     pub fn clear(&self) {
-        self.data.write().unwrap().clear();
+        self.state.write().unwrap().clear();
     }
 
     /// Get the number of entries in the store.
     pub fn len(&self) -> usize {
-        self.data.read().unwrap().len()
+        self.state.read().unwrap().len()
     }
 
     /// Check if the store is empty.
     pub fn is_empty(&self) -> bool {
-        self.data.read().unwrap().is_empty()
+        self.state.read().unwrap().is_empty()
     }
 
     /// Get all keys in the store.
     pub fn keys(&self) -> Vec<K> {
-        self.data.read().unwrap().keys().cloned().collect()
+        self.state.read().unwrap().keys()
     }
 
     /// Get statistics for the store.
     ///
     /// Only meaningful if `track_stats` was enabled in the config.
     pub fn stats(&self) -> MemoryStoreStats {
-        self.stats.read().unwrap().clone()
+        self.stats.snapshot()
     }
 
     /// Reset statistics.
     pub fn reset_stats(&self) {
-        *self.stats.write().unwrap() = MemoryStoreStats::default();
+        self.stats.reset();
     }
 
     /// Get or insert a value using a factory function.
@@ -241,44 +196,25 @@ where
     where
         F: FnOnce() -> V,
     {
-        // Try to get first (read lock only)
-        if let Some(value) = self.get(&key) {
+        if let Some(value) = self.state.read().unwrap().get_cloned(&key) {
+            self.stats.record_hit();
             return value;
         }
 
-        // Need to insert (write lock)
-        let mut data = self.data.write().unwrap();
+        let outcome = self.state.write().unwrap().get_or_insert_with(key, factory);
 
-        // Double-check after acquiring write lock
-        if let Some(value) = data.get(&key) {
-            if self.config.track_stats {
-                self.stats.write().unwrap().hits += 1;
+        if outcome.inserted {
+            self.stats.record_miss();
+            if outcome.evicted {
+                self.stats.record_eviction();
             }
-            return value.clone();
+            self.stats.record_insertion();
+        } else {
+            self.stats.record_miss();
+            self.stats.record_hit();
         }
 
-        // Create and insert
-        let value = factory();
-
-        // Check capacity and evict if necessary
-        if self.config.max_entries > 0 && data.len() >= self.config.max_entries {
-            if let Some(first_key) = data.keys().next().cloned() {
-                data.remove(&first_key);
-                if self.config.track_stats {
-                    self.stats.write().unwrap().evictions += 1;
-                }
-            }
-        }
-
-        data.insert(key, value.clone());
-
-        if self.config.track_stats {
-            let mut stats = self.stats.write().unwrap();
-            stats.misses += 1;
-            stats.insertions += 1;
-        }
-
-        value
+        outcome.value
     }
 }
 
@@ -309,7 +245,6 @@ mod tests {
         store.insert("b".to_string(), 2);
         assert_eq!(store.len(), 2);
 
-        // This should evict one entry
         store.insert("c".to_string(), 3);
         assert_eq!(store.len(), 2);
         assert_eq!(store.stats().evictions, 1);
@@ -340,7 +275,6 @@ mod tests {
         let value = store.get_or_insert_with("key1".to_string(), || 42);
         assert_eq!(value, 42);
 
-        // Should return cached value, not call factory
         let value = store.get_or_insert_with("key1".to_string(), || 100);
         assert_eq!(value, 42);
     }
@@ -377,7 +311,6 @@ mod tests {
         let store2 = store1.clone();
         assert_eq!(store2.get(&"key".to_string()), Some("value".to_string()));
 
-        // Changes in store2 should be visible in store1
         store2.insert("key2".to_string(), "value2".to_string());
         assert_eq!(store1.get(&"key2".to_string()), Some("value2".to_string()));
     }

--- a/crates/rh-foundation/src/memory/state.rs
+++ b/crates/rh-foundation/src/memory/state.rs
@@ -32,7 +32,11 @@ where
     }
 
     pub(super) fn insert(&mut self, key: K, value: V) -> InsertOutcome {
-        let evicted = self.evict_if_at_capacity();
+        let evicted = if self.data.contains_key(&key) {
+            false
+        } else {
+            self.evict_if_at_capacity()
+        };
         self.data.insert(key, value);
         InsertOutcome { evicted }
     }

--- a/crates/rh-foundation/src/memory/state.rs
+++ b/crates/rh-foundation/src/memory/state.rs
@@ -1,0 +1,103 @@
+use std::collections::HashMap;
+use std::hash::Hash;
+
+#[derive(Debug)]
+pub(super) struct StoreState<K, V> {
+    data: HashMap<K, V>,
+    max_entries: usize,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct InsertOutcome {
+    pub(super) evicted: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct GetOrInsertOutcome<V> {
+    pub(super) value: V,
+    pub(super) inserted: bool,
+    pub(super) evicted: bool,
+}
+
+impl<K, V> StoreState<K, V>
+where
+    K: Eq + Hash + Clone,
+    V: Clone,
+{
+    pub(super) fn new(max_entries: usize) -> Self {
+        Self {
+            data: HashMap::new(),
+            max_entries,
+        }
+    }
+
+    pub(super) fn insert(&mut self, key: K, value: V) -> InsertOutcome {
+        let evicted = self.evict_if_at_capacity();
+        self.data.insert(key, value);
+        InsertOutcome { evicted }
+    }
+
+    pub(super) fn get_cloned(&self, key: &K) -> Option<V> {
+        self.data.get(key).cloned()
+    }
+
+    pub(super) fn contains(&self, key: &K) -> bool {
+        self.data.contains_key(key)
+    }
+
+    pub(super) fn remove(&mut self, key: &K) -> Option<V> {
+        self.data.remove(key)
+    }
+
+    pub(super) fn clear(&mut self) {
+        self.data.clear();
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    pub(super) fn keys(&self) -> Vec<K> {
+        self.data.keys().cloned().collect()
+    }
+
+    pub(super) fn get_or_insert_with<F>(&mut self, key: K, factory: F) -> GetOrInsertOutcome<V>
+    where
+        F: FnOnce() -> V,
+    {
+        if let Some(value) = self.data.get(&key) {
+            return GetOrInsertOutcome {
+                value: value.clone(),
+                inserted: false,
+                evicted: false,
+            };
+        }
+
+        let value = factory();
+        let evicted = self.evict_if_at_capacity();
+        self.data.insert(key, value.clone());
+
+        GetOrInsertOutcome {
+            value,
+            inserted: true,
+            evicted,
+        }
+    }
+
+    fn evict_if_at_capacity(&mut self) -> bool {
+        if self.max_entries == 0 || self.data.len() < self.max_entries {
+            return false;
+        }
+
+        if let Some(first_key) = self.data.keys().next().cloned() {
+            self.data.remove(&first_key);
+            return true;
+        }
+
+        false
+    }
+}

--- a/crates/rh-foundation/src/memory/stats.rs
+++ b/crates/rh-foundation/src/memory/stats.rs
@@ -1,0 +1,80 @@
+use std::sync::{Arc, RwLock};
+
+/// Statistics for a memory store.
+#[derive(Debug, Clone, Default)]
+pub struct MemoryStoreStats {
+    /// Number of cache hits.
+    pub hits: u64,
+    /// Number of cache misses.
+    pub misses: u64,
+    /// Number of insertions.
+    pub insertions: u64,
+    /// Number of removals.
+    pub removals: u64,
+    /// Number of evictions due to capacity limits.
+    pub evictions: u64,
+}
+
+impl MemoryStoreStats {
+    /// Calculate the hit rate (0.0 to 1.0).
+    pub fn hit_rate(&self) -> f64 {
+        let total = self.hits + self.misses;
+        if total == 0 {
+            0.0
+        } else {
+            self.hits as f64 / total as f64
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct StatsRecorder {
+    enabled: bool,
+    stats: Arc<RwLock<MemoryStoreStats>>,
+}
+
+impl StatsRecorder {
+    pub(super) fn new(enabled: bool) -> Self {
+        Self {
+            enabled,
+            stats: Arc::new(RwLock::new(MemoryStoreStats::default())),
+        }
+    }
+
+    pub(super) fn snapshot(&self) -> MemoryStoreStats {
+        self.stats.read().unwrap().clone()
+    }
+
+    pub(super) fn reset(&self) {
+        *self.stats.write().unwrap() = MemoryStoreStats::default();
+    }
+
+    pub(super) fn record_hit(&self) {
+        self.update(|stats| stats.hits += 1);
+    }
+
+    pub(super) fn record_miss(&self) {
+        self.update(|stats| stats.misses += 1);
+    }
+
+    pub(super) fn record_insertion(&self) {
+        self.update(|stats| stats.insertions += 1);
+    }
+
+    pub(super) fn record_removal(&self) {
+        self.update(|stats| stats.removals += 1);
+    }
+
+    pub(super) fn record_eviction(&self) {
+        self.update(|stats| stats.evictions += 1);
+    }
+
+    fn update(&self, apply: impl FnOnce(&mut MemoryStoreStats)) {
+        if !self.enabled {
+            return;
+        }
+
+        let mut stats = self.stats.write().unwrap();
+        apply(&mut stats);
+    }
+}

--- a/crates/rh-foundation/src/snapshot/merge_validation.rs
+++ b/crates/rh-foundation/src/snapshot/merge_validation.rs
@@ -1,0 +1,196 @@
+use std::collections::HashMap;
+
+use tracing::trace;
+
+use crate::snapshot::error::SnapshotError;
+use crate::snapshot::types::{ElementBinding, ElementConstraint, ElementType};
+
+pub(super) fn merge_cardinality(
+    base_min: Option<u32>,
+    base_max: Option<&str>,
+    diff_min: Option<u32>,
+    diff_max: Option<&str>,
+    path: &str,
+) -> Result<(u32, String), SnapshotError> {
+    let base_min = base_min.unwrap_or(0);
+    let base_max = base_max.unwrap_or("*");
+    let diff_min = diff_min.unwrap_or(base_min);
+    let diff_max = diff_max.unwrap_or(base_max);
+
+    if diff_min < base_min {
+        return Err(SnapshotError::MergeError(format!(
+            "Invalid cardinality for {path}: differential min ({diff_min}) is less than base min ({base_min})"
+        )));
+    }
+
+    let base_max_numeric = parse_max_cardinality(base_max);
+    let diff_max_numeric = parse_max_cardinality(diff_max);
+
+    match (base_max_numeric, diff_max_numeric) {
+        (Some(base_max_val), Some(diff_max_val)) => {
+            if diff_max_val > base_max_val {
+                return Err(SnapshotError::MergeError(format!(
+                    "Invalid cardinality for {path}: differential max ({diff_max}) is greater than base max ({base_max})"
+                )));
+            }
+        }
+        (Some(_), None) => {
+            return Err(SnapshotError::MergeError(format!(
+                "Invalid cardinality for {path}: differential max ({diff_max}) is greater than base max ({base_max})"
+            )));
+        }
+        (None, _) => {}
+    }
+
+    if let Some(diff_max_val) = diff_max_numeric {
+        if diff_min > diff_max_val {
+            return Err(SnapshotError::MergeError(format!(
+                "Invalid cardinality for {path}: min ({diff_min}) is greater than max ({diff_max})"
+            )));
+        }
+    }
+
+    trace!(
+        "Merged cardinality for {}: {}..{} (from base {}..{}, diff {}..{})",
+        path,
+        diff_min,
+        diff_max,
+        base_min,
+        base_max,
+        diff_min,
+        diff_max
+    );
+
+    Ok((diff_min, diff_max.to_string()))
+}
+
+pub(super) fn merge_types(
+    base_types: Option<&Vec<ElementType>>,
+    diff_types: Option<&Vec<ElementType>>,
+    path: &str,
+) -> Result<Option<Vec<ElementType>>, SnapshotError> {
+    match (base_types, diff_types) {
+        (Some(base), Some(diff)) => {
+            for diff_type in diff {
+                if !base
+                    .iter()
+                    .any(|base_type| base_type.code == diff_type.code)
+                {
+                    return Err(SnapshotError::MergeError(format!(
+                        "Invalid type restriction for {path}: differential type '{}' is not in base types",
+                        diff_type.code
+                    )));
+                }
+            }
+
+            trace!(
+                "Merged types for {path}: {} differential types (restricted from {} base types)",
+                diff.len(),
+                base.len()
+            );
+            Ok(Some(diff.clone()))
+        }
+        (Some(base), None) => Ok(Some(base.clone())),
+        (None, Some(diff)) => Ok(Some(diff.clone())),
+        (None, None) => Ok(None),
+    }
+}
+
+pub(super) fn merge_binding(
+    base_binding: Option<&ElementBinding>,
+    diff_binding: Option<&ElementBinding>,
+    path: &str,
+) -> Result<Option<ElementBinding>, SnapshotError> {
+    match (base_binding, diff_binding) {
+        (Some(base), Some(diff)) => {
+            let base_strength = parse_binding_strength(&base.strength);
+            let diff_strength = parse_binding_strength(&diff.strength);
+
+            if diff_strength < base_strength {
+                return Err(SnapshotError::MergeError(format!(
+                    "Invalid binding for {path}: differential strength '{}' is weaker than base strength '{}'",
+                    diff.strength, base.strength
+                )));
+            }
+
+            trace!(
+                "Merged binding for {path}: {} (from base {})",
+                diff.strength,
+                base.strength
+            );
+            Ok(Some(diff.clone()))
+        }
+        (Some(base), None) => Ok(Some(base.clone())),
+        (None, Some(diff)) => Ok(Some(diff.clone())),
+        (None, None) => Ok(None),
+    }
+}
+
+pub(super) fn merge_constraints(
+    base: &Option<Vec<ElementConstraint>>,
+    diff: &Option<Vec<ElementConstraint>>,
+    path: &str,
+) -> Result<Option<Vec<ElementConstraint>>, SnapshotError> {
+    match (base, diff) {
+        (Some(base_constraints), Some(diff_constraints)) => {
+            let mut merged = base_constraints.clone();
+            let mut seen_keys: HashMap<String, String> = base_constraints
+                .iter()
+                .map(|constraint| {
+                    (
+                        constraint.key.clone(),
+                        constraint.expression.clone().unwrap_or_default(),
+                    )
+                })
+                .collect();
+
+            for diff_constraint in diff_constraints {
+                if let Some(existing_expr) = seen_keys.get(&diff_constraint.key) {
+                    let diff_expr = diff_constraint.expression.as_deref().unwrap_or("");
+                    if existing_expr != diff_expr {
+                        return Err(SnapshotError::MergeError(format!(
+                            "Duplicate constraint key '{}' for {path} with different expressions",
+                            diff_constraint.key
+                        )));
+                    }
+                    continue;
+                }
+
+                seen_keys.insert(
+                    diff_constraint.key.clone(),
+                    diff_constraint.expression.clone().unwrap_or_default(),
+                );
+                merged.push(diff_constraint.clone());
+            }
+
+            trace!(
+                "Merged constraints for {path}: {} total constraints (from {} base + {} differential)",
+                merged.len(),
+                base_constraints.len(),
+                diff_constraints.len()
+            );
+            Ok(Some(merged))
+        }
+        (Some(base_constraints), None) => Ok(Some(base_constraints.clone())),
+        (None, Some(diff_constraints)) => Ok(Some(diff_constraints.clone())),
+        (None, None) => Ok(None),
+    }
+}
+
+fn parse_max_cardinality(max: &str) -> Option<u32> {
+    if max == "*" {
+        None
+    } else {
+        max.parse::<u32>().ok()
+    }
+}
+
+fn parse_binding_strength(strength: &str) -> u8 {
+    match strength.to_lowercase().as_str() {
+        "example" => 0,
+        "preferred" => 1,
+        "extensible" => 2,
+        "required" => 3,
+        _ => 0,
+    }
+}

--- a/crates/rh-foundation/src/snapshot/merger.rs
+++ b/crates/rh-foundation/src/snapshot/merger.rs
@@ -1,8 +1,13 @@
+use std::collections::HashMap;
+
+use tracing::debug;
+
 use crate::snapshot::error::{SnapshotError, SnapshotResult};
+use crate::snapshot::merge_validation::{
+    merge_binding, merge_cardinality, merge_constraints, merge_types,
+};
 use crate::snapshot::path::ElementPath;
 use crate::snapshot::types::ElementDefinition;
-use std::collections::HashMap;
-use tracing::{debug, trace};
 
 pub struct ElementMerger;
 
@@ -32,7 +37,12 @@ impl ElementMerger {
         base: &[ElementDefinition],
     ) -> HashMap<(String, Option<String>), ElementDefinition> {
         base.iter()
-            .map(|e| ((e.path.clone(), e.slice_name.clone()), e.clone()))
+            .map(|element| {
+                (
+                    (element.path.clone(), element.slice_name.clone()),
+                    element.clone(),
+                )
+            })
             .collect()
     }
 
@@ -62,12 +72,12 @@ impl ElementMerger {
     }
 
     fn sort_elements_by_path(elements: &mut [ElementDefinition]) {
-        elements.sort_by(|a, b| match a.path.cmp(&b.path) {
-            std::cmp::Ordering::Equal => match (&a.slice_name, &b.slice_name) {
+        elements.sort_by(|left, right| match left.path.cmp(&right.path) {
+            std::cmp::Ordering::Equal => match (&left.slice_name, &right.slice_name) {
                 (None, None) => std::cmp::Ordering::Equal,
                 (None, Some(_)) => std::cmp::Ordering::Less,
                 (Some(_), None) => std::cmp::Ordering::Greater,
-                (Some(a_name), Some(b_name)) => a_name.cmp(b_name),
+                (Some(left_name), Some(right_name)) => left_name.cmp(right_name),
             },
             other => other,
         });
@@ -78,14 +88,12 @@ impl ElementMerger {
     ) {
         let mut new_elements = Vec::new();
 
-        // Cache ElementPaths for base elements to avoid repeated parsing
         let base_elements: Vec<(&String, ElementPath, &ElementDefinition)> = element_map
             .iter()
-            .filter(|((_, sn), _)| sn.is_none())
-            .map(|((path, _), elem)| (path, ElementPath::new(path), elem))
+            .filter(|((_, slice_name), _)| slice_name.is_none())
+            .map(|((path, _), element)| (path, ElementPath::new(path), element))
             .collect();
 
-        // Collect slice roots
         let slice_roots: Vec<(String, String)> = element_map
             .keys()
             .filter_map(|(path, slice_name)| {
@@ -96,21 +104,21 @@ impl ElementMerger {
         for (slice_path_str, slice_name) in slice_roots {
             let slice_base_path = ElementPath::new(&slice_path_str);
 
-            for (path, elem_path, elem) in &base_elements {
-                if elem_path.is_child_of(&slice_base_path) {
+            for (path, element_path, element) in &base_elements {
+                if element_path.is_child_of(&slice_base_path) {
                     let slice_child_key = ((*path).clone(), Some(slice_name.clone()));
 
                     if !element_map.contains_key(&slice_child_key) {
-                        let mut new_elem = (*elem).clone();
-                        new_elem.slice_name = Some(slice_name.clone());
-                        new_elements.push((slice_child_key, new_elem));
+                        let mut new_element = (*element).clone();
+                        new_element.slice_name = Some(slice_name.clone());
+                        new_elements.push((slice_child_key, new_element));
                     }
                 }
             }
         }
 
-        for (key, elem) in new_elements {
-            element_map.insert(key, elem);
+        for (key, element) in new_elements {
+            element_map.insert(key, element);
         }
     }
 
@@ -118,7 +126,7 @@ impl ElementMerger {
         base: &ElementDefinition,
         diff: &ElementDefinition,
     ) -> Result<ElementDefinition, SnapshotError> {
-        let (merged_min, merged_max) = Self::merge_cardinality(
+        let (merged_min, merged_max) = merge_cardinality(
             base.min,
             base.max.as_deref(),
             diff.min,
@@ -126,19 +134,16 @@ impl ElementMerger {
             &diff.path,
         )?;
 
-        let merged_type = Self::merge_types(base.type_.as_ref(), diff.type_.as_ref(), &diff.path)?;
-
+        let merged_type = merge_types(base.type_.as_ref(), diff.type_.as_ref(), &diff.path)?;
         let merged_binding =
-            Self::merge_binding(base.binding.as_ref(), diff.binding.as_ref(), &diff.path)?;
-
-        let merged_constraints =
-            Self::merge_constraints(&base.constraint, &diff.constraint, &diff.path)?;
+            merge_binding(base.binding.as_ref(), diff.binding.as_ref(), &diff.path)?;
+        let merged_constraints = merge_constraints(&base.constraint, &diff.constraint, &diff.path)?;
 
         Ok(ElementDefinition {
             path: diff.path.clone(),
             id: diff.id.clone().or_else(|| base.id.clone()),
             min: Some(merged_min),
-            max: Some(merged_max.to_string()),
+            max: Some(merged_max),
             type_: merged_type,
             binding: merged_binding,
             constraint: merged_constraints,
@@ -160,192 +165,11 @@ impl ElementMerger {
             slice_name: diff.slice_name.clone().or_else(|| base.slice_name.clone()),
         })
     }
-
-    fn merge_cardinality(
-        base_min: Option<u32>,
-        base_max: Option<&str>,
-        diff_min: Option<u32>,
-        diff_max: Option<&str>,
-        path: &str,
-    ) -> Result<(u32, String), SnapshotError> {
-        let base_min = base_min.unwrap_or(0);
-        let base_max = base_max.unwrap_or("*");
-        let diff_min = diff_min.unwrap_or(base_min);
-        let diff_max = diff_max.unwrap_or(base_max);
-
-        if diff_min < base_min {
-            return Err(SnapshotError::MergeError(format!(
-                "Invalid cardinality for {path}: differential min ({diff_min}) is less than base min ({base_min})"
-            )));
-        }
-
-        let base_max_numeric = Self::parse_max_cardinality(base_max);
-        let diff_max_numeric = Self::parse_max_cardinality(diff_max);
-
-        match (base_max_numeric, diff_max_numeric) {
-            (Some(base_max_val), Some(diff_max_val)) => {
-                if diff_max_val > base_max_val {
-                    return Err(SnapshotError::MergeError(format!(
-                        "Invalid cardinality for {path}: differential max ({diff_max}) is greater than base max ({base_max})"
-                    )));
-                }
-            }
-            (Some(_), None) => {
-                return Err(SnapshotError::MergeError(format!(
-                    "Invalid cardinality for {path}: differential max ({diff_max}) is greater than base max ({base_max})"
-                )));
-            }
-            (None, _) => {}
-        }
-
-        if let Some(diff_max_val) = diff_max_numeric {
-            if diff_min > diff_max_val {
-                return Err(SnapshotError::MergeError(format!(
-                    "Invalid cardinality for {path}: min ({diff_min}) is greater than max ({diff_max})"
-                )));
-            }
-        }
-
-        trace!(
-            "Merged cardinality for {}: {}..{} (from base {}..{}, diff {}..{})",
-            path,
-            diff_min,
-            diff_max,
-            base_min,
-            base_max,
-            diff_min,
-            diff_max
-        );
-
-        Ok((diff_min, diff_max.to_string()))
-    }
-
-    fn parse_max_cardinality(max: &str) -> Option<u32> {
-        if max == "*" {
-            None
-        } else {
-            max.parse::<u32>().ok()
-        }
-    }
-
-    fn merge_types(
-        base_types: Option<&Vec<crate::snapshot::types::ElementType>>,
-        diff_types: Option<&Vec<crate::snapshot::types::ElementType>>,
-        path: &str,
-    ) -> Result<Option<Vec<crate::snapshot::types::ElementType>>, SnapshotError> {
-        match (base_types, diff_types) {
-            (Some(base), Some(diff)) => {
-                for diff_type in diff {
-                    let is_valid = base.iter().any(|base_type| {
-                        if base_type.code != diff_type.code {
-                            return false;
-                        }
-                        true
-                    });
-
-                    if !is_valid {
-                        return Err(SnapshotError::MergeError(format!(
-                            "Invalid type restriction for {path}: differential type '{}' is not in base types",
-                            diff_type.code
-                        )));
-                    }
-                }
-
-                trace!("Merged types for {path}: {} differential types (restricted from {} base types)", diff.len(), base.len());
-                Ok(Some(diff.clone()))
-            }
-            (Some(base), None) => Ok(Some(base.clone())),
-            (None, Some(diff)) => Ok(Some(diff.clone())),
-            (None, None) => Ok(None),
-        }
-    }
-
-    fn merge_binding(
-        base_binding: Option<&crate::snapshot::types::ElementBinding>,
-        diff_binding: Option<&crate::snapshot::types::ElementBinding>,
-        path: &str,
-    ) -> Result<Option<crate::snapshot::types::ElementBinding>, SnapshotError> {
-        match (base_binding, diff_binding) {
-            (Some(base), Some(diff)) => {
-                let base_strength = Self::parse_binding_strength(&base.strength);
-                let diff_strength = Self::parse_binding_strength(&diff.strength);
-
-                if diff_strength < base_strength {
-                    return Err(SnapshotError::MergeError(format!(
-                        "Invalid binding for {path}: differential strength '{}' is weaker than base strength '{}'",
-                        diff.strength, base.strength
-                    )));
-                }
-
-                trace!(
-                    "Merged binding for {path}: {} (from base {})",
-                    diff.strength,
-                    base.strength
-                );
-                Ok(Some(diff.clone()))
-            }
-            (Some(base), None) => Ok(Some(base.clone())),
-            (None, Some(diff)) => Ok(Some(diff.clone())),
-            (None, None) => Ok(None),
-        }
-    }
-
-    fn parse_binding_strength(strength: &str) -> u8 {
-        match strength.to_lowercase().as_str() {
-            "example" => 0,
-            "preferred" => 1,
-            "extensible" => 2,
-            "required" => 3,
-            _ => 0,
-        }
-    }
-
-    fn merge_constraints(
-        base: &Option<Vec<crate::snapshot::types::ElementConstraint>>,
-        diff: &Option<Vec<crate::snapshot::types::ElementConstraint>>,
-        path: &str,
-    ) -> Result<Option<Vec<crate::snapshot::types::ElementConstraint>>, SnapshotError> {
-        match (base, diff) {
-            (Some(base_constraints), Some(diff_constraints)) => {
-                let mut merged = base_constraints.clone();
-                let mut seen_keys: HashMap<String, String> = base_constraints
-                    .iter()
-                    .map(|c| (c.key.clone(), c.expression.clone().unwrap_or_default()))
-                    .collect();
-
-                for diff_constraint in diff_constraints {
-                    if let Some(existing_expr) = seen_keys.get(&diff_constraint.key) {
-                        let diff_expr = diff_constraint.expression.as_deref().unwrap_or("");
-                        if existing_expr != diff_expr {
-                            return Err(SnapshotError::MergeError(format!(
-                                "Duplicate constraint key '{}' for {path} with different expressions",
-                                diff_constraint.key
-                            )));
-                        }
-                        continue;
-                    }
-                    seen_keys.insert(
-                        diff_constraint.key.clone(),
-                        diff_constraint.expression.clone().unwrap_or_default(),
-                    );
-                    merged.push(diff_constraint.clone());
-                }
-
-                trace!("Merged constraints for {path}: {} total constraints (from {} base + {} differential)", 
-                    merged.len(), base_constraints.len(), diff_constraints.len());
-                Ok(Some(merged))
-            }
-            (Some(base_constraints), None) => Ok(Some(base_constraints.clone())),
-            (None, Some(diff_constraints)) => Ok(Some(diff_constraints.clone())),
-            (None, None) => Ok(None),
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::snapshot::types::ElementDefinition;
 
     fn create_element(path: &str, slice_name: Option<&str>) -> ElementDefinition {
         ElementDefinition {
@@ -365,7 +189,7 @@ mod tests {
             is_modifier: None,
             is_modifier_reason: None,
             slicing: None,
-            slice_name: slice_name.map(|s| s.to_string()),
+            slice_name: slice_name.map(|slice| slice.to_string()),
         }
     }
 
@@ -386,14 +210,12 @@ mod tests {
     fn test_expand_slice_children() {
         let mut map = HashMap::new();
 
-        // Base elements
         let base_root = create_element("Patient.identifier", None);
         let base_child = create_element("Patient.identifier.system", None);
 
         map.insert(("Patient.identifier".to_string(), None), base_root);
         map.insert(("Patient.identifier.system".to_string(), None), base_child);
 
-        // Slice root
         let slice_root = create_element("Patient.identifier", Some("MRN"));
         map.insert(
             ("Patient.identifier".to_string(), Some("MRN".to_string())),
@@ -402,7 +224,6 @@ mod tests {
 
         ElementMerger::expand_slice_children(&mut map);
 
-        // Check if child was copied to slice
         assert!(map.contains_key(&(
             "Patient.identifier.system".to_string(),
             Some("MRN".to_string())

--- a/crates/rh-foundation/src/snapshot/mod.rs
+++ b/crates/rh-foundation/src/snapshot/mod.rs
@@ -1,3 +1,7 @@
+mod merge_validation;
+mod path_helpers;
+mod sd_load_support;
+
 pub mod error;
 pub mod generator;
 pub mod merger;

--- a/crates/rh-foundation/src/snapshot/path.rs
+++ b/crates/rh-foundation/src/snapshot/path.rs
@@ -1,3 +1,9 @@
+use crate::snapshot::path_helpers::{
+    find_slice_name, has_reslice, matches_choice_type_parts, normalized_choice_segment,
+    parent_slice_parts, parts_are_parent_child, split_path, starts_with_lowercase,
+    strip_slice_segments,
+};
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ElementPath {
     parts: Vec<String>,
@@ -6,7 +12,7 @@ pub struct ElementPath {
 
 impl ElementPath {
     pub fn new(path: &str) -> Self {
-        let parts: Vec<String> = path.split('.').map(|s| s.to_string()).collect();
+        let parts = split_path(path);
         Self {
             parts,
             original: path.to_string(),
@@ -46,17 +52,7 @@ impl ElementPath {
     }
 
     pub fn is_parent_of(&self, other: &ElementPath) -> bool {
-        if self.depth() >= other.depth() {
-            return false;
-        }
-
-        for (i, part) in self.parts.iter().enumerate() {
-            if other.parts.get(i) != Some(part) {
-                return false;
-            }
-        }
-
-        true
+        parts_are_parent_child(&self.parts, &other.parts)
     }
 
     pub fn is_child_of(&self, other: &ElementPath) -> bool {
@@ -99,41 +95,19 @@ impl ElementPath {
     }
 
     pub fn matches_choice_type(&self, base_path: &ElementPath) -> bool {
-        if self.depth() != base_path.depth() {
-            return false;
-        }
-
-        for i in 0..self.parts.len() - 1 {
-            if self.parts[i] != base_path.parts[i] {
-                return false;
-            }
-        }
-
-        let base_last = base_path.parts.last().unwrap();
-        let self_last = self.parts.last().unwrap();
-
-        if base_last.ends_with("[x]") {
-            let base_prefix = &base_last[..base_last.len() - 3];
-            self_last.starts_with(base_prefix)
-        } else {
-            false
-        }
+        matches_choice_type_parts(&self.parts, &base_path.parts)
     }
 
     fn is_lowercase_start(s: &str) -> bool {
-        s.chars().next().is_some_and(|c| c.is_lowercase())
+        starts_with_lowercase(s)
     }
 
     pub fn normalize_choice_type(&self) -> ElementPath {
         let mut normalized_parts = self.parts.clone();
         if let Some(last) = normalized_parts.last_mut() {
-            if last.len() > 3 && Self::is_lowercase_start(last) {
-                for (i, c) in last.char_indices() {
-                    if c.is_uppercase() {
-                        let prefix = &last[..i];
-                        *last = format!("{prefix}[x]");
-                        break;
-                    }
+            if Self::is_lowercase_start(last) {
+                if let Some(normalized) = normalized_choice_segment(last) {
+                    *last = normalized;
                 }
             }
         }
@@ -145,12 +119,7 @@ impl ElementPath {
     }
 
     pub fn slice_name(&self) -> Option<&str> {
-        for part in &self.parts {
-            if let Some(colon_pos) = part.rfind(':') {
-                return Some(&part[colon_pos + 1..]);
-            }
-        }
-        None
+        find_slice_name(&self.parts)
     }
 
     pub fn base_path(&self) -> ElementPath {
@@ -158,43 +127,17 @@ impl ElementPath {
             return self.clone();
         }
 
-        let base_parts: Vec<String> = self
-            .parts
-            .iter()
-            .map(|part| {
-                if let Some(colon_pos) = part.rfind(':') {
-                    part[..colon_pos].to_string()
-                } else {
-                    part.clone()
-                }
-            })
-            .collect();
-
-        Self::from_parts(base_parts)
+        Self::from_parts(strip_slice_segments(&self.parts))
     }
 
     pub fn is_reslice(&self) -> bool {
-        if let Some(last_part) = self.parts.last() {
-            last_part.matches(':').count() > 1
-        } else {
-            false
-        }
+        self.parts
+            .last()
+            .is_some_and(|last_part| has_reslice(last_part))
     }
 
     pub fn parent_slice(&self) -> Option<ElementPath> {
-        if !self.is_reslice() {
-            return None;
-        }
-
-        if let Some(last_part) = self.parts.last() {
-            let colon_pos = last_part.rfind(':').unwrap();
-            let mut parent_parts = self.parts.clone();
-            parent_parts.pop();
-            parent_parts.push(last_part[..colon_pos].to_string());
-            return Some(Self::from_parts(parent_parts));
-        }
-
-        None
+        parent_slice_parts(&self.parts).map(Self::from_parts)
     }
 }
 

--- a/crates/rh-foundation/src/snapshot/path_helpers.rs
+++ b/crates/rh-foundation/src/snapshot/path_helpers.rs
@@ -1,0 +1,89 @@
+pub(super) fn split_path(path: &str) -> Vec<String> {
+    path.split('.').map(ToString::to_string).collect()
+}
+
+pub(super) fn parts_are_parent_child(parent: &[String], child: &[String]) -> bool {
+    parent.len() < child.len()
+        && parent
+            .iter()
+            .zip(child.iter())
+            .all(|(left, right)| left == right)
+}
+
+pub(super) fn matches_choice_type_parts(parts: &[String], base_parts: &[String]) -> bool {
+    if parts.len() != base_parts.len() || parts.is_empty() {
+        return false;
+    }
+
+    if !parts[..parts.len() - 1]
+        .iter()
+        .zip(base_parts[..base_parts.len() - 1].iter())
+        .all(|(left, right)| left == right)
+    {
+        return false;
+    }
+
+    let Some(base_last) = base_parts.last() else {
+        return false;
+    };
+    let Some(last) = parts.last() else {
+        return false;
+    };
+
+    if let Some(prefix) = base_last.strip_suffix("[x]") {
+        last.starts_with(prefix)
+    } else {
+        false
+    }
+}
+
+pub(super) fn starts_with_lowercase(value: &str) -> bool {
+    value.chars().next().is_some_and(|c| c.is_lowercase())
+}
+
+pub(super) fn normalized_choice_segment(segment: &str) -> Option<String> {
+    if segment.len() <= 3 || !starts_with_lowercase(segment) {
+        return None;
+    }
+
+    for (index, character) in segment.char_indices() {
+        if character.is_uppercase() {
+            return Some(format!("{}[x]", &segment[..index]));
+        }
+    }
+
+    None
+}
+
+pub(super) fn find_slice_name(parts: &[String]) -> Option<&str> {
+    parts
+        .iter()
+        .find_map(|part| part.rsplit_once(':').map(|(_, name)| name))
+}
+
+pub(super) fn strip_slice_segments(parts: &[String]) -> Vec<String> {
+    parts
+        .iter()
+        .map(|part| {
+            part.rsplit_once(':')
+                .map_or_else(|| part.clone(), |(base, _)| base.to_string())
+        })
+        .collect()
+}
+
+pub(super) fn has_reslice(part: &str) -> bool {
+    part.matches(':').count() > 1
+}
+
+pub(super) fn parent_slice_parts(parts: &[String]) -> Option<Vec<String>> {
+    let last_part = parts.last()?;
+    let (parent_slice, _) = last_part.rsplit_once(':')?;
+    if !has_reslice(last_part) {
+        return None;
+    }
+
+    let mut parent_parts = parts.to_vec();
+    parent_parts.pop();
+    parent_parts.push(parent_slice.to_string());
+    Some(parent_parts)
+}

--- a/crates/rh-foundation/src/snapshot/sd_load_support.rs
+++ b/crates/rh-foundation/src/snapshot/sd_load_support.rs
@@ -1,0 +1,102 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::snapshot::error::{SnapshotError, SnapshotResult};
+use crate::snapshot::types::StructureDefinition;
+
+pub(super) fn read_file(path: &Path) -> SnapshotResult<String> {
+    fs::read_to_string(path).map_err(|error| {
+        SnapshotError::Other(format!("Failed to read file {}: {}", path.display(), error))
+    })
+}
+
+pub(super) fn ensure_directory(dir: &Path) -> SnapshotResult<()> {
+    if !dir.exists() {
+        return Err(SnapshotError::Other(format!(
+            "Directory does not exist: {}",
+            dir.display()
+        )));
+    }
+
+    if !dir.is_dir() {
+        return Err(SnapshotError::Other(format!(
+            "Path is not a directory: {}",
+            dir.display()
+        )));
+    }
+
+    Ok(())
+}
+
+pub(super) fn json_files_in_directory(dir: &Path) -> SnapshotResult<Vec<PathBuf>> {
+    let entries = fs::read_dir(dir).map_err(|error| {
+        SnapshotError::Other(format!(
+            "Failed to read directory {}: {}",
+            dir.display(),
+            error
+        ))
+    })?;
+
+    let mut files = Vec::new();
+    for entry in entries {
+        let entry = entry.map_err(|error| {
+            SnapshotError::Other(format!("Failed to read directory entry: {error}"))
+        })?;
+        let path = entry.path();
+        if path.is_file()
+            && path
+                .extension()
+                .is_some_and(|extension| extension == "json")
+        {
+            files.push(path);
+        }
+    }
+
+    Ok(files)
+}
+
+pub(super) fn try_parse_structure_definition(
+    content: &str,
+) -> SnapshotResult<Option<StructureDefinition>> {
+    let json: serde_json::Value =
+        serde_json::from_str(content).map_err(SnapshotError::SerializationError)?;
+
+    if json.get("resourceType")
+        != Some(&serde_json::Value::String(
+            "StructureDefinition".to_string(),
+        ))
+    {
+        return Ok(None);
+    }
+
+    let structure_definition =
+        serde_json::from_value(json).map_err(SnapshotError::SerializationError)?;
+    validate_structure_definition(&structure_definition)?;
+    Ok(Some(structure_definition))
+}
+
+pub(super) fn validate_structure_definition(sd: &StructureDefinition) -> SnapshotResult<()> {
+    if sd.url.is_empty() {
+        return Err(SnapshotError::InvalidStructureDefinition(
+            "StructureDefinition.url is required".to_string(),
+        ));
+    }
+
+    if sd.name.is_empty() {
+        return Err(SnapshotError::InvalidStructureDefinition(
+            "StructureDefinition.name is required".to_string(),
+        ));
+    }
+
+    if sd.type_.is_empty() {
+        return Err(SnapshotError::InvalidStructureDefinition(
+            "StructureDefinition.type is required".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+pub(super) fn package_directory(packages_dir: &Path, package_name: &str, version: &str) -> PathBuf {
+    packages_dir.join(format!("{package_name}#{version}"))
+}

--- a/crates/rh-foundation/src/snapshot/sd_loader.rs
+++ b/crates/rh-foundation/src/snapshot/sd_loader.rs
@@ -1,8 +1,13 @@
-use crate::snapshot::error::{SnapshotError, SnapshotResult};
-use crate::snapshot::types::StructureDefinition;
-use std::fs;
 use std::path::{Path, PathBuf};
+
 use tracing::{debug, info, warn};
+
+use crate::snapshot::error::{SnapshotError, SnapshotResult};
+use crate::snapshot::sd_load_support::{
+    ensure_directory, json_files_in_directory, package_directory, read_file,
+    try_parse_structure_definition, validate_structure_definition,
+};
+use crate::snapshot::types::StructureDefinition;
 
 pub struct StructureDefinitionLoader;
 
@@ -10,18 +15,18 @@ impl StructureDefinitionLoader {
     pub fn load_from_file(path: &Path) -> SnapshotResult<StructureDefinition> {
         debug!("Loading StructureDefinition from file: {}", path.display());
 
-        let content = fs::read_to_string(path).map_err(|e| {
-            SnapshotError::Other(format!("Failed to read file {}: {}", path.display(), e))
-        })?;
-
-        let sd: StructureDefinition =
+        let content = read_file(path)?;
+        let structure_definition: StructureDefinition =
             serde_json::from_str(&content).map_err(SnapshotError::SerializationError)?;
 
-        Self::validate_structure_definition(&sd)?;
+        Self::validate_structure_definition(&structure_definition)?;
 
-        info!("Loaded StructureDefinition: {} ({})", sd.name, sd.url);
+        info!(
+            "Loaded StructureDefinition: {} ({})",
+            structure_definition.name, structure_definition.url
+        );
 
-        Ok(sd)
+        Ok(structure_definition)
     }
 
     pub fn load_from_directory(dir: &Path) -> SnapshotResult<Vec<StructureDefinition>> {
@@ -30,51 +35,21 @@ impl StructureDefinitionLoader {
             dir.display()
         );
 
-        if !dir.exists() {
-            return Err(SnapshotError::Other(format!(
-                "Directory does not exist: {}",
-                dir.display()
-            )));
-        }
-
-        if !dir.is_dir() {
-            return Err(SnapshotError::Other(format!(
-                "Path is not a directory: {}",
-                dir.display()
-            )));
-        }
+        ensure_directory(dir)?;
 
         let mut structure_definitions = Vec::new();
-        let entries = fs::read_dir(dir).map_err(|e| {
-            SnapshotError::Other(format!("Failed to read directory {}: {}", dir.display(), e))
-        })?;
-
-        for entry in entries {
-            let entry = entry.map_err(|e| {
-                SnapshotError::Other(format!("Failed to read directory entry: {e}"))
-            })?;
-
-            let path = entry.path();
-
-            if path.is_file() {
-                if let Some(ext) = path.extension() {
-                    if ext == "json" {
-                        match Self::try_load_structure_definition(&path) {
-                            Ok(Some(sd)) => {
-                                structure_definitions.push(sd);
-                            }
-                            Ok(None) => {
-                                debug!("Skipping non-StructureDefinition file: {}", path.display());
-                            }
-                            Err(e) => {
-                                warn!(
-                                    "Failed to load StructureDefinition from {}: {}",
-                                    path.display(),
-                                    e
-                                );
-                            }
-                        }
-                    }
+        for path in json_files_in_directory(dir)? {
+            match Self::try_load_structure_definition(&path) {
+                Ok(Some(structure_definition)) => structure_definitions.push(structure_definition),
+                Ok(None) => {
+                    debug!("Skipping non-StructureDefinition file: {}", path.display());
+                }
+                Err(error) => {
+                    warn!(
+                        "Failed to load StructureDefinition from {}: {}",
+                        path.display(),
+                        error
+                    );
                 }
             }
         }
@@ -120,58 +95,23 @@ impl StructureDefinitionLoader {
     }
 
     fn try_load_structure_definition(path: &Path) -> SnapshotResult<Option<StructureDefinition>> {
-        let content = fs::read_to_string(path).map_err(|e| {
-            SnapshotError::Other(format!("Failed to read file {}: {}", path.display(), e))
-        })?;
-
-        let json: serde_json::Value =
-            serde_json::from_str(&content).map_err(SnapshotError::SerializationError)?;
-
-        if json.get("resourceType")
-            == Some(&serde_json::Value::String(
-                "StructureDefinition".to_string(),
-            ))
-        {
-            let sd: StructureDefinition =
-                serde_json::from_value(json).map_err(SnapshotError::SerializationError)?;
-
-            Self::validate_structure_definition(&sd)?;
-            Ok(Some(sd))
-        } else {
-            Ok(None)
-        }
+        let content = read_file(path)?;
+        try_parse_structure_definition(&content)
     }
 
     fn validate_structure_definition(sd: &StructureDefinition) -> SnapshotResult<()> {
-        if sd.url.is_empty() {
-            return Err(SnapshotError::InvalidStructureDefinition(
-                "StructureDefinition.url is required".to_string(),
-            ));
-        }
-
-        if sd.name.is_empty() {
-            return Err(SnapshotError::InvalidStructureDefinition(
-                "StructureDefinition.name is required".to_string(),
-            ));
-        }
-
-        if sd.type_.is_empty() {
-            return Err(SnapshotError::InvalidStructureDefinition(
-                "StructureDefinition.type is required".to_string(),
-            ));
-        }
-
-        Ok(())
+        validate_structure_definition(sd)
     }
 
     fn get_package_directory(packages_dir: &Path, package_name: &str, version: &str) -> PathBuf {
-        packages_dir.join(format!("{package_name}#{version}"))
+        package_directory(packages_dir, package_name, version)
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fs;
     use std::io::Write;
     use tempfile::TempDir;
 

--- a/crates/rh-validator/examples/custom_workflow.rs
+++ b/crates/rh-validator/examples/custom_workflow.rs
@@ -125,7 +125,7 @@ fn report_worst_issues(results: &[(String, Value, rh_validator::ValidationResult
         .map(|(id, _, result)| (id.clone(), result.issues.len()))
         .collect();
 
-    resource_issues.sort_by(|a, b| b.1.cmp(&a.1));
+    resource_issues.sort_by_key(|b| std::cmp::Reverse(b.1));
 
     for (id, count) in resource_issues.iter().take(limit) {
         println!("{id}: {count} issues");

--- a/crates/rh-validator/src/validator.rs
+++ b/crates/rh-validator/src/validator.rs
@@ -1373,9 +1373,9 @@ fn validate_string_security(
                 ));
             }
         }
-        Value::String(s) => {
+        Value::String(s)
             // Check for HTML-like content in strings
-            if contains_html_tags(s) {
+            if contains_html_tags(s) => {
                 let issue = if security_checks_enabled {
                     ValidationIssue::error(
                         IssueCode::Invalid,
@@ -1389,7 +1389,6 @@ fn validate_string_security(
                 };
                 issues.push(issue.with_path(current_path.to_string()));
             }
-        }
         _ => {}
     }
 
@@ -2095,17 +2094,16 @@ fn validate_no_embedded_html_recursive(
                 validate_no_embedded_html_recursive(item, &child_path, issues);
             }
         }
-        Value::String(s) => {
+        Value::String(s)
             // Check for embedded HTML tags (security risk)
             // Look for patterns like <tag> or </tag> or <tag />
             // This is reported as a warning (informational) to match Java validator behavior
-            if contains_html_tags(s) {
+            if contains_html_tags(s) => {
                 issues.push(ValidationIssue::warning(
                     IssueCode::Invalid,
                     "The string value contains text that looks like embedded HTML tags. If this content is rendered to HTML without appropriate post-processing, it may be a security risk".to_string(),
                 ).with_path(current_path));
             }
-        }
         _ => {}
     }
 }
@@ -2386,24 +2384,22 @@ fn validate_primitive_format(
                 }
             }
         }
-        "oid" => {
+        "oid"
             // FHIR oid: urn:oid:[0-2](\.(0|[1-9][0-9]*))+
-            if !s.starts_with("urn:oid:") {
+            if !s.starts_with("urn:oid:") => {
                 return Some(ValidationIssue::error(
                     IssueCode::Value,
                     format!("Invalid oid at '{path}': must start with 'urn:oid:'"),
                 ));
             }
-        }
-        "uuid" => {
+        "uuid"
             // FHIR uuid: urn:uuid:[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}
-            if !s.starts_with("urn:uuid:") {
+            if !s.starts_with("urn:uuid:") => {
                 return Some(ValidationIssue::error(
                     IssueCode::Value,
                     format!("Invalid uuid at '{path}': must start with 'urn:uuid:'"),
                 ));
             }
-        }
         "positiveInt" => {
             if let Some(n) = value.as_i64() {
                 if n < 1 {
@@ -2424,14 +2420,13 @@ fn validate_primitive_format(
                 }
             }
         }
-        "base64Binary" => {
-            if !is_valid_base64(s) {
+        "base64Binary"
+            if !is_valid_base64(s) => {
                 return Some(ValidationIssue::error(
                     IssueCode::Value,
                     format!("The value '{s}' is not a valid Base64 value"),
                 ));
             }
-        }
         _ => {}
     }
 

--- a/crates/rh-validator/tests/fhir_test_cases/runner.rs
+++ b/crates/rh-validator/tests/fhir_test_cases/runner.rs
@@ -211,7 +211,7 @@ impl TestRunner {
         // Also add the profile source itself if present
         let profile_source = test.get_profile_source_path(validator_dir);
 
-        for supporting_path in all_supporting.into_iter().chain(profile_source.into_iter()) {
+        for supporting_path in all_supporting.into_iter().chain(profile_source) {
             if supporting_path.exists() {
                 if let Ok(content) = std::fs::read_to_string(&supporting_path) {
                     if let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) {


### PR DESCRIPTION
## Summary
- split `rh-foundation` loader internals into focused submodules while keeping the public API stable
- split memory store internals into dedicated state and stats modules behind the existing `MemoryStore` surface
- extract snapshot helper modules for merge validation, path handling, and StructureDefinition loading support

## Notes
- preserves existing module exports and feature-gated entry points
- leaves workspace versioning and release tags untouched

## Validation
- cargo fmt --all
- cargo test -p rh-foundation --all-features
- cargo clippy -p rh-foundation --all-targets --all-features -- -D warnings