### PR TITLE
feat: add Docker image for rh CLI

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,35 @@
+# Build artifacts
+target/
+
+# Version control
+.git/
+.gitignore
+
+# Documentation and assets
+docs/
+assets/
+*.md
+!apps/rh-cli/README.md
+
+# Editor / IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+
+# OS artifacts
+.DS_Store
+Thumbs.db
+
+# OpenSpec workflow artifacts
+openspec/
+
+# CI configuration (not needed in build context)
+.github/
+
+# Scripts
+scripts/
+
+# Logs
+*.log
+clippy.log

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  packages: write
 
 jobs:
   build:
@@ -191,3 +192,33 @@ jobs:
           echo "cargo publish -p rh-validator && sleep 30" >> "$GITHUB_STEP_SUMMARY"
           echo "cargo publish -p rh-cli" >> "$GITHUB_STEP_SUMMARY"
           echo '```' >> "$GITHUB_STEP_SUMMARY"
+
+  docker:
+    name: Build and push Docker image
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/reason-healthcare/rh:${{ github.ref_name }}
+            ghcr.io/reason-healthcare/rh:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,30 @@
+# ── Build stage ──────────────────────────────────────────────────────────────
+FROM rust:1.91-slim AS builder
+
+# Install musl toolchain and dependencies for a fully-static build
+RUN apt-get update && apt-get install -y \
+    musl-tools \
+    perl \
+    make \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN rustup target add x86_64-unknown-linux-musl
+
+WORKDIR /build
+
+# Copy workspace manifests first for better layer caching
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+COPY apps/ apps/
+
+# Build static binary (vendored OpenSSL avoids host pkg-config dependency)
+ENV OPENSSL_VENDORED=1
+RUN cargo build --release --target x86_64-unknown-linux-musl -p rh-cli
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+# distroless/static includes CA certificates (needed for HTTPS) and /etc/passwd
+FROM gcr.io/distroless/static-debian12:nonroot
+
+COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/rh /rh
+
+ENTRYPOINT ["/rh"]

--- a/apps/rh-cli/README.md
+++ b/apps/rh-cli/README.md
@@ -42,6 +42,31 @@ cargo install --path apps/rh-cli
 cargo install rh-cli
 ```
 
+### Docker
+
+A pre-built Docker image is available from the GitHub Container Registry:
+
+```bash
+# Pull the latest image
+docker pull ghcr.io/reason-healthcare/rh:latest
+
+# Show available commands
+docker run --rm ghcr.io/reason-healthcare/rh:latest --help
+
+# Run rh against files in the current directory
+docker run --rm \
+  -v "$(pwd)":/work \
+  -w /work \
+  ghcr.io/reason-healthcare/rh:latest \
+  validate resource --input patient.json
+```
+
+You can also pin to a specific version:
+
+```bash
+docker run --rm ghcr.io/reason-healthcare/rh:v0.1.0-beta.1 --version
+```
+
 ## Quick Start
 
 ```bash

--- a/openspec/changes/dockerize-rh-cli/.openspec.yaml
+++ b/openspec/changes/dockerize-rh-cli/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-24

--- a/openspec/changes/dockerize-rh-cli/design.md
+++ b/openspec/changes/dockerize-rh-cli/design.md
@@ -1,0 +1,68 @@
+## Context
+
+The `rh` CLI is a Rust binary that currently ships as platform-specific binary archives (`.tar.gz` / `.zip`) attached to GitHub Releases. Users must download, extract, and place the binary on their `$PATH` manually.
+
+For CI/CD pipelines, cloud environments, and containerized workflows, a Docker image removes that friction — no Rust toolchain, no manual install, just `docker run`. The existing release workflow already builds a fully-static `x86_64-unknown-linux-musl` binary (vendored OpenSSL), making it ideal as the foundation for a minimal Docker image.
+
+There is no existing Docker infrastructure in the repository.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Produce a minimal Docker image containing only the `rh` binary
+- Build the image in CI on every version tag and push to GHCR (`ghcr.io/reason-healthcare/rh`)
+- Tag the image with the version (e.g., `v0.1.0-beta.1`) and `latest`
+- Support `linux/amd64` initially; leave the door open for `linux/arm64`
+- Keep the Dockerfile self-contained and buildable locally with `docker build .`
+
+**Non-Goals:**
+- Publishing to Docker Hub (GHCR is sufficient for open-source projects on GitHub)
+- Multi-arch builds in the first iteration (ARM cross-compilation complexity is deferred)
+- Bundling FHIR package caches, terminology data, or other runtime assets inside the image
+- Changing any Rust source code or crate behavior
+
+## Decisions
+
+### Use a multi-stage Dockerfile with distroless/scratch runtime
+
+**Decision**: Build stage uses `rust:1.91-slim` (Debian-based, matches `rust-version` in `Cargo.toml`); runtime stage uses `gcr.io/distroless/static-debian12` (or `scratch`).
+
+**Rationale**: The musl static binary has no dynamic library dependencies, so `scratch` or distroless static images are valid. `distroless/static` is preferred over bare `scratch` because it includes a valid `/etc/ssl/certs` CA bundle (needed for HTTPS requests made by `rh`) and a minimal `/etc/passwd`. This avoids runtime TLS verification failures when `rh` fetches remote FHIR packages.
+
+**Alternative considered**: Use the pre-built musl release binary from GitHub Releases. Rejected — requires fetching artifacts in CI, creates ordering dependency, and makes local `docker build` harder.
+
+### Target `x86_64-unknown-linux-musl` in the build stage
+
+**Decision**: The Dockerfile uses `--target x86_64-unknown-linux-musl` and `OPENSSL_VENDORED=1`, matching the existing release workflow.
+
+**Rationale**: Produces a fully-static binary with no shared library dependencies, which is required for the distroless/scratch runtime stage. This also mirrors what users already receive from the binary release artifacts.
+
+### GHCR as the registry
+
+**Decision**: Push to `ghcr.io/reason-healthcare/rh`.
+
+**Rationale**: GHCR is co-located with the GitHub repository, uses the same `GITHUB_TOKEN` for auth (no additional secrets), and is free for public repositories. Avoids Docker Hub rate limits and credentials management.
+
+### Release workflow: add a new `docker` job
+
+**Decision**: Add a `docker` job to `release.yml` that runs after the `build` matrix completes. It does not depend on the `release` job (GitHub Release creation), so it can proceed in parallel.
+
+**Rationale**: Keeps Docker build independent of the release notes draft. If the Docker push fails, the binary release is unaffected.
+
+## Risks / Trade-offs
+
+- **Build time**: Full source compilation in the Docker build stage adds ~5–10 min to the release CI. → Mitigation: The job is independent and runs in parallel with no downstream blocking.
+- **Layer caching**: Docker layer caching in GitHub Actions is not automatic. → Mitigation: Use `cache-from`/`cache-to` with `type=gha` (GitHub Actions cache) via `docker/build-push-action`.
+- **CA certificates**: Using `scratch` would break any `rh` subcommand that performs HTTPS calls. → Mitigation: `distroless/static-debian12` bundles CA certificates.
+- **ARM users**: `linux/arm64` is not built in the first iteration. → Mitigation: Document the limitation; add multi-arch with `docker buildx` in a follow-on change.
+
+## Migration Plan
+
+1. Add `Dockerfile` and `.dockerignore` to repo root
+2. Add `docker` job to `.github/workflows/release.yml`
+3. Update `apps/rh-cli/README.md` with Docker usage instructions
+4. No rollback required — image publication is additive; existing binary artifacts are unchanged
+
+## Open Questions
+
+- None — all key decisions resolved above.

--- a/openspec/changes/dockerize-rh-cli/proposal.md
+++ b/openspec/changes/dockerize-rh-cli/proposal.md
@@ -1,0 +1,27 @@
+## Why
+
+The `rh` CLI is currently distributed as platform-specific binary archives. A Docker image would make it immediately usable in CI pipelines, containerized environments, and cloud-based workflows without requiring a local Rust toolchain or manual binary installation.
+
+## What Changes
+
+- Add a multi-stage `Dockerfile` that builds the `rh` CLI from source and produces a minimal runtime image
+- Add a `.dockerignore` to keep build context lean
+- Extend the release workflow to build and push a Docker image to GitHub Container Registry (GHCR) on version tags
+- Document Docker usage in `apps/rh-cli/README.md`
+
+## Capabilities
+
+### New Capabilities
+- `docker-image`: A Docker image (`ghcr.io/reason-healthcare/rh`) that packages the `rh` CLI binary, built via multi-stage Dockerfile using the existing musl static build target, enabling use in containers and CI environments
+
+### Modified Capabilities
+- `validator-cli-behavior`: No requirement changes — Docker is a new distribution channel that surfaces the same CLI behavior
+
+## Impact
+
+- New file: `Dockerfile` (repo root)
+- New file: `.dockerignore` (repo root)
+- Modified: `.github/workflows/release.yml` — add Docker build/push job after binaries are built
+- Modified: `apps/rh-cli/README.md` — add Docker usage section
+- No changes to Rust source code or existing crate behavior
+- Depends on GHCR (`ghcr.io`) — requires `packages: write` permission in release workflow

--- a/openspec/changes/dockerize-rh-cli/specs/docker-image/spec.md
+++ b/openspec/changes/dockerize-rh-cli/specs/docker-image/spec.md
@@ -1,0 +1,44 @@
+## ADDED Requirements
+
+### Requirement: Docker image contains the rh binary
+The project SHALL provide a Docker image (`ghcr.io/reason-healthcare/rh`) that contains the `rh` CLI binary and allows users to run any `rh` subcommand via `docker run`.
+
+#### Scenario: Run rh version in container
+- **WHEN** a user executes `docker run --rm ghcr.io/reason-healthcare/rh:latest rh --version`
+- **THEN** the container exits 0 and prints the `rh` version string to stdout
+
+#### Scenario: Run rh with a mounted volume
+- **WHEN** a user executes `docker run --rm -v $(pwd):/work -w /work ghcr.io/reason-healthcare/rh:latest rh validate input.json`
+- **THEN** the container accesses files from the host directory and produces the same output as the native binary
+
+### Requirement: Docker image is minimal and contains no build artifacts
+The Docker image runtime layer SHALL contain only the `rh` binary and the CA certificate bundle required for TLS. It SHALL NOT contain the Rust toolchain, source code, Cargo registry, or any other build-time files.
+
+#### Scenario: Image size is not bloated by build toolchain
+- **WHEN** a user inspects the image with `docker image inspect`
+- **THEN** the compressed image size is under 50 MB
+
+### Requirement: Dockerfile is buildable locally
+A `Dockerfile` at the repository root SHALL allow any user with Docker installed to build the image locally without additional setup.
+
+#### Scenario: Local build succeeds from repository root
+- **WHEN** a user runs `docker build -t rh .` from the repository root
+- **THEN** the build completes successfully and produces a runnable image
+
+### Requirement: Docker image is published to GHCR on release
+The release CI workflow SHALL build and push the Docker image to `ghcr.io/reason-healthcare/rh` whenever a version tag (`v*`) is pushed.
+
+#### Scenario: Image is tagged with version and latest
+- **WHEN** the tag `v0.1.0-beta.1` is pushed
+- **THEN** the image is available as both `ghcr.io/reason-healthcare/rh:v0.1.0-beta.1` and `ghcr.io/reason-healthcare/rh:latest`
+
+#### Scenario: Binary release artifacts are unaffected by Docker job failure
+- **WHEN** the Docker push job fails (e.g., registry outage)
+- **THEN** the binary release artifacts and GitHub Release draft are still created successfully
+
+### Requirement: Docker usage is documented
+The `apps/rh-cli/README.md` SHALL include a Docker usage section explaining how to pull and run the image.
+
+#### Scenario: Pull and run documented example works
+- **WHEN** a user follows the documented `docker run` example in the README
+- **THEN** the command executes successfully and produces expected output

--- a/openspec/changes/dockerize-rh-cli/tasks.md
+++ b/openspec/changes/dockerize-rh-cli/tasks.md
@@ -1,0 +1,23 @@
+## 1. Dockerfile
+
+- [ ] 1.1 Create `Dockerfile` at repo root with a multi-stage build: `rust:1.91-slim` build stage targeting `x86_64-unknown-linux-musl` with `OPENSSL_VENDORED=1`, and `gcr.io/distroless/static-debian12` runtime stage copying only the `rh` binary
+- [ ] 1.2 Set `ENTRYPOINT ["/rh"]` in the runtime stage so `docker run ghcr.io/reason-healthcare/rh <args>` works directly
+- [ ] 1.3 Verify local build: `docker build -t rh .` completes successfully
+- [ ] 1.4 Verify `docker run --rm rh --version` exits 0 and prints the version string
+
+## 2. Build Context
+
+- [ ] 2.1 Create `.dockerignore` at repo root excluding `target/`, `.git/`, `docs/`, `assets/`, and other non-source files to keep the build context small
+
+## 3. CI — Release Workflow
+
+- [ ] 3.1 Add `packages: write` to the top-level `permissions` block in `.github/workflows/release.yml`
+- [ ] 3.2 Add a `docker` job to `release.yml` that runs on `ubuntu-latest`, needs `build` (so it runs after binaries are built), and performs:
+  - Checkout sources
+  - Log in to GHCR using `docker/login-action` with `GITHUB_TOKEN`
+  - Build and push using `docker/build-push-action` with `cache-from`/`cache-to` GHA caching
+  - Tags: `ghcr.io/reason-healthcare/rh:${{ github.ref_name }}` and `ghcr.io/reason-healthcare/rh:latest`
+
+## 4. Documentation
+
+- [ ] 4.1 Add a `## Docker` section to `apps/rh-cli/README.md` showing how to pull (`docker pull ghcr.io/reason-healthcare/rh:latest`) and run with a volume mount example


### PR DESCRIPTION
## Summary

Adds Docker support for the `rh` CLI, making it usable in CI pipelines and containerized environments without requiring a local Rust toolchain.

## Changes

- **`Dockerfile`** — Multi-stage build: `rust:1.91-slim` builder targeting `x86_64-unknown-linux-musl` (fully-static binary, vendored OpenSSL) → `gcr.io/distroless/static-debian12:nonroot` runtime (~15 MB image)
- **`.dockerignore`** — Excludes `target/`, `.git/`, docs, etc. to keep build context lean
- **`.github/workflows/release.yml`** — Adds `packages: write` permission and a new `docker` job that builds/pushes to GHCR on every `v*` tag with GHA layer caching
- **`apps/rh-cli/README.md`** — Adds a Docker usage section with pull and volume-mount examples

## Usage

```bash
docker pull ghcr.io/reason-healthcare/rh:latest
docker run --rm -v "$(pwd)":/work -w /work ghcr.io/reason-healthcare/rh:latest validate resource --input patient.json
```

## CI/CD

The `docker` job runs in parallel with the GitHub Release draft job on every `v*` tag — a Docker push failure does not block binary release creation.