### PR TITLE
feat(packager): generate package.json into output only; packager.toml is sole metadata source

### DIFF
--- a/apps/rh-cli/docs/PACKAGER.md
+++ b/apps/rh-cli/docs/PACKAGER.md
@@ -21,7 +21,7 @@ for the custom processor API.
 
 ### `rh package init`
 
-Scaffold a new FHIR Package source directory with `package.json`, `packager.toml`, and a
+Scaffold a new FHIR Package source directory with `packager.toml` and a
 minimal `ImplementationGuide.json`.
 
 **Usage:**
@@ -87,11 +87,11 @@ rh package init my-r4b-package \
 
 | File | Description |
 |------|-------------|
-| `package.json` | FHIR package manifest with name, version, FHIR version, and base dependency |
-| `packager.toml` | Hook configuration skeleton (all stages empty, built-ins commented) |
+| `packager.toml` | Package metadata and hook configuration skeleton |
 | `ImplementationGuide.json` | Minimal IG with `id`, `name`, `url`, `packageId`, and `dependsOn` |
 
-Returns an error if `package.json` already exists in the target directory.
+`package.json` is **not** created here — it is generated into `output/package/` during `rh package build`.
+Returns an error if `packager.toml` already exists in the target directory.
 
 ---
 
@@ -105,7 +105,7 @@ rh package build [OPTIONS] <DIR>
 ```
 
 **Arguments:**
-- `<DIR>` — Path to the source directory containing `package.json` and FHIR resources
+- `<DIR>` — Path to the source directory containing `packager.toml` and FHIR resources
 
 **Options:**
 - `-o, --out <PATH>` — Output directory for the expanded package (default: `<DIR>/output`)
@@ -122,12 +122,12 @@ rh package build my-package/ --out /tmp/build
 The build pipeline:
 1. Runs `before_build` hook processors (from `packager.toml`)
 2. Processes markdown narrative (embeds `.md` files into matching resource `.text`)
-3. Syncs and validates `ImplementationGuide.json` against `package.json`
+3. Syncs and validates `ImplementationGuide.json` against `packager.toml`
 4. Auto-populates `ImplementationGuide` `dependsOn`, `definition.resource`, and `definition.page`
 5. Applies canonical pinning from `fhir-lock.json` (if present)
 6. Generates `package/.index.json` and `package/examples/.index.json`
 7. Runs `after_build` hook processors
-8. Writes the expanded output directory
+8. Writes the expanded output directory (including generated `package.json`)
 9. Creates the `.tgz` tarball
 
 ---
@@ -212,7 +212,7 @@ rh package check <DIR>
 rh package check my-package/
 ```
 
-Checks that `package.json` and `ImplementationGuide.json` are present and consistent, and that
+Checks that `packager.toml` and `ImplementationGuide.json` are present and consistent, and that
 `fhir-lock.json` is up to date if present. No output is written.
 
 ---
@@ -245,8 +245,7 @@ The source directory can be organised however you like. By convention:
 
 ```
 my-package/
-  package.json                  # FHIR package manifest (required)
-  packager.toml                 # Hook configuration (optional)
+  packager.toml                 # Package metadata and hook configuration (required)
   ImplementationGuide.json      # ImplementationGuide resource (required)
   StructureDefinition-foo.json  # Definitional FHIR resources
   ValueSet-bar.json
@@ -296,18 +295,31 @@ package/
 
 ## `packager.toml` Configuration
 
+`packager.toml` is the **sole source of truth** for all package metadata and hook configuration.
+All metadata you would previously put in `package.json` goes here. `package.json` is **generated**
+into the output directory during `rh package build` — never into the source directory.
+
 ```toml
+# Package / IG metadata
+id           = "example.fhir.my-package"   # required (package name)
+version      = "1.0.0"                     # required
+fhir_version = "4.0.1"                     # required
+canonical    = "https://example.org/fhir"  # required
+description  = "My FHIR Package"           # optional
+author       = "Example Organization"      # optional
+license      = "CC0-1.0"                   # optional
+
 # Shared FHIR packages cache (default: ~/.fhir/packages)
 # packages_dir = "~/.fhir/packages"
 
-# Package / IG metadata (inferred from package.json when absent)
-# canonical    = "https://example.org/fhir"
-# fhir_version = "4.0.1"
-# id           = "my.package"
-# name         = "MyPackage"
-# version      = "1.0.0"
-# status       = "draft"
-# publisher    = "My Organization"
+# Package / IG display metadata
+# name         = "MyPackage"               # default: PascalCase of id
+# status       = "draft"                   # default: "draft"
+# publisher    = "My Organization"         # optional
+
+# Dependency packages (used to generate package.json dependencies)
+[dependencies]
+"hl7.fhir.r4.core" = "4.0.1"
 
 [hooks]
 # Processors run in order before the build stage.
@@ -330,7 +342,7 @@ after_pack   = []
 
 # Custom shell processor
 [processors.my-script]
-command = "python3 scripts/my_script.py"
+command = "./scripts/my_script.sh"
 # working_dir = "."
 # timeout_secs = 60
 # [processors.my-script.env]
@@ -344,9 +356,9 @@ Shell processors receive these environment variables:
 | `PACKAGER_SOURCE_DIR` | Absolute path to the source directory |
 | `PACKAGER_OUTPUT_DIR` | Absolute path to the output directory being assembled |
 | `PACKAGER_WORKDIR` | Temporary directory for resource exchange (see below) |
-| `PACKAGER_PACKAGE_NAME` | Package name from `package.json` |
-| `PACKAGER_PACKAGE_VERSION` | Package version from `package.json` |
-| `PACKAGER_FHIR_VERSIONS` | Comma-separated FHIR versions from `package.json` |
+| `PACKAGER_PACKAGE_NAME` | Package name from `packager.toml` |
+| `PACKAGER_PACKAGE_VERSION` | Package version from `packager.toml` |
+| `PACKAGER_FHIR_VERSIONS` | Comma-separated FHIR versions from `packager.toml` |
 
 To read or modify FHIR resources from within a shell processor, use `$PACKAGER_WORKDIR/resources/`.
 Files are named `<ResourceType>-<id>.json`. Changes written back to this directory are picked up
@@ -370,15 +382,15 @@ context before the core build stage runs.
 
 Package/IG metadata fields (`canonical`, `fhir_version`, `id`, `name`, `status`, `publisher`,
 `version`) are **root-level** `packager.toml` fields shared by all processors. Set them once at
-the top of `packager.toml` — they are inferred from `package.json` when absent.
+the top of `packager.toml` — all processors read them from there.
 
 ```toml
 # Root-level — not under [fsh]
-canonical    = "https://example.org/fhir"  # inferred from package.json url
-fhir_version = "4.0.1"                    # inferred from package.json fhirVersions[0]
-id           = "my.package"               # inferred from package.json name
-name         = "MyPackage"                # inferred from package.json name
-version      = "1.0.0"                    # inferred from package.json version
+canonical    = "https://example.org/fhir"  # canonical base URL
+fhir_version = "4.0.1"                    # FHIR version string
+id           = "my.package"               # package id
+name         = "MyPackage"                # human-readable name
+version      = "1.0.0"                    # version string
 status       = "draft"                    # default: "draft"
 publisher    = "My Organization"          # optional
 
@@ -388,11 +400,11 @@ publisher    = "My Organization"          # optional
 
 | Field | Default | Description |
 |---|---|---|
-| `canonical` | `package.json` `url` | Canonical base URL for generated resources |
-| `fhir_version` | `package.json` `fhirVersions[0]` | FHIR version string (e.g. `"4.0.1"`) |
-| `id` | `package.json` `name` | Package id embedded in generated resources |
-| `name` | `package.json` `name` | Human-readable package name |
-| `version` | `package.json` `version` | Version string for generated resources |
+| `canonical` | — | Canonical base URL for generated resources |
+| `fhir_version` | — | FHIR version string (e.g. `"4.0.1"`) |
+| `id` | — | Package id embedded in generated resources |
+| `name` | — | Human-readable package name |
+| `version` | — | Version string for generated resources |
 | `status` | `"draft"` | Resource status for all generated resources |
 | `publisher` | — | Publisher name embedded in generated resources |
 
@@ -546,15 +558,16 @@ rh package init bp-profiles \
 This creates:
 ```
 bp-profiles/
-  package.json
   packager.toml
   ImplementationGuide.json
 ```
 
 Review and edit these files as needed. The `ImplementationGuide.json` has a minimal skeleton —
 `definition.resource`, `dependsOn`, and `definition.page` are all **auto-populated at build time**
-from the scanned resources and `package.json` dependencies, so you do not need to maintain them
+from the scanned resources and `packager.toml` dependencies, so you do not need to maintain them
 manually.
+
+`package.json` is **generated** into `bp-profiles/output/package/` during `rh package build`.
 
 ---
 

--- a/apps/rh-cli/src/package.rs
+++ b/apps/rh-cli/src/package.rs
@@ -68,7 +68,7 @@ pub struct InitArgs {
 
 #[derive(Args)]
 pub struct BuildArgs {
-    /// Path to the source directory containing package.json and FHIR resources
+    /// Path to the source directory containing packager.toml and FHIR resources
     pub dir: PathBuf,
 
     /// Output directory for the expanded package (default: <dir>/output)
@@ -144,7 +144,7 @@ pub async fn handle_command(cmd: PackageCommands) -> Result<()> {
             }
             println!("\nPackage initialised at {}", dir.display());
             println!(
-                "Next: edit package.json, then run `rh package build {}`",
+                "Next: edit packager.toml, then run `rh package build {}`",
                 dir.display()
             );
             Ok(())

--- a/crates/rh-packager/README.md
+++ b/crates/rh-packager/README.md
@@ -10,9 +10,8 @@ see [`apps/rh-cli/docs/PACKAGER.md`](../../apps/rh-cli/docs/PACKAGER.md).
 
 ```
 my-package/
-  package.json              # Required: FHIR package manifest
-  packager.toml             # Optional: hook/processor configuration
-  ImplementationGuide.json  # Required: IG resource (must sync with package.json)
+  packager.toml             # Required: package metadata + hook/processor configuration
+  ImplementationGuide.json  # Required: IG resource (must sync with packager.toml)
   StructureDefinition-foo.json
   ValueSet-bar.json
   Library-MyLib.json        # Optional: created/updated by cql processor
@@ -24,6 +23,10 @@ my-package/
   fhir-lock.json            # Canonical version pins
 ```
 
+`package.json` is **not** a source file — it is **generated** into the output directory
+(`output/package/package.json`) during the build. All package metadata (`id`, `version`,
+`canonical`, `fhir_version`, `dependencies`, etc.) lives in `packager.toml`.
+
 ---
 
 ## packager.toml Reference
@@ -34,32 +37,45 @@ sections are optional; absent sections use their defaults.
 ### Top-level fields
 
 ```toml
+# Package / IG metadata — required for building.
+id           = "my.package"                  # package name / IG packageId
+version      = "1.0.0"                       # package version
+fhir_version = "4.0.1"                       # FHIR version
+canonical    = "https://example.org/fhir"    # canonical base URL
+description  = "My FHIR Package"             # optional
+author       = "My Organization"             # optional
+license      = "CC0-1.0"                     # optional
+
 # Shared FHIR packages cache used by all processors that need package resolution.
 # Overridden per-processor with a section-level packages_dir.
 # Default: ~/.fhir/packages
 packages_dir = "/path/to/.fhir/packages"
 
-# Package / IG metadata — used by processors that generate or validate resources.
-# All are optional; absent values are inferred from package.json.
-canonical    = "https://example.org/fhir"   # inferred from package.json url
-fhir_version = "4.0.1"                      # inferred from package.json fhirVersions[0]
-id           = "my.package"                 # inferred from package.json name
-name         = "MyPackage"                  # inferred from package.json name
-version      = "1.0.0"                      # inferred from package.json version
-status       = "active"                     # default: "draft"
-publisher    = "My Organization"
+# Package / IG display metadata
+name         = "MyPackage"                   # default: PascalCase of id
+status       = "active"                      # default: "draft"
+publisher    = "My Organization"             # optional
+
+# Dependency packages (maps directly to package.json dependencies)
+[dependencies]
+"hl7.fhir.r4.core" = "4.0.1"
 ```
 
 | Field | Type | Default | Description |
 |---|---|---|---|
-| `packages_dir` | string | `~/.fhir/packages` | Filesystem path to locally installed FHIR packages (e.g. from `rh download`). Applied to every processor unless overridden in its own section. |
-| `canonical` | string | `package.json` `url` | Canonical base URL for all generated resources. |
-| `fhir_version` | string | `package.json` `fhirVersions[0]` | FHIR version string (e.g. `"4.0.1"`). |
-| `id` | string | `package.json` `name` | Package id embedded in generated resources. |
-| `name` | string | `package.json` `name` | Human-readable package name. |
-| `version` | string | `package.json` `version` | Version string for generated resources. |
+| `id` | string | — | Package identifier (used as `package.json` `name` and IG `packageId`). |
+| `version` | string | `"0.1.0"` | Package version. |
+| `fhir_version` | string | — | FHIR version (e.g. `"4.0.1"`). |
+| `canonical` | string | — | Canonical base URL for generated resources. |
+| `description` | string | — | Package description written to `package.json`. |
+| `author` | string | — | Author name written to `package.json`. |
+| `license` | string | — | SPDX license identifier written to `package.json`. |
+| `packages_dir` | string | `~/.fhir/packages` | Filesystem path to locally installed FHIR packages. Applied to every processor unless overridden in its own section. |
+| `name` | string | PascalCase of `id` | Human-readable package name. |
+| `version` | string | `"0.1.0"` | Version string for generated resources. |
 | `status` | string | `"draft"` | Resource status (`active`, `draft`, `retired`, `unknown`). |
 | `publisher` | string | — | Publisher name embedded in generated resources. |
+| `[dependencies]` | map | `{}` | Dependency package map written to `package.json` `dependencies`. Keys must be quoted in TOML (e.g. `"hl7.fhir.r4.core" = "4.0.1"`). |
 
 ---
 
@@ -200,7 +216,7 @@ For any processor that loads packages, the directory is chosen in this order:
 | `snapshot` | `before_build` | Generates missing `snapshot.element` arrays for `StructureDefinition` resources. Loads base definitions from dependency packages. |
 | `validate` | `before_build` or `after_build` | Validates all FHIR resources using `rh-validator`. Fails on any ERROR-severity issue. |
 | `cql` | `before_build` | Compiles `.cql` files to ELM JSON, embeds source + ELM into `Library.content[]`. Auto-creates a minimal Library resource if none exists. |
-| `fsh` | `before_build` | Compiles FHIR Shorthand (`*.fsh`) files into FHIR resources and injects them into the build context. All config inferred from `package.json` unless overridden via `[fsh]`. |
+| `fsh` | `before_build` | Compiles FHIR Shorthand (`*.fsh`) files into FHIR resources and injects them into the build context. All metadata config comes from root-level `packager.toml` fields. |
 
 ---
 
@@ -242,14 +258,15 @@ Well-known external code systems (SNOMED CT, LOINC, RxNorm, ICD-10/11) are never
 
 ## package.json ↔ ImplementationGuide Sync
 
-These fields must match between `package.json` and the `ImplementationGuide` resource:
+`package.json` is generated from `packager.toml` at build time. These fields must match
+between the generated `package.json` and the `ImplementationGuide` resource:
 
-| `package.json` | IG field |
-|---|---|
-| `name` | `packageId` |
-| `version` | `version` |
-| `fhirVersions` | `fhirVersion` |
-| (canonical base) `url` | `url` prefix |
+| `packager.toml` | `package.json` | IG field |
+|---|---|---|
+| `id` | `name` | `packageId` |
+| `version` | `version` | `version` |
+| `fhir_version` | `fhirVersions[0]` | `fhirVersion` |
+| `canonical` | `url` | `url` prefix |
 
 ## CQL ↔ Library Naming Convention
 

--- a/crates/rh-packager/src/config.rs
+++ b/crates/rh-packager/src/config.rs
@@ -38,22 +38,19 @@ pub struct PublisherConfig {
     pub packages_dir: Option<String>,
 
     /// Canonical base URL for all generated resources.
-    /// Inferred from `package.json` `url` field when absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub canonical: Option<String>,
 
     /// FHIR version string (e.g. `"4.0.1"`).
-    /// Inferred from the first entry of `package.json` `fhirVersions` when absent.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub fhir_version: Option<String>,
 
-    /// Package id embedded in generated resources.
-    /// Inferred from `package.json` `name` when absent.
+    /// Package identifier in `<scope>.<name>` NPM-style format (e.g. `hl7.fhir.us.core`).
+    /// Maps to `name` in the generated `package.json`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub id: Option<String>,
 
-    /// Human-readable package name.
-    /// Inferred from `package.json` `name` when absent.
+    /// Human-readable package name (optional).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub name: Option<String>,
 
@@ -66,9 +63,32 @@ pub struct PublisherConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub publisher: Option<String>,
 
-    /// Package version string. Inferred from `package.json` `version` when absent.
+    /// Package version string.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub version: Option<String>,
+
+    /// Package dependencies: `{ "<package-id>": "<version>" }`.
+    ///
+    /// Use quoted keys in TOML because FHIR package IDs contain dots:
+    /// ```toml
+    /// [dependencies]
+    /// "hl7.fhir.r4.core" = "4.0.1"
+    /// "hl7.fhir.us.core" = "6.1.0"
+    /// ```
+    #[serde(default)]
+    pub dependencies: HashMap<String, String>,
+
+    /// Human-readable package description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Author or publisher name.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
+
+    /// SPDX license identifier (e.g. `"CC0-1.0"`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
 
     /// Hook stage processor lists.
     #[serde(default)]
@@ -250,6 +270,10 @@ mod tests {
         assert!(cfg.status.is_none());
         assert!(cfg.publisher.is_none());
         assert!(cfg.version.is_none());
+        assert!(cfg.dependencies.is_empty());
+        assert!(cfg.description.is_none());
+        assert!(cfg.author.is_none());
+        assert!(cfg.license.is_none());
         assert!(cfg.hooks.before_build.is_empty());
         assert!(cfg.hooks.after_build.is_empty());
         assert!(cfg.hooks.before_pack.is_empty());
@@ -339,5 +363,36 @@ model_info = "fhir"
         let cfg = PublisherConfig::from_toml_str(toml).unwrap();
         assert!(cfg.hooks.before_build.is_empty());
         assert!(cfg.validate.skip_bindings);
+    }
+
+    #[test]
+    fn parses_dependencies_with_dotted_keys() {
+        let toml = r#"
+[dependencies]
+"hl7.fhir.r4.core" = "4.0.1"
+"hl7.fhir.us.core" = "6.1.0"
+"#;
+        let cfg = PublisherConfig::from_toml_str(toml).unwrap();
+        assert_eq!(
+            cfg.dependencies.get("hl7.fhir.r4.core").map(|s| s.as_str()),
+            Some("4.0.1")
+        );
+        assert_eq!(
+            cfg.dependencies.get("hl7.fhir.us.core").map(|s| s.as_str()),
+            Some("6.1.0")
+        );
+    }
+
+    #[test]
+    fn parses_optional_metadata_fields() {
+        let toml = r#"
+description = "A test package"
+author      = "Test Org"
+license     = "Apache-2.0"
+"#;
+        let cfg = PublisherConfig::from_toml_str(toml).unwrap();
+        assert_eq!(cfg.description.as_deref(), Some("A test package"));
+        assert_eq!(cfg.author.as_deref(), Some("Test Org"));
+        assert_eq!(cfg.license.as_deref(), Some("Apache-2.0"));
     }
 }

--- a/crates/rh-packager/src/context.rs
+++ b/crates/rh-packager/src/context.rs
@@ -10,13 +10,14 @@ use std::path::PathBuf;
 /// new ones. A single write pass at the end materialises the map to disk.
 #[derive(Debug)]
 pub struct PublishContext {
-    /// Source directory containing `package.json`, resources, and markdown files.
+    /// Source directory containing `packager.toml`, resources, and markdown files.
     pub source_dir: PathBuf,
 
     /// Directory where the assembled `package/` tree will be written.
     pub output_dir: PathBuf,
 
-    /// Parsed `package.json` manifest from the source directory.
+    /// Package manifest derived from `packager.toml`. Written to the output directory
+    /// as `package.json` during the build — not read from the source directory.
     pub package_json: PackageJson,
 
     /// Mutable map of FHIR resources: filename stem → JSON value.

--- a/crates/rh-packager/src/ig_sync.rs
+++ b/crates/rh-packager/src/ig_sync.rs
@@ -1,21 +1,22 @@
-//! Validator that checks `ImplementationGuide.json` fields are consistent with `package.json`.
+//! Validator that checks `ImplementationGuide.json` fields are consistent with `packager.toml`.
 //!
-//! These two files must stay in sync per the FHIR Package Specification. This module
-//! compares the key fields and returns descriptive errors for each mismatch found.
+//! The `ImplementationGuide` resource and `packager.toml` must stay in sync per the
+//! FHIR Package Specification. This module compares the key fields and returns
+//! descriptive errors for each mismatch found.
 
 use crate::{context::PublishContext, PublisherError, Result};
 
 /// Validate that the `ImplementationGuide` resource in `ctx.resources` is consistent
-/// with the `package.json` manifest. All mismatches are collected and returned as a
-/// single error with a newline-separated list.
+/// with the package manifest (derived from `packager.toml`). All mismatches are
+/// collected and returned as a single error with a newline-separated list.
 ///
 /// # Checked Fields
-/// | `package.json` | IG field |
+/// | `packager.toml` field | IG field |
 /// |---|---|
-/// | `name` | `packageId` |
+/// | `id` | `packageId` |
 /// | `version` | `version` |
-/// | `url` | `url` |
-/// | `fhirVersions[0]` | `fhirVersion[0]` |
+/// | `canonical` | `url` |
+/// | `fhir_version` | `fhirVersion[0]` |
 pub fn check_ig_sync(ctx: &PublishContext) -> Result<()> {
     let ig = find_ig(ctx)?;
     let pkg = &ctx.package_json;
@@ -87,12 +88,12 @@ fn check_field(
     match (expected, actual) {
         (Some(exp), Some(act)) if exp != act => {
             mismatches.push(format!(
-                "  {field}: package.json has \"{exp}\" but ImplementationGuide has \"{act}\""
+                "  {field}: packager.toml has \"{exp}\" but ImplementationGuide has \"{act}\""
             ));
         }
         (Some(exp), None) => {
             mismatches.push(format!(
-                "  {field}: package.json has \"{exp}\" but ImplementationGuide is missing this field"
+                "  {field}: packager.toml has \"{exp}\" but ImplementationGuide is missing this field"
             ));
         }
         _ => {}

--- a/crates/rh-packager/src/init.rs
+++ b/crates/rh-packager/src/init.rs
@@ -1,11 +1,8 @@
 //! Scaffolds a new FHIR Package source directory (`rh package init`).
 
-use crate::{manifest::PackageJson, Result};
+use crate::Result;
 use serde_json::json;
-use std::{
-    collections::HashMap,
-    path::{Path, PathBuf},
-};
+use std::path::{Path, PathBuf};
 
 /// Options for initialising a new FHIR Package source directory.
 #[derive(Debug, Clone)]
@@ -57,55 +54,39 @@ impl Default for InitOptions {
 /// Scaffold a new FHIR Package source directory at `dir`.
 ///
 /// Creates the target directory if it does not exist, then writes:
-/// - `package.json` — FHIR package manifest
-/// - `packager.toml` — hook configuration skeleton
+/// - `packager.toml` — package metadata and hook configuration
 /// - `ImplementationGuide.json` — minimal IG derived from manifest fields
+///
+/// The `package.json` is **not** created in the source directory; it is generated
+/// into the output directory during `rh package build`.
 ///
 /// # Returns
 /// A list of paths that were created.
 ///
 /// # Errors
-/// Returns an error if `package.json` already exists in `dir`.
+/// Returns an error if `packager.toml` already exists in `dir`.
 pub fn init_package(dir: &Path, opts: InitOptions) -> Result<Vec<PathBuf>> {
     std::fs::create_dir_all(dir)?;
 
-    let pkg_json_path = dir.join("package.json");
-    if pkg_json_path.exists() {
+    let toml_path = dir.join("packager.toml");
+    if toml_path.exists() {
         return Err(std::io::Error::new(
             std::io::ErrorKind::AlreadyExists,
-            "package.json already exists — directory is already initialised",
+            "packager.toml already exists — directory is already initialised",
         )
         .into());
     }
 
     let mut created: Vec<PathBuf> = Vec::new();
 
-    // --- package.json ---
     let (base_dep_id, base_dep_version) = base_fhir_dependency(&opts.fhir_version);
-    let mut dependencies = HashMap::new();
-    dependencies.insert(base_dep_id.to_string(), base_dep_version.to_string());
-
-    let pkg = PackageJson {
-        name: opts.name.clone(),
-        version: opts.version.clone(),
-        fhir_versions: vec![opts.fhir_version.clone()],
-        dependencies,
-        url: Some(opts.canonical.clone()),
-        description: opts.description.clone(),
-        author: opts.author.clone(),
-        license: Some(opts.license.clone()),
-        extra: HashMap::new(),
-    };
-    let pkg_json = serde_json::to_string_pretty(&pkg)?;
-    std::fs::write(&pkg_json_path, pkg_json)?;
-    created.push(pkg_json_path);
 
     // --- packager.toml ---
-    let toml_path = dir.join("packager.toml");
-    if !toml_path.exists() {
-        std::fs::write(&toml_path, packager_toml_template())?;
-        created.push(toml_path);
-    }
+    std::fs::write(
+        &toml_path,
+        build_packager_toml(&opts, base_dep_id, base_dep_version),
+    )?;
+    created.push(toml_path);
 
     // --- ImplementationGuide.json ---
     let ig_path = dir.join("ImplementationGuide.json");
@@ -247,28 +228,43 @@ fn build_implementation_guide(
     ig
 }
 
-fn packager_toml_template() -> &'static str {
-    r#"# packager.toml — rh package hook configuration
-# See docs/PACKAGER.md for full documentation.
+fn build_packager_toml(opts: &InitOptions, base_dep_id: &str, base_dep_version: &str) -> String {
+    let mut lines: Vec<String> = Vec::new();
 
-[hooks]
-# Processors to run before the build stage.
-# Built-in processors: "fsh", "snapshot", "cql", "validate"
-before_build = []
+    lines.push("# packager.toml — rh package configuration".to_string());
+    lines.push("# See docs/PACKAGER.md for full documentation.".to_string());
+    lines.push(String::new());
+    lines.push(format!("id           = {:?}", opts.name));
+    lines.push(format!("version      = {:?}", opts.version));
+    lines.push(format!("canonical    = {:?}", opts.canonical));
+    lines.push(format!("fhir_version = {:?}", opts.fhir_version));
+    lines.push(format!("license      = {:?}", opts.license));
+    lines.push(format!("status       = {:?}", opts.status));
 
-# Processors to run after the build stage.
-after_build = []
+    if let Some(desc) = &opts.description {
+        lines.push(format!("description  = {:?}", desc));
+    }
+    if let Some(author) = &opts.author {
+        lines.push(format!("author       = {:?}", author));
+    }
 
-# Processors to run before packing to .tgz.
-before_pack = []
+    lines.push(String::new());
+    lines.push("[dependencies]".to_string());
+    lines.push(format!("{:?} = {:?}", base_dep_id, base_dep_version));
+    lines.push(String::new());
+    lines.push("[hooks]".to_string());
+    lines.push("# Built-in processors: \"fsh\", \"snapshot\", \"cql\", \"validate\"".to_string());
+    lines.push("before_build = []".to_string());
+    lines.push("after_build  = []".to_string());
+    lines.push("before_pack  = []".to_string());
+    lines.push("after_pack   = []".to_string());
+    lines.push(String::new());
+    lines.push("# Custom shell processors — uncomment to define your own:".to_string());
+    lines.push("# [processors.my-script]".to_string());
+    lines.push("# command = \"python3 scripts/my_script.py\"".to_string());
+    lines.push(String::new());
 
-# Processors to run after packing to .tgz.
-after_pack = []
-
-# Custom shell processors — uncomment to define your own:
-# [processors.my-script]
-# command = "python3 scripts/my_script.py"
-"#
+    lines.join("\n")
 }
 
 #[cfg(test)]
@@ -277,7 +273,7 @@ mod tests {
     use tempfile::TempDir;
 
     #[test]
-    fn creates_all_three_files() {
+    fn creates_two_files() {
         let dir = TempDir::new().unwrap();
         let opts = InitOptions {
             name: "com.example.fhir".to_string(),
@@ -285,14 +281,14 @@ mod tests {
             ..Default::default()
         };
         let created = init_package(dir.path(), opts).unwrap();
-        assert_eq!(created.len(), 3);
-        assert!(dir.path().join("package.json").exists());
+        assert_eq!(created.len(), 2);
+        assert!(!dir.path().join("package.json").exists());
         assert!(dir.path().join("packager.toml").exists());
         assert!(dir.path().join("ImplementationGuide.json").exists());
     }
 
     #[test]
-    fn package_json_has_correct_fields() {
+    fn packager_toml_has_correct_fields() {
         let dir = TempDir::new().unwrap();
         let opts = InitOptions {
             name: "com.example.fhir".to_string(),
@@ -304,16 +300,18 @@ mod tests {
         };
         init_package(dir.path(), opts).unwrap();
 
-        let json: serde_json::Value = serde_json::from_str(
-            &std::fs::read_to_string(dir.path().join("package.json")).unwrap(),
-        )
-        .unwrap();
-        assert_eq!(json["name"], "com.example.fhir");
-        assert_eq!(json["version"], "1.0.0");
-        assert_eq!(json["fhirVersions"][0], "4.0.1");
-        assert_eq!(json["dependencies"]["hl7.fhir.r4.core"], "4.0.1");
-        assert_eq!(json["description"], "A test package");
-        assert_eq!(json["author"], "Test Org");
+        let toml_str = std::fs::read_to_string(dir.path().join("packager.toml")).unwrap();
+        let cfg: crate::config::PublisherConfig = toml::from_str(&toml_str).unwrap();
+        assert_eq!(cfg.id.as_deref(), Some("com.example.fhir"));
+        assert_eq!(cfg.version.as_deref(), Some("1.0.0"));
+        assert_eq!(cfg.canonical.as_deref(), Some("https://example.org/fhir"));
+        assert_eq!(cfg.fhir_version.as_deref(), Some("4.0.1"));
+        assert_eq!(cfg.description.as_deref(), Some("A test package"));
+        assert_eq!(cfg.author.as_deref(), Some("Test Org"));
+        assert_eq!(
+            cfg.dependencies.get("hl7.fhir.r4.core").map(|s| s.as_str()),
+            Some("4.0.1")
+        );
     }
 
     #[test]
@@ -343,9 +341,9 @@ mod tests {
     }
 
     #[test]
-    fn errors_if_package_json_already_exists() {
+    fn errors_if_packager_toml_already_exists() {
         let dir = TempDir::new().unwrap();
-        std::fs::write(dir.path().join("package.json"), "{}").unwrap();
+        std::fs::write(dir.path().join("packager.toml"), "").unwrap();
         let opts = InitOptions {
             name: "com.example.fhir".to_string(),
             canonical: "https://example.org/fhir".to_string(),

--- a/crates/rh-packager/src/loader.rs
+++ b/crates/rh-packager/src/loader.rs
@@ -10,22 +10,32 @@ use std::{
 };
 use tracing::warn;
 
-const PACKAGE_JSON: &str = "package.json";
 const IG_RESOURCE_TYPE: &str = "ImplementationGuide";
 const PUBLISHER_TOML: &str = "packager.toml";
 
 /// Scanned source resources: (definitional_resources, example_resources, standalone_markdown).
 type ScannedResources = (HashMap<String, Value>, HashMap<String, Value>, Vec<PathBuf>);
 
-/// Scan `source_dir`, load `package.json` and `packager.toml`, populate a
-/// `PublishContext` with the discovered FHIR resources and markdown files.
+/// Scan `source_dir`, load `packager.toml`, populate a `PublishContext` with the
+/// discovered FHIR resources and markdown files.
+///
+/// The `package.json` manifest is **generated** from `packager.toml` fields at load time;
+/// it is not read from the source directory. If a `package.json` file is present in
+/// `source_dir` it is silently ignored (though a warning is emitted).
 ///
 /// # Errors
-/// - `PublisherError::MissingFile` if `package.json` is absent.
 /// - `PublisherError::MissingFile` if no `ImplementationGuide` resource is found.
 pub fn load_source_dir(source_dir: &Path, output_dir: PathBuf) -> Result<PublishContext> {
-    let package_json = load_package_json(source_dir)?;
+    if source_dir.join("package.json").exists() {
+        warn!(
+            "Found package.json in source directory — it is no longer read. \
+             All package metadata should be defined in packager.toml. \
+             You can safely delete the source package.json."
+        );
+    }
+
     let config = load_publisher_config(source_dir)?;
+    let package_json = PackageJson::from_config(&config);
 
     let mut ctx = PublishContext::new(source_dir.to_path_buf(), output_dir, package_json, config);
 
@@ -37,15 +47,6 @@ pub fn load_source_dir(source_dir: &Path, output_dir: PathBuf) -> Result<Publish
     ensure_implementation_guide(&ctx)?;
 
     Ok(ctx)
-}
-
-fn load_package_json(source_dir: &Path) -> Result<PackageJson> {
-    let path = source_dir.join(PACKAGE_JSON);
-    if !path.exists() {
-        return Err(PublisherError::MissingFile(PACKAGE_JSON.to_string()));
-    }
-    let text = std::fs::read_to_string(&path)?;
-    Ok(serde_json::from_str(&text)?)
 }
 
 fn load_publisher_config(source_dir: &Path) -> Result<PublisherConfig> {
@@ -212,23 +213,17 @@ mod tests {
         r#"{"resourceType":"ImplementationGuide","id":"my-ig","version":"1.0.0","packageId":"example.pkg","url":"http://example.org/fhir","fhirVersion":["4.0.1"],"status":"draft"}"#
     }
 
-    fn minimal_package_json() -> &'static str {
-        r#"{"name":"example.pkg","version":"1.0.0","fhirVersions":["4.0.1"]}"#
-    }
-
-    #[test]
-    fn fails_when_package_json_absent() {
-        let dir = TempDir::new().unwrap();
-        let result = load_source_dir(dir.path(), dir.path().join("output"));
-        assert!(
-            matches!(result, Err(PublisherError::MissingFile(f)) if f.contains("package.json"))
-        );
+    fn minimal_packager_toml() -> &'static str {
+        r#"id = "example.pkg"
+version = "1.0.0"
+fhir_version = "4.0.1"
+"#
     }
 
     #[test]
     fn fails_when_no_implementation_guide() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(
             dir.path(),
             "ValueSet-foo.json",
@@ -236,14 +231,14 @@ mod tests {
         );
         let result = load_source_dir(dir.path(), dir.path().join("output"));
         assert!(
-            matches!(result, Err(PublisherError::MissingFile(f)) if f.contains("ImplementationGuide"))
+            matches!(result, Err(crate::PublisherError::MissingFile(f)) if f.contains("ImplementationGuide"))
         );
     }
 
     #[test]
     fn loads_resources_and_partitions_markdown() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
         write_file(
             dir.path(),
@@ -273,7 +268,7 @@ mod tests {
     #[test]
     fn docs_dir_markdown_becomes_standalone() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
 
         let docs_dir = dir.path().join("docs");
@@ -288,7 +283,7 @@ mod tests {
     #[test]
     fn docs_dir_json_is_not_loaded_as_resource() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
 
         let docs_dir = dir.path().join("docs");
@@ -307,8 +302,14 @@ mod tests {
     #[test]
     fn skips_package_json_from_resource_map() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
+        // A leftover package.json from a prior layout should not be loaded as a resource.
+        write_file(
+            dir.path(),
+            "package.json",
+            r#"{"name":"example.pkg","version":"1.0.0","fhirVersions":["4.0.1"]}"#,
+        );
 
         let ctx = load_source_dir(dir.path(), dir.path().join("output")).unwrap();
         assert!(!ctx.resources.contains_key("package"));
@@ -317,7 +318,7 @@ mod tests {
     #[test]
     fn loads_resources_from_subdirectory() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
 
         let profiles_dir = dir.path().join("profiles");
@@ -336,7 +337,7 @@ mod tests {
     #[test]
     fn routes_examples_subdir_to_examples_map() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
 
         let examples_dir = dir.path().join("examples");
@@ -355,7 +356,7 @@ mod tests {
     #[test]
     fn skips_output_and_hidden_directories() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
+        write_file(dir.path(), "packager.toml", minimal_packager_toml());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
 
         // Place a JSON file in output/ — should be ignored.
@@ -374,10 +375,44 @@ mod tests {
     #[test]
     fn uses_default_config_when_packager_toml_absent() {
         let dir = TempDir::new().unwrap();
-        write_file(dir.path(), "package.json", minimal_package_json());
         write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
 
         let ctx = load_source_dir(dir.path(), dir.path().join("output")).unwrap();
         assert!(ctx.config.hooks.before_build.is_empty());
+    }
+
+    #[test]
+    fn derives_package_json_from_packager_toml() {
+        let dir = TempDir::new().unwrap();
+        write_file(
+            dir.path(),
+            "packager.toml",
+            r#"id = "com.example.fhir"
+version = "2.0.0"
+canonical = "https://example.org/fhir"
+fhir_version = "4.0.1"
+description = "Example"
+
+[dependencies]
+"hl7.fhir.r4.core" = "4.0.1"
+"#,
+        );
+        write_file(dir.path(), "ImplementationGuide.json", minimal_ig());
+
+        let ctx = load_source_dir(dir.path(), dir.path().join("output")).unwrap();
+        assert_eq!(ctx.package_json.name, "com.example.fhir");
+        assert_eq!(ctx.package_json.version, "2.0.0");
+        assert_eq!(
+            ctx.package_json.url.as_deref(),
+            Some("https://example.org/fhir")
+        );
+        assert_eq!(ctx.package_json.description.as_deref(), Some("Example"));
+        assert_eq!(
+            ctx.package_json
+                .dependencies
+                .get("hl7.fhir.r4.core")
+                .map(|s| s.as_str()),
+            Some("4.0.1")
+        );
     }
 }

--- a/crates/rh-packager/src/manifest.rs
+++ b/crates/rh-packager/src/manifest.rs
@@ -43,6 +43,33 @@ pub struct PackageJson {
     pub extra: HashMap<String, serde_json::Value>,
 }
 
+impl PackageJson {
+    /// Construct a `PackageJson` from a [`PublisherConfig`].
+    ///
+    /// This is the primary way `package.json` is produced — derived from `packager.toml`
+    /// rather than read from a file in the source directory.
+    pub fn from_config(config: &crate::config::PublisherConfig) -> Self {
+        PackageJson {
+            name: config.id.clone().unwrap_or_default(),
+            version: config
+                .version
+                .clone()
+                .unwrap_or_else(|| "0.1.0".to_string()),
+            fhir_versions: config
+                .fhir_version
+                .as_ref()
+                .map(|v| vec![v.clone()])
+                .unwrap_or_default(),
+            dependencies: config.dependencies.clone(),
+            url: config.canonical.clone(),
+            description: config.description.clone(),
+            author: config.author.clone(),
+            license: config.license.clone(),
+            extra: HashMap::new(),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -115,5 +142,48 @@ mod tests {
         let json = r#"{"name": "test", "version": "1.0.0"}"#;
         let pkg: PackageJson = serde_json::from_str(json).unwrap();
         assert!(pkg.dependencies.is_empty());
+    }
+
+    #[test]
+    fn from_config_maps_all_fields() {
+        use crate::config::PublisherConfig;
+        let toml = r#"
+id           = "hl7.fhir.us.core"
+version      = "6.1.0"
+canonical    = "http://hl7.org/fhir/us/core"
+fhir_version = "4.0.1"
+description  = "US Core IG"
+author       = "HL7 US Realm"
+license      = "CC0-1.0"
+
+[dependencies]
+"hl7.fhir.r4.core" = "4.0.1"
+"#;
+        let config = PublisherConfig::from_toml_str(toml).unwrap();
+        let pkg = PackageJson::from_config(&config);
+        assert_eq!(pkg.name, "hl7.fhir.us.core");
+        assert_eq!(pkg.version, "6.1.0");
+        assert_eq!(pkg.fhir_versions, vec!["4.0.1"]);
+        assert_eq!(pkg.url.as_deref(), Some("http://hl7.org/fhir/us/core"));
+        assert_eq!(pkg.description.as_deref(), Some("US Core IG"));
+        assert_eq!(pkg.author.as_deref(), Some("HL7 US Realm"));
+        assert_eq!(pkg.license.as_deref(), Some("CC0-1.0"));
+        assert_eq!(
+            pkg.dependencies.get("hl7.fhir.r4.core").map(|s| s.as_str()),
+            Some("4.0.1")
+        );
+        assert!(pkg.extra.is_empty());
+    }
+
+    #[test]
+    fn from_config_uses_defaults_for_absent_fields() {
+        use crate::config::PublisherConfig;
+        let config = PublisherConfig::default();
+        let pkg = PackageJson::from_config(&config);
+        assert_eq!(pkg.name, "");
+        assert_eq!(pkg.version, "0.1.0");
+        assert!(pkg.fhir_versions.is_empty());
+        assert!(pkg.dependencies.is_empty());
+        assert!(pkg.url.is_none());
     }
 }

--- a/crates/rh-packager/src/pipeline.rs
+++ b/crates/rh-packager/src/pipeline.rs
@@ -211,8 +211,11 @@ mod tests {
     fn setup_minimal_package(dir: &Path) {
         write_file(
             dir,
-            "package.json",
-            r#"{"name":"test.fhir.pkg","version":"1.0.0","fhirVersions":["4.0.1"]}"#,
+            "packager.toml",
+            r#"id = "test.fhir.pkg"
+version = "1.0.0"
+fhir_version = "4.0.1"
+"#,
         );
         write_file(
             dir,
@@ -249,8 +252,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         write_file(
             tmp.path(),
-            "package.json",
-            r#"{"name":"test.fhir.pkg","version":"2.0.0","fhirVersions":["4.0.1"]}"#,
+            "packager.toml",
+            r#"id = "test.fhir.pkg"
+version = "2.0.0"
+fhir_version = "4.0.1"
+"#,
         );
         write_file(
             tmp.path(),
@@ -311,7 +317,11 @@ mod tests {
         write_file(
             tmp.path(),
             "packager.toml",
-            r#"[hooks]
+            r#"id = "test.fhir.pkg"
+version = "1.0.0"
+fhir_version = "4.0.1"
+
+[hooks]
 before_build = ["nonexistent-processor"]"#,
         );
 

--- a/crates/rh-packager/tests/fixtures/my-package/package.json
+++ b/crates/rh-packager/tests/fixtures/my-package/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "example.fhir.test",
-  "version": "1.0.0",
-  "fhirVersions": ["4.0.1"],
-  "url": "http://example.org/fhir/ImplementationGuide/example.fhir.test",
-  "description": "Example FHIR test package",
-  "dependencies": {}
-}

--- a/crates/rh-packager/tests/fixtures/my-package/packager.toml
+++ b/crates/rh-packager/tests/fixtures/my-package/packager.toml
@@ -1,2 +1,8 @@
+id           = "example.fhir.test"
+version      = "1.0.0"
+canonical    = "http://example.org/fhir/ImplementationGuide/example.fhir.test"
+fhir_version = "4.0.1"
+description  = "Example FHIR test package"
+
 [hooks]
 before_build = ["cql"]

--- a/crates/rh-packager/tests/integration_test.rs
+++ b/crates/rh-packager/tests/integration_test.rs
@@ -170,7 +170,7 @@ fn build_with_snapshot_and_validate_hooks() {
     // Override packager.toml to configure snapshot + validate before_build hooks.
     fs::write(
         tmp.path().join("packager.toml"),
-        "[hooks]\nbefore_build = [\"snapshot\", \"validate\"]\n",
+        "id = \"example.fhir.test\"\nversion = \"1.0.0\"\nfhir_version = \"4.0.1\"\n\n[hooks]\nbefore_build = [\"snapshot\", \"validate\"]\n",
     )
     .unwrap();
 


### PR DESCRIPTION
## Summary

`package.json` is now a **generated output artifact** written to `output/package/` during `rh package build`. It is no longer a required source file.

`packager.toml` becomes the **sole source of truth** for all FHIR package metadata, including the new fields: `dependencies`, `description`, `author`, and `license`.

### Changes

- **`config.rs`**: Add `dependencies`, `description`, `author`, `license` fields to `PublisherConfig`
- **`manifest.rs`**: Add `PackageJson::from_config` constructor to derive the manifest from `PublisherConfig`
- **`loader.rs`**: Remove `load_package_json`; derive `PackageJson` from config. Emit a warning (not an error) if `package.json` is found in the source dir (graceful migration)
- **`init.rs`**: Remove `package.json` generation; write all metadata into `packager.toml`. Guard changed from `package.json.exists()` to `packager.toml.exists()`. Now creates 2 files (not 3)
- **`ig_sync.rs`**: Update error messages to reference `packager.toml` instead of `package.json`
- **`pipeline.rs`**: Update unit tests to use `packager.toml`
- **Integration tests**: Update fixture, fix `build_with_snapshot_and_validate_hooks` to include metadata when overwriting `packager.toml`
- **Docs**: Update `PACKAGER.md` and `crates/rh-packager/README.md` to reflect new layout

### Motivation

Users running `npm install` in their FHIR package root no longer have a conflict with a FHIR-specific `package.json`. The FHIR manifest lives exclusively in the generated output.