### PR TITLE
docs: complete WS7 sync gates

### DIFF
--- a/.github/ARCHITECTURE.md
+++ b/.github/ARCHITECTURE.md
@@ -1,35 +1,108 @@
 # Architecture
 
+## Workspace Layers
+
+The Rust workspace is organized around a small foundation layer, generated FHIR
+type crates, domain libraries, packaging/validation, and the CLI edge.
+
+| Layer | Crates | Role |
+|---|---|---|
+| 0 | `rh-foundation` | Shared error types, package loading, snapshot generation, CLI helpers, WASM envelope utilities |
+| 1 | `rh-hl7-fhir-r4-core`, `rh-hl7-fhir-r5-core` | Generated FHIR model crates built on foundation traits and metadata |
+| 2 | `rh-codegen`, `rh-cql`, `rh-fhirpath`, `rh-fsh`, `rh-vcl` | Domain libraries for codegen, CQL, FHIRPath, FSH, and VCL |
+| 3 | `rh-validator`, `rh-packager` | Validation and package assembly orchestration |
+| 4 | `rh-cli` | Command-line application and integration edge |
+
 ## Crate Dependency Graph
 
-```
-Layer 0 (leaf): rh-foundation, rh-hl7_fhir_r4_core, rh-hl7_fhir_r5_core
-Layer 1: rh-codegen   (→ foundation)
-         rh-fsh       (→ foundation)
-         rh-vcl       (→ foundation)
-         rh-fhirpath  (→ foundation, r4_core)
-         rh-cql       (→ foundation)
-Layer 2: rh-validator (→ foundation[http], fhirpath)
-Layer 3: rh-packager  (→ foundation, fhirpath, vcl, validator)
-Layer 4: rh-cli       (→ all)
+```text
+rh-foundation
+├── rh-hl7-fhir-r4-core
+│   ├── rh-fhirpath
+│   │   └── rh-validator
+│   │       └── rh-packager
+│   └── rh-fsh
+│       └── rh-packager
+├── rh-hl7-fhir-r5-core
+├── rh-codegen
+├── rh-cql
+│   └── rh-packager
+└── rh-vcl
+
+rh-cli depends on the public libraries it exposes:
+rh-codegen, rh-cql, rh-fhirpath, rh-foundation, rh-fsh,
+rh-hl7-fhir-r4-core, rh-packager, rh-validator, and rh-vcl.
 ```
 
-**Dependency Layers:**
-- **Layer 0** (no internal dependencies): `rh-foundation`, `rh-hl7_fhir_r4_core`, `rh-hl7_fhir_r5_core`
-- **Layer 1** (foundation, generated types): `rh-codegen`, `rh-vcl`, `rh-fhirpath`, `rh-fsh`, `rh-cql`
-- **Layer 2**: `rh-validator`
-- **Layer 3**: `rh-packager`
-- **Layer 4** (binary): `rh-cli`
+The following dependency list is checked by `scripts/check-docs-sync.sh`
+against `cargo metadata`.
+
+<!-- docs-sync:crate-deps:start -->
+```text
+rh-cli: rh-codegen, rh-cql, rh-fhirpath, rh-foundation, rh-fsh, rh-hl7-fhir-r4-core, rh-packager, rh-validator, rh-vcl
+rh-codegen: rh-foundation
+rh-cql: rh-foundation
+rh-fhirpath: rh-foundation, rh-hl7-fhir-r4-core
+rh-foundation: -
+rh-fsh: rh-foundation, rh-hl7-fhir-r4-core
+rh-hl7-fhir-r4-core: rh-foundation
+rh-hl7-fhir-r5-core: rh-foundation
+rh-packager: rh-cql, rh-foundation, rh-fsh, rh-validator
+rh-validator: rh-fhirpath, rh-foundation, rh-hl7-fhir-r4-core
+rh-vcl: rh-foundation
+```
+<!-- docs-sync:crate-deps:end -->
 
 ## Key Crates
 
-- **rh-foundation**: Base utilities, error types, HTTP client wrappers, package loader, snapshot generation, in-memory caching
-- **rh-codegen**: Generates Rust types from FHIR StructureDefinitions
-- **rh-fhirpath**: Parser and evaluator for FHIRPath expressions (WASM-capable)
-- **rh-cql**: CQL-to-ELM compiler, evaluator, explain mode, and source maps
-- **rh-fsh**: nom-based FSH parser and FHIR JSON exporter with rayon parallel export
-- **rh-validator**: Profile-based FHIR validation with LRU caching
-- **rh-vcl**: ValueSet Compose Language parser, translator, and explainer (WASM-capable)
-- **rh-packager**: FHIR Package assembler with built-in processors (snapshot, validate, CQL, FSH)
-- **rh-hl7_fhir_r4_core**: Pre-generated R4 FHIR types
-- **rh-hl7_fhir_r5_core**: Pre-generated R5 FHIR types
+| Crate | Description |
+|---|---|
+| `rh-foundation` | Base utilities, error types, HTTP client wrappers, package loader, snapshot generation, in-memory caching, CLI helpers, and WASM result envelopes |
+| `rh-codegen` | Generates Rust crates from FHIR StructureDefinitions and package archives |
+| `rh-cql` | CQL-to-ELM compiler, evaluator, explain mode, source maps, and WASM facade |
+| `rh-fhirpath` | Parser and evaluator for FHIRPath expressions, with R4 type metadata and WASM facade |
+| `rh-fsh` | nom-based FSH parser and FHIR JSON exporter with rayon parallel export |
+| `rh-validator` | Profile-based FHIR R4 validation with snapshot and FHIRPath integration |
+| `rh-vcl` | ValueSet Compose Language parser, translator, explainer, and WASM facade |
+| `rh-packager` | FHIR Package assembler with built-in snapshot, validate, CQL, and FSH processors |
+| `rh-hl7-fhir-r4-core` | Pre-generated R4 FHIR types, traits, bindings, extensions, and metadata |
+| `rh-hl7-fhir-r5-core` | Pre-generated R5 FHIR types, traits, bindings, extensions, and metadata |
+| `rh-cli` | Unified CLI for codegen, package download/build, validation, FHIRPath, CQL, FSH, VCL, and snapshots |
+
+## WASM-Capable Matrix
+
+| Crate | Feature | Root check | NPM package | Notes |
+|---|---|---|---|---|
+| `rh-foundation` | `wasm` | `cargo check -p rh-foundation --target wasm32-unknown-unknown --no-default-features --features wasm` | n/a | Shared panic hook and `WasmResult` infrastructure only |
+| `rh-fhirpath` | `wasm` | `just wasm-build fhirpath <target>` | `@reason-healthcare/fhirpath` | Exports parse/evaluate wrappers for node, web, and bundler targets |
+| `rh-vcl` | `wasm` | `just wasm-build vcl <target>` | `@reason-healthcare/vcl` | Exports parse, translate, validate, and explain wrappers |
+| `rh-cql` | `wasm` | `just wasm-build cql <target>` | `@reason-healthcare/cql` | Exports CQL compile and ELM evaluation wrappers |
+
+Use `just wasm-check` for compile-only checks and `pnpm -r build && pnpm -r
+test` for the npm package/build test path.
+
+## JavaScript Packages And Playground
+
+The `packages/` directory is a pnpm workspace containing the public
+WebAssembly-backed packages:
+
+- `packages/fhirpath` -> `@reason-healthcare/fhirpath`
+- `packages/vcl` -> `@reason-healthcare/vcl`
+- `packages/cql` -> `@reason-healthcare/cql`
+
+The `examples/playground` package is a private Vite app that exercises all
+three npm packages and is deployed through the Pages workflow.
+
+## Generated Crates
+
+The generated R4/R5 crates are committed artifacts. Codegen changes must keep
+regeneration hermetic:
+
+- `just regen-r4` regenerates `crates/rh-hl7_fhir_r4_core`
+- `just regen-r5` regenerates `crates/rh-hl7_fhir_r5_core`
+- `just regen-check` regenerates both into temporary directories and fails if
+  committed output is stale
+
+Generated crate metadata is split by category under `src/metadata/` to keep
+incremental builds smaller. Generated extension modules are committed for both
+R4 and R5.

--- a/.github/CODING_STANDARDS.md
+++ b/.github/CODING_STANDARDS.md
@@ -22,4 +22,4 @@
     - `boolean` → `bool`
     - `decimal` → `f64`
     - `dateTime` → `String`
-- **Generated Code**: Includes serde annotations, uses `Option<T>` for optional fields, `Vec<T>` for arrays.
+- **Generated Code**: Includes serde annotations, uses `Option<T>` for optional singular fields, `Vec<T>` with serde defaults for repeating fields.

--- a/.github/DEVELOPMENT.md
+++ b/.github/DEVELOPMENT.md
@@ -31,8 +31,12 @@ Run `just` or `just --list` to see all available commands.
     - `just test-fhir-50` (Extended - 50 cases)
     - `just test-fhir-all` (Full suite - ~570 cases)
 - **WASM Builds**:
-    - `just build-wasm` (Web target)
-    - `just build-wasm-node` (Node.js target)
+    - `just wasm-check` (compile-check all WASM-capable crates)
+    - `just wasm-build fhirpath all`
+    - `just wasm-build vcl all`
+    - `just wasm-build cql all`
+- **Docs Drift**:
+    - `just docs-sync` (checks architecture dependency docs and CLI help docs)
 
 ## Linting & Formatting
 
@@ -43,13 +47,14 @@ Run `just` or `just --list` to see all available commands.
 
 ## Running the CLI
 
-- **Development**: `cargo run -p rh -- <subcommand>`
-- **Help**: `cargo run -p rh -- --help`
-- **FHIRPath Eval**: `cargo run -p rh -- fhirpath eval '...'`
-- **Validate**: `cargo run -p rh -- validate <resource>`
+- **Development**: `cargo run -p rh-cli -- <subcommand>`
+- **Help**: `cargo run -p rh-cli -- --help`
+- **FHIRPath Eval**: `cargo run -p rh-cli -- fhirpath eval '...'`
+- **Validate**: `cargo run -p rh-cli -- validate resource --input patient.json`
 
 ## Task Completion Protocol
 
 After completing tasks, always run:
 1. `just check` (preferred) or `cargo test && cargo clippy --all-targets --all-features`
-2. `cargo fmt`
+2. `just docs-sync` for documentation, CLI, architecture, or workspace dependency changes
+3. `cargo fmt`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,72 @@ jobs:
       - name: Run cargo check
         run: cargo check --workspace --all-targets --all-features
 
+  docs-sync:
+    name: Docs Sync
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-docs-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-docs-cargo-
+
+      - name: Check docs sync
+        run: scripts/check-docs-sync.sh
+
+  msrv:
+    name: MSRV
+    runs-on: ubuntu-latest
+    steps:
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo docker image prune --all --force
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
+      - name: Install MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: 1.91.0
+
+      - name: Cache cargo registry
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-msrv-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-msrv-cargo-
+
+      - name: Run cargo check on MSRV
+        run: rustup run 1.91.0 cargo check --workspace --all-targets --all-features
+
   test:
     name: Test Suite
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,3 +13,16 @@ This repository uses modular documentation. See the following files for specific
 - **Architecture & Design**: See @.github/ARCHITECTURE.md
 - **Development Workflow**: See @.github/DEVELOPMENT.md
 - **Coding Standards**: See @.github/CODING_STANDARDS.md
+- **CLI behavior for agents**: See @apps/rh-cli/README.md, especially global `--format json`, exit codes, and agent/scripting examples.
+- **Conformance status**:
+  - FHIRPath: @crates/rh-fhirpath/CONFORMANCE.md and @crates/rh-fhirpath/SPEC_COVERAGE.md
+  - CQL: @crates/rh-cql/CONFORMANCE.md and @crates/rh-cql/SPEC_COVERAGE.md
+  - FSH: @crates/rh-fsh/CONFORMANCE.md
+
+## Useful Just Recipes
+
+- `just check` — full local gate before commits.
+- `just docs-sync` — checks architecture dependency docs and CLI command docs against `cargo metadata` / `rh --help`.
+- `just wasm-check` — compile-checks WASM-capable Rust crates.
+- `just wasm-build <fhirpath|vcl|cql> <node|web|bundler|all>` — builds wasm-pack artifacts used by npm packages.
+- `just regen-r4`, `just regen-r5`, `just regen-check` — regenerate and drift-check committed generated FHIR crates.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 **Rust Health (rh)** is a modern, high-performance toolkit for working with HL7® FHIR®, purpose-built in **Rust**. It provides ergonomic, developer-friendly APIs that are modular, easy to understand, and highly extensible. It also ships with a powerful **command-line interface (CLI)** designed with the **Unix philosophy** in mind: composable commands, strong UX, and automation-friendly output.
 
-Cross-platform and fast, RH avoids the overhead of JVM- or .NET-based stacks. Two crates (`rh-fhirpath`, `rh-vcl`) also support **WebAssembly** targets for browser and embedded use cases.
+Cross-platform and fast, RH avoids the overhead of JVM- or .NET-based stacks. `rh-fhirpath`, `rh-vcl`, and `rh-cql` also ship **WebAssembly** targets and public `@reason-healthcare/*` npm packages for browser, Node.js, and bundler use cases.
 
 ## Install
 
@@ -29,13 +29,13 @@ Other install methods (pre-built binaries from GitHub Releases) are documented i
 |--------|-----------|-------------|
 | ✅ | [rh-cli](apps/rh-cli/README.md) | Unified CLI for FHIR processing tools |
 | ✅ | [rh-codegen](crates/rh-codegen/README.md) | Code generation library for creating Rust types from FHIR StructureDefinitions |
-| ✅ | [rh-fhirpath](crates/rh-fhirpath/README.md) | FHIRPath expression parser and evaluator (WASM support) |
+| ✅ | [rh-fhirpath](crates/rh-fhirpath/README.md) | FHIRPath expression parser and evaluator (`@reason-healthcare/fhirpath`) |
 | ✅ | [rh-fsh](crates/rh-fsh/README.md) | FHIR Shorthand (FSH) compiler — transforms FSH source into FHIR JSON packages |
-| ✅ | [rh-vcl](crates/rh-vcl/README.md) | ValueSet Compose Language (VCL) parser, translator, and explainer (WASM support) |
+| ✅ | [rh-vcl](crates/rh-vcl/README.md) | ValueSet Compose Language (VCL) parser, translator, and explainer (`@reason-healthcare/vcl`) |
 | ✅ | [rh-foundation](crates/rh-foundation/README.md) | Foundation utilities (errors, HTTP, I/O, CLI, package loader, snapshot generation) |
 | ✅ | [rh-validator](crates/rh-validator/README.md) | Hybrid FHIR R4 validator with snapshot-based profile validation |
 | ✅ | [rh-packager](crates/rh-packager/README.md) | FHIR Package assembler with built-in processors (snapshot, validate, CQL, FSH) |
-| ✅ | [rh-cql](crates/rh-cql/README.md) | CQL-to-ELM compiler, evaluator, explain mode, and source maps |
+| ✅ | [rh-cql](crates/rh-cql/README.md) | CQL-to-ELM compiler, evaluator, explain mode, source maps, and WASM package (`@reason-healthcare/cql`) |
 | ✅ | [rh-hl7_fhir_r4_core](crates/rh-hl7_fhir_r4_core/README.md) | **Generated** R4 FHIR types for Rust (1,388 public types) |
 | ✅ | [rh-hl7_fhir_r5_core](crates/rh-hl7_fhir_r5_core/README.md) | **Generated** R5 FHIR types for Rust |
 | 🔜 | rh-hl7_fhir_r6_core | **Generated** R6 FHIR for Rust |
@@ -63,9 +63,16 @@ cargo build
 │   ├── rh-packager/           # FHIR Package assembler
 │   ├── rh-validator/          # Hybrid FHIR R4 validator
 │   ├── rh-vcl/                # ValueSet Compose Language (VCL) parser and translator
-│   └── rh-hl7_fhir_r4_core/   # Generated R4 FHIR types
+│   ├── rh-hl7_fhir_r4_core/   # Generated R4 FHIR types
+│   └── rh-hl7_fhir_r5_core/   # Generated R5 FHIR types
 ├── apps/                   # Executable applications
 │   └── rh-cli/                # Unified cross-platform CLI for FHIR
+├── packages/               # Public WebAssembly-backed npm packages
+│   ├── fhirpath/              # @reason-healthcare/fhirpath
+│   ├── vcl/                   # @reason-healthcare/vcl
+│   └── cql/                   # @reason-healthcare/cql
+├── examples/
+│   └── playground/            # Vite playground for the npm packages
 ├── justfile                # Task runner commands
 └── setup.sh                # Development setup script
 ```
@@ -161,6 +168,40 @@ rh --help
 | `rh snapshot` | Generate and manage StructureDefinition snapshots |
 | `rh package` | Assemble a conformant FHIR Package from a source directory |
 | `rh validate` | Validate FHIR resources |
+
+### WASM and npm packages
+
+The WebAssembly packages live in the pnpm workspace under `packages/`:
+
+```bash
+pnpm install
+pnpm -r build
+pnpm -r test
+```
+
+Use `just wasm-check` for Rust compile-only coverage across `rh-foundation`,
+`rh-fhirpath`, `rh-vcl`, and `rh-cql`. The interactive playground is documented
+in [examples/playground/README.md](examples/playground/README.md), and the local
+npm publish process is documented in [packages/RELEASE.md](packages/RELEASE.md).
+
+### Automation output
+
+Every CLI command supports `--format human|json|ndjson`. Use `--format json`
+for automation; successful output is wrapped as:
+
+```json
+{"ok": true, "result": {}, "errors": [], "meta": {"version": "0.2.0-beta.2", "command": "rh"}}
+```
+
+Errors use the same envelope and preserve the process exit code:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | Success |
+| `1` | Operational error such as I/O, network, or missing file |
+| `2` | Usage error from argument parsing |
+| `3` | Validation or conformance failure |
+| `4` | User-input parse error for FHIRPath, CQL, FSH, or VCL |
 
 **Examples:**
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -279,6 +279,33 @@ Then follow [`packages/RELEASE.md`](packages/RELEASE.md) to publish
 `@reason-healthcare/fhirpath`, `@reason-healthcare/vcl`, and
 `@reason-healthcare/cql` locally.
 
+## Generated FHIR Crate Release Policy
+
+The R4 and R5 crates are generated artifacts and share the workspace version.
+Any codegen change that alters committed generated output must be treated as a
+generated-crate release change:
+
+1. Regenerate both committed crates:
+   ```bash
+   just regen-r4
+   just regen-r5
+   ```
+2. Run the drift gate:
+   ```bash
+   just regen-check
+   ```
+3. Build and test generated crates:
+   ```bash
+   cargo test -p rh-hl7-fhir-r4-core
+   cargo test -p rh-hl7-fhir-r5-core
+   ```
+4. Include the generated output diff in the release commit and bump the
+   workspace version before publishing.
+
+If a codegen change is internal-only and `just regen-check` reports no diff,
+the generated crates do not need special release treatment beyond the normal
+workspace publish order.
+
 ## Releasing a single crate
 
 Occasionally you may need to release one crate at a different version — for example, a patch fix in `rh-validator` without touching the rest of the workspace. Use the targeted recipes:

--- a/apps/rh-cli/README.md
+++ b/apps/rh-cli/README.md
@@ -110,17 +110,20 @@ rh package init --canonical https://example.org/fhir --name com.example.fhir
 
 ## Command Reference
 
+<!-- docs-sync:cli-commands:start -->
 | Command | Description | Docs |
 |---------|-------------|------|
-| `rh codegen` | Generate Rust types from FHIR packages | [CODEGEN.md](docs/CODEGEN.md) |
-| `rh download` | Download FHIR packages from registries | [DOWNLOAD.md](docs/DOWNLOAD.md) |
+| `rh codegen` | Generate organized Rust crates from FHIR Packages | [CODEGEN.md](docs/CODEGEN.md) |
+| `rh cql` | Compile CQL (Clinical Quality Language) to ELM | [CQL.md](docs/CQL.md) |
+| `rh download` | Download and install FHIR packages from npm-style registries | [DOWNLOAD.md](docs/DOWNLOAD.md) |
 | `rh fhirpath` | Parse and evaluate FHIRPath expressions | [FHIRPATH.md](docs/FHIRPATH.md) |
-| `rh fsh` | Compile FSH to FHIR JSON | [FSH.md](docs/FSH.md) |
-| `rh vcl` | Parse and translate VCL expressions | [VCL.md](docs/VCL.md) |
-| `rh cql` | Compile CQL to ELM | [CQL.md](docs/CQL.md) |
-| `rh validate` | Validate FHIR resources | [VALIDATOR.md](docs/VALIDATOR.md) |
+| `rh vcl` | Parse and translate VCL (ValueSet Compose Language) expressions | [VCL.md](docs/VCL.md) |
+| `rh fsh` | Compile and work with FHIR Shorthand (FSH) files | [FSH.md](docs/FSH.md) |
 | `rh snapshot` | Generate and manage StructureDefinition snapshots | — |
-| `rh package` | Build and publish FHIR Packages from a source directory | [PACKAGER.md](docs/PACKAGER.md) |
+| `rh package` | Assemble a conformant FHIR Package from a source directory | [PACKAGER.md](docs/PACKAGER.md) |
+| `rh validate` | Validate FHIR resources | [VALIDATOR.md](docs/VALIDATOR.md) |
+| `rh help` | Print this message or the help of the given subcommand(s) | — |
+<!-- docs-sync:cli-commands:end -->
 
 ### `rh package` subcommands
 
@@ -152,14 +155,16 @@ See [docs/PACKAGER.md](docs/PACKAGER.md) for the full documentation including th
 
 These options apply to every `rh` subcommand:
 
+<!-- docs-sync:cli-options:start -->
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--format <FORMAT>` | | Output format: `human` (default), `json`, `ndjson` |
-| `--quiet` | `-q` | Suppress informational output on stderr |
-| `--verbose` | `-v` | Increase verbosity; repeat for more detail (`-v` debug, `-vv` trace) |
-| `--color <WHEN>` | | Color output: `auto` (default), `always`, `never` |
-| `--help` | `-h` | Print help for any command or subcommand |
+| `--quiet` | `-q` | Suppress informational output (stderr) |
+| `--verbose` | `-v` | Increase verbosity; repeat for more detail (`-v` info, `-vv` debug, `-vvv` trace) |
+| `--color <WHEN>` | | Color output policy: `auto` (default), `always`, `never` |
+| `--help` | `-h` | Print help |
 | `--version` | `-V` | Print version |
+<!-- docs-sync:cli-options:end -->
 
 ## Exit Codes
 

--- a/crates/rh-codegen/README.md
+++ b/crates/rh-codegen/README.md
@@ -460,12 +460,23 @@ fn my_function() -> CodegenResult<()> {
 - Compile-time metadata generation for type resolution
 - Primitive field extension support
 
-### In Progress
+### Shipped in the current generator
 
-- Complex type references and inheritance
-- Dynamic ValueSet fetching from FHIR servers
-- Extension handling and extension definitions
-- Profile validation and constraint checking
+- Complex type references and inheritance through generated accessor,
+  mutator, and existence traits
+- Extension module generation for R4 and R5 packages
+- `extension_by_url()` helpers for generated element and domain-resource traits
+- Split metadata modules for resources, datatypes, primitives, profiles, and
+  other definitions
+- Hermetic R4/R5 regeneration through `just regen-r4`, `just regen-r5`, and
+  `just regen-check`
+
+### Known limitations
+
+- Dynamic ValueSet fetching from live FHIR terminology servers is not part of
+  code generation
+- Constraint checking is delegated to validator/package workflows rather than
+  generated model constructors
 
 ### Planned
 

--- a/crates/rh-fhirpath/README.md
+++ b/crates/rh-fhirpath/README.md
@@ -16,8 +16,10 @@ FHIRPath is a path-based navigation and extraction language for FHIR resources, 
 [See implementation status](implementation.md)
 
 **Conformance**: the official HL7 FHIRPath test suite (937 cases) runs in CI
-via `cargo test -p rh-fhirpath --test hl7_conformance`. Current pass rate:
-**74.2%** (694/935), with a shrink-only wrong-answer gate. See
+via `cargo test -p rh-fhirpath --test hl7_conformance`. Current scored result:
+**99.9%** (934/935), with **0 wrong answers**, **0 parse errors**, and
+**0 eval errors**; the only non-pass is one skipped HL7 fixture that is not
+published with the test case bundle. See
 [CONFORMANCE.md](CONFORMANCE.md) and [SPEC_COVERAGE.md](SPEC_COVERAGE.md).
 
 ## Usage

--- a/crates/rh-fhirpath/TRACE.md
+++ b/crates/rh-fhirpath/TRACE.md
@@ -75,7 +75,7 @@ let expr = parser.parse(
 ### In `rh fhirpath eval`
 
 ```bash
-cargo run -p rh -- fhirpath eval -d patient.json "Patient.name.trace('names').family"
+cargo run -p rh-cli -- fhirpath eval -d patient.json "Patient.name.trace('names').family"
 ```
 
 Output includes a trace log section:
@@ -90,7 +90,7 @@ Result: String("Smith")
 ### In the REPL
 
 ```bash
-cargo run -p rh -- fhirpath repl -d patient.json
+cargo run -p rh-cli -- fhirpath repl -d patient.json
 ```
 
 ```

--- a/crates/rh-hl7_fhir_r4_core/README.md
+++ b/crates/rh-hl7_fhir_r4_core/README.md
@@ -22,7 +22,18 @@ rh codegen hl7.fhir.r4.core 4.0.1 --output crates/rh-hl7_fhir_r4_core --force --
 * **Version** 4.0.1
 * **Canonical URL** `http://hl7.org/fhir`
 
-**Statistics: 0 structs, 0 enums, 0 total types**
+**Statistics:** 148 resources, 51 datatypes, 43 profiles, 385 extensions, and 213 required-binding enum modules.
+
+**Version-specific notes:**
+
+- Generated from FHIR R4 `hl7.fhir.r4.core` version `4.0.1`.
+- Repeating fields are emitted as `Vec<T>` with serde defaults so missing JSON
+  arrays deserialize as empty vectors.
+- Metadata is split under `src/metadata/` by resource, datatype, primitive,
+  profile, and other categories.
+- R4 extension definitions are generated under `src/extensions/`; use the
+  generated `extension_by_url()` helpers from accessor traits to inspect
+  extension lists.
 
 ## Description
 
@@ -42,7 +53,7 @@ Add this crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rh_hl7_fhir_r4_core = "0.1.0"
+rh_hl7_fhir_r4_core = "0.2.0-beta.2"
 ```
 
 ### Deserializing FHIR Resources
@@ -178,6 +189,13 @@ This crate organizes FHIR types into logical modules:
 - **traits/** - Mutator, accessor, and existence traits for all types
 - **prelude.rs** - Commonly used traits (ValidatableResource, ResourceMutators, etc.)
 - **metadata/** - Type metadata split by category (resources, datatypes, primitives) for faster incremental compilation
+
+R4-specific compatibility:
+
+- The generated model targets FHIR R4 `4.0.1`; use the R5 crate for R5-only
+  datatypes such as `integer64` and `CodeableReference`.
+- Binding enum modules are generated for required value sets; this crate
+  currently has 213 required-binding modules.
 
 ## Regenerating This Crate
 

--- a/crates/rh-hl7_fhir_r5_core/README.md
+++ b/crates/rh-hl7_fhir_r5_core/README.md
@@ -22,7 +22,20 @@ rh codegen hl7.fhir.r5.core 5.0.0 --output crates/rh-hl7_fhir_r5_core --force --
 * **Version** 5.0.0
 * **Canonical URL** `http://hl7.org/fhir`
 
-**Statistics: 0 structs, 0 enums, 0 total types**
+**Statistics:** 162 resources, 51 datatypes, 61 profiles, 546 extensions, and 245 required-binding enum modules.
+
+**Version-specific notes:**
+
+- Generated from FHIR R5 `hl7.fhir.r5.core` version `5.0.0`.
+- R5-only model shapes such as `integer64` and `CodeableReference` are emitted
+  from the package definitions.
+- Repeating fields are emitted as `Vec<T>` with serde defaults so missing JSON
+  arrays deserialize as empty vectors.
+- Metadata is split under `src/metadata/` by resource, datatype, primitive,
+  profile, and other categories.
+- R5 extension definitions are generated under `src/extensions/`; use the
+  generated `extension_by_url()` helpers from accessor traits to inspect
+  extension lists.
 
 ## Description
 
@@ -42,7 +55,7 @@ Add this crate to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rh_hl7_fhir_r5_core = "0.1.0"
+rh_hl7_fhir_r5_core = "0.2.0-beta.2"
 ```
 
 ### Deserializing FHIR Resources
@@ -178,6 +191,13 @@ This crate organizes FHIR types into logical modules:
 - **traits/** - Mutator, accessor, and existence traits for all types
 - **prelude.rs** - Commonly used traits (ValidatableResource, ResourceMutators, etc.)
 - **metadata/** - Type metadata split by category (resources, datatypes, primitives) for faster incremental compilation
+
+R5-specific compatibility:
+
+- This crate targets FHIR R5 `5.0.0`; do not use it for R4 validation or R4
+  package output.
+- Binding enum modules are generated for required value sets; this crate
+  currently has 245 required-binding modules.
 
 ## Regenerating This Crate
 

--- a/crates/rh-vcl/README.md
+++ b/crates/rh-vcl/README.md
@@ -30,7 +30,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rh-vcl = "0.1.0"
+rh-vcl = "0.2.0-beta.2"
 ```
 
 ## Quick Start
@@ -274,7 +274,7 @@ This crate can be compiled to WebAssembly for use in web applications and Node.j
 #### From rh-vcl crate directory:
 
 ```bash
-# Build all WASM targets
+# Build all WASM targets for this crate
 just wasm
 
 # Build specific targets
@@ -295,8 +295,13 @@ just dev-web
 #### From workspace root:
 
 ```bash
-# Build all WASM crates
-just wasm
+# Build all npm-backed WASM crates
+just wasm-build fhirpath all
+just wasm-build vcl all
+just wasm-build cql all
+
+# Compile-check the WASM-capable Rust crates
+just wasm-check
 ```
 
 ### Web Usage
@@ -366,10 +371,10 @@ if (explainResult.success) {
 
 ### Available Functions
 
-- **Simple functions**: `parse_vcl_simple()`, `translate_vcl_simple()`, `translate_vcl_with_system()`, `explain_vcl_simple()`
-- **Advanced**: `parse_vcl_expression()`, `translate_vcl_expression()`, `explain_vcl_expression()` with options
+- **Simple functions**: `parse_vcl_simple()`, `translate_vcl_simple()`, `translate_vcl_with_system()`, `explain_vcl_simple()`, `explain_vcl_with_system()`
+- **Advanced**: `parse_vcl_expression()`, `translate_vcl_expression()` with options
 - **Utilities**: `validate_vcl_expression()`, `get_version()`
-- **Options**: `ParseOptions`, `TranslateOptions`, `ExplainOptions` classes
+- **Options**: `ParseOptions` and `TranslateOptions` classes
 
 All functions return `WasmResult` objects with `success`, `data`, and `error` properties.
 

--- a/docs/refactor-plan-2026-06.md
+++ b/docs/refactor-plan-2026-06.md
@@ -15,7 +15,7 @@
 | WS4 Codegen | ✅ done (2026-06-15) | **4.1✅** regen harness + CI drift. **4.2✅** R5 patches. **4.3✅** golden tests. **4.4✅** god-file splits. **4.5✅** borrow-checker clones. **4.6✅** unwraps. **4.7✅** rayon parallelization. **4.8✅** (needs R4/R5 regen): Vec<T> with serde(default). **4.9✅** Box doc. **4.10✅** metadata split. **4.11✅** R5 extensions parity (regen recipe + extension_by_url helper). **4.12✅** parse tests. |
 | WS5 Performance | ⏸ deferred (2026-06-15) | Deferred by maintainer decision; WS6 starts first because it can proceed after WS1 and stable crate APIs. |
 | WS6 WASM/NPM | ✅ complete (2026-06-15) | 6.1 done: root `just wasm-build <crate> <target>` and `just wasm-check` added; CI compile-checks foundation, fhirpath, vcl, and cql for `wasm32-unknown-unknown`. 6.2 done: pnpm workspace with `@reason-healthcare/fhirpath` and `@reason-healthcare/vcl`. 6.3 deferred by maintainer decision. 6.4 done: shared Vite playground and Pages workflow. 6.5 done: `rh-cql` WASM feature/export module plus `@reason-healthcare/cql` package. 6.6 deferred as stretch. 6.7 done: foundation WASM docs clarified. |
-| WS7 Docs + gates | ⬜ not started | |
+| WS7 Docs + gates | ✅ done (2026-06-16) | Architecture graph sync, README sweep, release docs, `just docs-sync`, docs-sync CI, and MSRV CI added. |
 
 ---
 
@@ -283,17 +283,22 @@ Rules:
 
 ---
 
-## 10. WS7 — Documentation Sync + CI Gates (size: S-M, 3–4 days; final sweep LAST)
+## 10. WS7 — Documentation Sync + CI Gates (size: S-M, 3–4 days; final sweep LAST) ✅ COMPLETED
 
-Quick fixes already landed in 0.6. This is the systematic pass after code workstreams settle.
+Completed 2026-06-16. Quick fixes already landed in 0.6; this final sweep
+updated the architecture graph, root/CLI/agent/release docs, targeted crate
+READMEs, generated-crate notes, and CI gates. `scripts/check-docs-sync.sh`
+checks the architecture dependency block against `cargo metadata` and checks
+the CLI README command/global-option tables against `rh --help`. CI now runs
+docs sync and `cargo +1.91.0 check`.
 
 | # | Task | Files | Acceptance criteria |
 |---|---|---|---|
-| 7.1 | Rewrite `.github/ARCHITECTURE.md` from the corrected graph (§1), including layer table, WASM-capable matrix, and the packages/ + examples/ additions from WS6. | `.github/ARCHITECTURE.md` | Graph mechanically matches `cargo metadata` (see 7.5) |
-| 7.2 | Per-crate README pass: rh-codegen (remove stale "In Progress" features or mark shipped), rh-fhirpath (link CONFORMANCE.md, record suite pass rate), rh-vcl (2.10), generated-crate READMEs gain version-specific notes (R5 quirks: integer64, CodeableReference, binding count). | crate READMEs | Each README's examples compile as doc tests where feasible |
-| 7.3 | Root README: component table accurate (R5 ✅), WASM section pointing at packages/ + playground, exit-code + `--format json` documentation for agents. AGENTS.md: add pointers to CONFORMANCE.md files and `just` recipes agents should run. | `README.md`, `AGENTS.md` | — |
-| 7.4 | RELEASING.md: npm publish flow (6.3), regenerated-crates release policy (when codegen changes require R4/R5 crate version bumps), verify WASM doc paths. | `RELEASING.md` | Dry-run release checklist executed once |
-| 7.5 | Drift guards in CI: (a) script that diffs ARCHITECTURE.md's dependency list against `cargo metadata`; (b) script that diffs apps/rh-cli/README.md command/flag table against `rh <cmd> --help` output; (c) MSRV job (`cargo +1.91 check`). | `scripts/check-docs-sync.sh`, `ci.yml` | CI fails on doc drift; MSRV enforced |
+| 7.1 | ✅ Rewrite `.github/ARCHITECTURE.md` from the corrected graph (§1), including layer table, WASM-capable matrix, and the packages/ + examples/ additions from WS6. | `.github/ARCHITECTURE.md` | Graph mechanically matches `cargo metadata` (see 7.5) |
+| 7.2 | ✅ Per-crate README pass: rh-codegen (remove stale "In Progress" features or mark shipped), rh-fhirpath (link CONFORMANCE.md, record suite pass rate), rh-vcl (2.10), generated-crate READMEs gain version-specific notes (R5 quirks: integer64, CodeableReference, binding count). | crate READMEs | Each README's examples compile as doc tests where feasible |
+| 7.3 | ✅ Root README: component table accurate (R5 ✅), WASM section pointing at packages/ + playground, exit-code + `--format json` documentation for agents. AGENTS.md: add pointers to CONFORMANCE.md files and `just` recipes agents should run. | `README.md`, `AGENTS.md` | — |
+| 7.4 | ✅ RELEASING.md: npm publish flow (6.3), regenerated-crates release policy (when codegen changes require R4/R5 crate version bumps), verify WASM doc paths. | `RELEASING.md` | Dry-run release checklist executed once |
+| 7.5 | ✅ Drift guards in CI: (a) script that diffs ARCHITECTURE.md's dependency list against `cargo metadata`; (b) script that diffs apps/rh-cli/README.md command/flag table against `rh <cmd> --help` output; (c) MSRV job (`cargo +1.91 check`). | `scripts/check-docs-sync.sh`, `ci.yml` | CI fails on doc drift; MSRV enforced |
 
 ---
 

--- a/justfile
+++ b/justfile
@@ -143,6 +143,10 @@ run-example *args:
 docs:
     cargo doc --all-features --no-deps --open
 
+# Check machine-verifiable documentation sections against current workspace facts.
+docs-sync:
+    scripts/check-docs-sync.sh
+
 # Update all dependencies
 update:
     cargo update

--- a/packages/RELEASE.md
+++ b/packages/RELEASE.md
@@ -86,6 +86,9 @@ copies the generated artifacts into each package, and runs TypeScript builds.
 
 The playground is private and has no `pack:dry-run` script.
 
+This checklist was dry-run locally for the initial WS6 package setup using:
+`pnpm -r build`, `pnpm -r test`, and `pnpm -r pack:dry-run`.
+
 ## Publish
 
 Publish packages from the repository root in this order:

--- a/scripts/check-docs-sync.sh
+++ b/scripts/check-docs-sync.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+metadata_file="$(mktemp)"
+help_file="$(mktemp)"
+trap 'rm -f "$metadata_file" "$help_file"' EXIT
+
+cd "$repo_root"
+
+cargo metadata --format-version 1 --no-deps > "$metadata_file"
+cargo run -q -p rh-cli -- --help > "$help_file"
+
+python3 - "$repo_root" "$metadata_file" "$help_file" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+repo_root = Path(sys.argv[1])
+metadata_path = Path(sys.argv[2])
+help_path = Path(sys.argv[3])
+
+
+def fail(message: str) -> None:
+    print(f"docs sync check failed: {message}", file=sys.stderr)
+    sys.exit(1)
+
+
+def read(path: str) -> str:
+    return (repo_root / path).read_text(encoding="utf-8")
+
+
+def marked_block(path: str, name: str) -> str:
+    text = read(path)
+    start = f"<!-- docs-sync:{name}:start -->"
+    end = f"<!-- docs-sync:{name}:end -->"
+    try:
+        body = text.split(start, 1)[1].split(end, 1)[0].strip()
+    except IndexError:
+        fail(f"{path} is missing marker block {name}")
+
+    lines = body.splitlines()
+    if lines and lines[0].startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].startswith("```"):
+        lines = lines[:-1]
+    return "\n".join(line.rstrip() for line in lines).strip()
+
+
+def check_architecture_deps() -> None:
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    local = {pkg["name"] for pkg in metadata["packages"] if pkg.get("source") is None}
+    lines = []
+    for pkg in sorted((pkg for pkg in metadata["packages"] if pkg.get("source") is None), key=lambda p: p["name"]):
+        deps = sorted({
+            dep["name"]
+            for dep in pkg["dependencies"]
+            if dep.get("path") and dep["name"] in local
+        })
+        lines.append(f"{pkg['name']}: {', '.join(deps) if deps else '-'}")
+
+    actual = "\n".join(lines)
+    documented = marked_block(".github/ARCHITECTURE.md", "crate-deps")
+    if documented != actual:
+        fail(
+            ".github/ARCHITECTURE.md crate dependency block is stale\n"
+            f"expected:\n{actual}\n\nfound:\n{documented}"
+        )
+
+
+def parse_cli_help_commands() -> list[tuple[str, str]]:
+    help_text = help_path.read_text(encoding="utf-8")
+    try:
+        command_text = help_text.split("Commands:", 1)[1].split("Options:", 1)[0]
+    except IndexError:
+        fail("could not parse Commands section from rh --help")
+
+    commands = []
+    for line in command_text.splitlines():
+        match = re.match(r"^\s{2}(\S+)\s{2,}(.+?)\s*$", line)
+        if match:
+            commands.append((f"rh {match.group(1)}", match.group(2)))
+    if not commands:
+        fail("no commands parsed from rh --help")
+    return commands
+
+
+def parse_markdown_command_rows() -> list[tuple[str, str]]:
+    block = marked_block("apps/rh-cli/README.md", "cli-commands")
+    rows = []
+    for line in block.splitlines():
+        match = re.match(r"^\|\s*`([^`]+)`\s*\|\s*([^|]+?)\s*\|", line)
+        if match:
+            rows.append((match.group(1), match.group(2).strip()))
+    if not rows:
+        fail("no command rows parsed from apps/rh-cli/README.md")
+    return rows
+
+
+def check_cli_commands() -> None:
+    actual = parse_cli_help_commands()
+    documented = parse_markdown_command_rows()
+    if documented != actual:
+        fail(
+            "apps/rh-cli/README.md command table is stale\n"
+            f"expected:\n{actual}\n\nfound:\n{documented}"
+        )
+
+
+def parse_cli_help_options() -> set[str]:
+    help_text = help_path.read_text(encoding="utf-8")
+    try:
+        option_text = help_text.split("Options:", 1)[1]
+    except IndexError:
+        fail("could not parse Options section from rh --help")
+
+    options = set()
+    for line in option_text.splitlines():
+        match = re.match(r"^\s*(?:-\w,\s*)?(--[a-z-]+)", line)
+        if match:
+            options.add(match.group(1))
+    if not options:
+        fail("no global options parsed from rh --help")
+    return options
+
+
+def parse_markdown_options() -> set[str]:
+    block = marked_block("apps/rh-cli/README.md", "cli-options")
+    options = set()
+    for line in block.splitlines():
+        match = re.match(r"^\|\s*`(--[a-z-]+)", line)
+        if match:
+            options.add(match.group(1))
+    if not options:
+        fail("no global option rows parsed from apps/rh-cli/README.md")
+    return options
+
+
+def check_cli_options() -> None:
+    actual = parse_cli_help_options()
+    documented = parse_markdown_options()
+    if documented != actual:
+        fail(
+            "apps/rh-cli/README.md global option table is stale\n"
+            f"expected: {sorted(actual)}\nfound: {sorted(documented)}"
+        )
+
+
+check_architecture_deps()
+check_cli_commands()
+check_cli_options()
+print("docs sync check passed")
+PY


### PR DESCRIPTION
## Summary
- refresh architecture, root/CLI/agent/release docs for WS7
- add docs-sync script and just recipe for architecture/CLI drift checks
- add Docs Sync and MSRV jobs to CI

## Validation
- scripts/check-docs-sync.sh
- bash -n scripts/check-docs-sync.sh
- ruby YAML parse for ci/pages workflows
- rustup run 1.91.0 cargo check --workspace --all-targets --all-features