### PR TITLE
feat: expose CQL explain in WASM

### DIFF
--- a/crates/rh-cql/src/wasm.rs
+++ b/crates/rh-cql/src/wasm.rs
@@ -8,8 +8,8 @@ use wasm_bindgen::prelude::*;
 
 use crate::eval::value::{CqlCode, CqlConcept, CqlDate, CqlDateTime, CqlQuantity, CqlTime, Value};
 use crate::{
-    compile_to_elm_with_sourcemap, compile_to_json, evaluate_elm, CompilerOptions,
-    EvalContextBuilder, FixedClock, InMemoryDataProvider,
+    compile_to_elm_with_sourcemap, compile_to_json, evaluate_elm, explain_compile, explain_parse,
+    CompilerOptions, EvalContextBuilder, FixedClock, InMemoryDataProvider,
 };
 
 pub use rh_foundation::wasm::WasmResult;
@@ -173,6 +173,25 @@ pub fn evaluate_cql_elm(elm_json: &str, options: &EvaluateOptions) -> WasmResult
 pub fn compile_cql_simple(source: &str) -> WasmResult {
     let options = CompileOptions::new();
     compile_cql(source, &options)
+}
+
+#[wasm_bindgen]
+pub fn explain_cql_parse(source: &str) -> WasmResult {
+    explain_parse(source).map_or_else(parse_explain_err, WasmResult::ok)
+}
+
+#[wasm_bindgen]
+pub fn explain_cql_compile(source: &str, _options: &CompileOptions) -> WasmResult {
+    let result = explain_compile(source, Some(CompilerOptions::default()));
+    result.map_or_else(compile_explain_err, WasmResult::ok)
+}
+
+fn parse_explain_err(err: crate::CompilationError) -> WasmResult {
+    WasmResult::err(format!("Failed to explain CQL parse: {err}"))
+}
+
+fn compile_explain_err(err: crate::CompilationError) -> WasmResult {
+    WasmResult::err(format!("Failed to explain CQL compile: {err}"))
 }
 
 #[wasm_bindgen]

--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -14,6 +14,8 @@ import {
 } from "@reason-healthcare/vcl/web";
 import {
   compile as compileCql,
+  explainCompile as explainCqlCompile,
+  explainParse as explainCqlParse,
   initCql,
   version as cqlVersion
 } from "@reason-healthcare/cql/web";
@@ -114,6 +116,8 @@ app.innerHTML = `
           <textarea id="cql-source" spellcheck="false">${cqlSource}</textarea>
           <div class="actions">
             <button type="submit">Compile</button>
+<button type="button" class="secondary" id="cql-explain-compile">Explain Compile</button>
+<button type="button" class="secondary" id="cql-explain-parse">Explain Parse</button>
             <label class="toggle"><input type="checkbox" id="cql-source-map" /> Source map</label>
           </div>
         </form>
@@ -233,6 +237,18 @@ function bindCql(): void {
       { title: "CQL ELM output" }
     );
   });
+  requiredElement<HTMLButtonElement>("cql-explain-compile").addEventListener("click", () => {
+    renderResult(
+      "cql-output",
+      explainCqlCompile(textValue("cql-source"), { sourceMap: requiredElement<HTMLInputElement>("cql-source-map").checked }),
+      { title: "CQL compile explanation" }
+    );
+  });
+  requiredElement<HTMLButtonElement>("cql-explain-parse").addEventListener("click", () => {
+    renderResult("cql-output", explainCqlParse(textValue("cql-source")), {
+      title: "CQL parse explanation"
+    });
+  });
 }
 
 function renderVersions(): void {
@@ -320,6 +336,9 @@ function renderPayload(payload: unknown): string {
   if (isValidationPayload(payload)) {
     return renderValidationPayload(payload);
   }
+  if (isCqlSourceMapPayload(payload)) {
+    return renderCqlSourceMapPayload(payload);
+  }
   if (isElmLibraryPayload(payload)) {
     return renderElmLibrary(payload);
   }
@@ -331,6 +350,9 @@ function renderPayload(payload: unknown): string {
   }
   if (isRecord(payload)) {
     return renderObjectPayload(payload);
+  }
+  if (typeof payload === "string" && payload.includes("\n")) {
+    return renderTextPayload(payload);
   }
   return `<section class="rendered-block"><h3>Value</h3><p class="scalar">${escapeHtml(String(payload ?? ""))}</p></section>`;
 }
@@ -364,6 +386,39 @@ function renderElmLibrary(payload: { library: unknown }): string {
       ${rows ? `<table><thead><tr><th>Definition</th><th>Expression</th></tr></thead><tbody>${rows}</tbody></table>` : ""}
     </section>
   `;
+}
+
+function renderCqlSourceMapPayload(payload: { library: unknown; sourceMap: unknown }): string {
+  const library = isRecord(payload.library) ? payload.library : {};
+  const identifier = isRecord(library.identifier) ? library.identifier : {};
+  const sourceMap = isRecord(payload.sourceMap) ? payload.sourceMap : {};
+  const sourceDocuments = Array.isArray(sourceMap.source_documents) ? sourceMap.source_documents : [];
+  const mappings = Array.isArray(sourceMap.mappings) ? sourceMap.mappings : [];
+  const nodeMetas = Array.isArray(sourceMap.elm_node_metas) ? sourceMap.elm_node_metas : [];
+  const record = payload as Record<string, unknown>;
+  const diagnostics = ["errors", "warnings", "messages"].map((key) => {
+    const values = Array.isArray(record[key]) ? record[key] : [];
+    return { key, count: values.length };
+  });
+  const rows = sourceDocuments.map((entry) => {
+    const doc = isRecord(entry) ? entry : {};
+    return `<tr><td>${escapeHtml(String(doc.doc_id ?? "(document)"))}</td><td>${escapeHtml(String(doc.uri ?? "(inline source)"))}</td></tr>`;
+  }).join("");
+  const title = [identifier.id, identifier.version].filter(Boolean).join(" ") || "Anonymous library";
+  const diagnosticText = diagnostics.map(({ key, count }) => `${count} ${key}`).join(", ");
+
+  return [
+    `<section class="rendered-block">`,
+    `<h3>${escapeHtml(title)} source map</h3>`,
+    `<div class="metric-grid">`,
+    `<div><span>${sourceDocuments.length}</span><p>source document${sourceDocuments.length === 1 ? "" : "s"}</p></div>`,
+    `<div><span>${mappings.length}</span><p>mapping${mappings.length === 1 ? "" : "s"}</p></div>`,
+    `<div><span>${nodeMetas.length}</span><p>ELM node${nodeMetas.length === 1 ? "" : "s"}</p></div>`,
+    `</div>`,
+    `<p>${escapeHtml(diagnosticText)}.</p>`,
+    rows ? `<table><thead><tr><th>Document</th><th>URI</th></tr></thead><tbody>${rows}</tbody></table>` : "",
+    `</section>`
+  ].join("");
 }
 
 function renderValueSetCompose(payload: { include?: unknown[]; exclude?: unknown[] }): string {
@@ -408,6 +463,10 @@ function renderObjectPayload(payload: Record<string, unknown>): string {
   return `<section class="rendered-block"><h3>Rendered fields</h3><table><tbody>${rows}</tbody></table></section>`;
 }
 
+function renderTextPayload(payload: string): string {
+  return `<section class="rendered-block"><h3>Explanation</h3><pre class="explanation-pre">${escapeHtml(payload)}</pre></section>`;
+}
+
 function renderInlineValue(value: unknown): string {
   if (value === null || value === undefined) {
     return `<span class="muted">null</span>`;
@@ -445,6 +504,10 @@ function isValidationPayload(value: unknown): value is { valid: boolean; message
 
 function isElmLibraryPayload(value: unknown): value is { library: unknown } {
   return isRecord(value) && isRecord(value.library);
+}
+
+function isCqlSourceMapPayload(value: unknown): value is { library: unknown; sourceMap: unknown } {
+  return isRecord(value) && isRecord(value.library) && isRecord(value.sourceMap);
 }
 
 function isValueSetComposePayload(value: unknown): value is { include?: unknown[]; exclude?: unknown[] } {

--- a/examples/playground/src/styles.css
+++ b/examples/playground/src/styles.css
@@ -368,6 +368,38 @@ textarea.short {
   font-size: 0.88rem;
 }
 
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin: 12px 0;
+}
+
+.metric-grid div {
+  padding: 10px;
+  border: 1px solid #d9e2e4;
+  border-radius: 6px;
+  background: #f8fafb;
+}
+
+.metric-grid span {
+  display: block;
+  color: #0f766e;
+  font-size: 1.3rem;
+  font-weight: 800;
+}
+
+.metric-grid p {
+  margin: 2px 0 0;
+  color: #53666d;
+  font-size: 0.78rem;
+}
+
+.explanation-pre {
+  white-space: pre-wrap;
+  overflow-x: auto;
+}
+
 .rendered-block th,
 .rendered-block td {
   padding: 9px 10px;
@@ -441,5 +473,9 @@ textarea.short {
 
   .view-toggle {
     width: 100%;
+  }
+
+  .metric-grid {
+    grid-template-columns: 1fr;
   }
 }

--- a/packages/cql/src/bundler.ts
+++ b/packages/cql/src/bundler.ts
@@ -34,6 +34,22 @@ export function compile<T = unknown>(
   }
 }
 
+export function explainParse(source: string): WasmCallResult<string> {
+  return toPlainResult<string>(wasm.explain_cql_parse(source), false);
+}
+
+export function explainCompile(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<string> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<string>(wasm.explain_cql_compile(source, rawOptions), false);
+  } finally {
+    rawOptions.free();
+  }
+}
+
 export function evaluate<T = unknown>(
   elmJson: string | unknown,
   options: EvaluateOptions

--- a/packages/cql/src/node.ts
+++ b/packages/cql/src/node.ts
@@ -38,6 +38,22 @@ export function compile<T = unknown>(
   }
 }
 
+export function explainParse(source: string): WasmCallResult<string> {
+  return toPlainResult<string>(wasm.explain_cql_parse(source), false);
+}
+
+export function explainCompile(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<string> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<string>(wasm.explain_cql_compile(source, rawOptions), false);
+  } finally {
+    rawOptions.free();
+  }
+}
+
 export function evaluate<T = unknown>(
   elmJson: string | unknown,
   options: EvaluateOptions

--- a/packages/cql/src/web.ts
+++ b/packages/cql/src/web.ts
@@ -36,6 +36,22 @@ export function compile<T = unknown>(
   }
 }
 
+export function explainParse(source: string): WasmCallResult<string> {
+  return toPlainResult<string>(wasm.explain_cql_parse(source), false);
+}
+
+export function explainCompile(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<string> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<string>(wasm.explain_cql_compile(source, rawOptions), false);
+  } finally {
+    rawOptions.free();
+  }
+}
+
 export function evaluate<T = unknown>(
   elmJson: string | unknown,
   options: EvaluateOptions

--- a/packages/cql/test/node.test.ts
+++ b/packages/cql/test/node.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { compile, evaluate, version } from "../dist/node.js";
+import { compile, evaluate, explainCompile, explainParse, version } from "../dist/node.js";
 
 const source = "library Test version '1.0' define X: 1 + 2";
 
@@ -30,6 +30,20 @@ describe("@reason-healthcare/cql node wrapper", () => {
       result: 3,
       type: "integer"
     });
+  });
+
+  it("explains CQL parse output", () => {
+    const result = explainParse(source);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("ExpressionDef(X)");
+  });
+
+  it("explains CQL compile output", () => {
+    const result = explainCompile(source);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toContain("ExpressionDef(X)");
   });
 
   it("exposes the crate version", () => {


### PR DESCRIPTION
## Summary
- expose CQL parse and compile explanation APIs from WASM and package wrappers
- add CQL explain controls to the playground
- render CQL source map summaries distinctly from plain ELM output

## Verification
- git diff --check origin/main..HEAD
- pnpm --filter @reason-healthcare/cql build
- pnpm --filter @reason-healthcare/cql test
- pnpm --filter @reason-healthcare/playground build
- pnpm --filter @reason-healthcare/playground test