### PR TITLE
refactor(rh-codegen): remove dead code and simplify internals

### DIFF
--- a/crates/rh-codegen/src/generator.rs
+++ b/crates/rh-codegen/src/generator.rs
@@ -38,7 +38,6 @@ pub struct CodeGenerator {
 }
 
 impl CodeGenerator {
-    #[allow(dead_code)] // Methods below are preserved during refactoring transition
     /// Create a new code generator with the given configuration
     pub fn new(config: CodegenConfig) -> Self {
         let value_set_manager = ValueSetManager::new();
@@ -392,11 +391,6 @@ impl CodeGenerator {
         crate::naming::Naming::filename(structure_def)
     }
 
-    /// Generate a comprehensive Resource trait with common FHIR resource methods
-    // pub fn generate_resource_trait(&mut self) -> CodegenResult<String> {
-    //     let mut trait_generator = TraitGenerator::new();
-    //     trait_generator.generate_resource_trait()
-    // }
     /// Generate a trait file directly from a RustTrait object
     pub fn generate_trait_file_from_trait<P: AsRef<Path>>(
         &self,
@@ -407,12 +401,6 @@ impl CodeGenerator {
         let file_generator = FileGenerator::new(&self.config, &self.token_generator);
         file_generator.generate_trait_file_from_trait(rust_trait, output_path)
     }
-
-    // Generate an impl block for the Resource trait
-    // pub fn generate_resource_impl(&self) -> String {
-    //     let trait_generator = TraitGenerator::new();
-    //     trait_generator.generate_resource_impl()
-    // }
 }
 
 #[cfg(test)]

--- a/crates/rh-codegen/src/generators/crate_generator.rs
+++ b/crates/rh-codegen/src/generators/crate_generator.rs
@@ -9,8 +9,6 @@ use std::path::Path;
 use anyhow::Result;
 use chrono::Local;
 
-// use crate::quality::{run_quality_checks, QualityConfig};
-
 /// Parameters for crate generation
 #[derive(Debug, Clone)]
 pub struct CrateGenerationParams<'a> {
@@ -88,7 +86,7 @@ pub fn generate_crate_structure(params: CrateGenerationParams) -> Result<()> {
     fs::write(&cargo_toml_path, cargo_toml_content)?;
 
     // Generate lib.rs with new structure
-    let lib_rs_content = generate_lib_rs_idiomatic()?;
+    let lib_rs_content = generate_lib_rs_idiomatic();
     let lib_rs_path = src_dir.join("lib.rs");
     fs::write(&lib_rs_path, lib_rs_content)?;
 
@@ -198,7 +196,7 @@ path = "src/lib.rs"
 }
 
 /// Generate lib.rs content with idiomatic module structure
-fn generate_lib_rs_idiomatic() -> Result<String> {
+fn generate_lib_rs_idiomatic() -> String {
     let lib_content = r#"//! Generated FHIR Rust bindings
 //!
 //! This crate contains Rust types and traits for FHIR resources and data types.
@@ -248,7 +246,7 @@ pub mod prelude;
 pub use serde::{Deserialize, Serialize};
 "#;
 
-    Ok(lib_content.to_string())
+    lib_content.to_string()
 }
 /// Generate mod.rs files for each module directory
 pub fn generate_module_files(
@@ -378,7 +376,6 @@ fn generate_crate_statistics_from_organized_dirs(
     primitives_dir: &Path,
 ) -> Result<CrateStatistics> {
     let mut num_structs = 0;
-    let num_enums = 0; // Enums would be handled separately
 
     // Count files in each directory
     for dir in [resource_dir, datatypes_dir, extensions_dir, primitives_dir] {
@@ -403,12 +400,10 @@ fn generate_crate_statistics_from_organized_dirs(
         }
     }
 
-    let total_types = num_structs + num_enums;
-
     Ok(CrateStatistics {
         num_structs,
-        num_enums,
-        total_types,
+        num_enums: 0,
+        total_types: num_structs,
         canonical_url: "Unknown".to_string(),
     })
 }

--- a/crates/rh-codegen/src/generators/mod.rs
+++ b/crates/rh-codegen/src/generators/mod.rs
@@ -25,8 +25,6 @@ pub mod file_generator;
 pub mod file_io_manager;
 pub mod import_manager;
 pub mod invariant_generator;
-// #[cfg(test)]
-// pub mod import_manager_integration_test;
 pub mod metadata_generator;
 pub mod mutator_trait_generator;
 pub mod naming_manager;

--- a/crates/rh-codegen/src/generators/trait_impl_generator.rs
+++ b/crates/rh-codegen/src/generators/trait_impl_generator.rs
@@ -20,7 +20,6 @@ impl TraitImplGenerator {
 
     /// Extract the base resource type from a FHIR baseDefinition URL
     /// For example: "http://hl7.org/fhir/StructureDefinition/Group" -> "Group"
-    #[allow(dead_code)]
     fn extract_base_resource_type(base_definition: &str) -> Option<String> {
         // FHIR baseDefinition URLs follow the pattern:
         // http://hl7.org/fhir/StructureDefinition/{ResourceType}
@@ -34,7 +33,6 @@ impl TraitImplGenerator {
 
     /// Check if a baseDefinition indicates this is a core FHIR resource
     /// Core resources inherit directly from Resource or DomainResource
-    #[allow(dead_code)]
     fn is_core_resource(base_definition: &str) -> bool {
         matches!(
             base_definition,


### PR DESCRIPTION
## Summary

Surgical cleanup of `crates/rh-codegen` internals. No behavioral changes. No changes to generated R4 FHIR crate output.

## Changes

### Dead code removal
- Remove dead `// use crate::quality::{run_quality_checks, QualityConfig};` import comment in `crate_generator.rs`
- Remove stale commented `generate_resource_trait` and `generate_resource_impl` method blocks in `generator.rs`
- Remove commented `// #[cfg(test)] // pub mod import_manager_integration_test;` lines in `generators/mod.rs`

### Simplification
- `generate_lib_rs_idiomatic()`: change return type from `Result<String>` to `String` — the function body is purely infallible string concatenation; the `Ok()` wrapper was misleading and forced a spurious `?` at the call site
- Inline dead `num_enums` and `total_types` local variables directly into the `CrateStatistics` struct literal (both were single-assignment constants with no intermediate use)

## Generated R4 FHIR crate

No changes to generated output.