### PR TITLE
Normalize FHIRPath time output

### DIFF
--- a/apps/rh-cli/src/fhirpath.rs
+++ b/apps/rh-cli/src/fhirpath.rs
@@ -42,9 +42,8 @@ fn fhirpath_value_to_json(value: &FhirPathValue) -> Value {
         }
         FhirPathValue::Integer(i) => Value::Number(serde_json::Number::from(*i)),
         FhirPathValue::Long(l) => Value::Number(serde_json::Number::from(*l)),
-        FhirPathValue::Date(s) | FhirPathValue::DateTime(s) | FhirPathValue::Time(s) => {
-            Value::String(s.clone())
-        }
+        FhirPathValue::Date(s) | FhirPathValue::DateTime(s) => Value::String(s.clone()),
+        FhirPathValue::Time(s) => Value::String(s.strip_prefix('T').unwrap_or(s).to_string()),
         FhirPathValue::TypedDateTime { value, .. } => Value::String(value.clone()),
         FhirPathValue::Quantity { value, unit } => {
             use rust_decimal::prelude::ToPrimitive;

--- a/crates/rh-fhirpath/src/evaluator/core/evaluator.rs
+++ b/crates/rh-fhirpath/src/evaluator/core/evaluator.rs
@@ -204,7 +204,9 @@ impl FhirPathEvaluator {
             Literal::LongNumber(i) => Ok(FhirPathValue::Long(*i)),
             Literal::Date(d) => Ok(FhirPathValue::Date(d.clone())),
             Literal::DateTime(dt) => Ok(FhirPathValue::DateTime(dt.clone())),
-            Literal::Time(t) => Ok(FhirPathValue::Time(t.clone())),
+            Literal::Time(t) => Ok(FhirPathValue::Time(
+                t.strip_prefix('T').unwrap_or(t).to_string(),
+            )),
             Literal::Quantity { value, unit } => Ok(FhirPathValue::Quantity {
                 value: *value,
                 unit: unit.clone(),
@@ -1344,7 +1346,9 @@ fn construct_typed_choice_value(suffix: &str, value: &serde_json::Value) -> Opti
                 rh_hl7_fhir_r4_core::metadata::FhirPrimitiveType::DateTime
             },
         }),
-        "Time" => value.as_str().map(|s| FhirPathValue::Time(s.to_string())),
+        "Time" => value
+            .as_str()
+            .map(|s| FhirPathValue::Time(s.strip_prefix('T').unwrap_or(s).to_string())),
         // Complex types not yet modelled: CodeableConcept, Coding, Reference,
         // Identifier, etc. Caller falls back to metadata/JSON-object handling.
         _ => None,

--- a/crates/rh-fhirpath/src/evaluator/functions/boundary_functions.rs
+++ b/crates/rh-fhirpath/src/evaluator/functions/boundary_functions.rs
@@ -260,7 +260,8 @@ fn boundary_datetime(s: &str, digits: i64, high: bool) -> FhirPathResult<FhirPat
 }
 
 fn boundary_time(s: &str, digits: i64, high: bool) -> String {
-    let t: Vec<&str> = s.split(':').collect();
+    let raw = s.strip_prefix('T').unwrap_or(s);
+    let t: Vec<&str> = raw.split(':').collect();
     let hour = t.first().copied().unwrap_or(if high { "23" } else { "00" });
     let minute = t.get(1).copied().unwrap_or(if high { "59" } else { "00" });
     let (sec, ms) = match t.get(2) {

--- a/crates/rh-fhirpath/src/evaluator/functions/conversion_functions.rs
+++ b/crates/rh-fhirpath/src/evaluator/functions/conversion_functions.rs
@@ -726,15 +726,9 @@ fn to_string(value: &FhirPathValue) -> FhirPathResult<FhirPathValue> {
 
         FhirPathValue::DateTime(dt) => Ok(FhirPathValue::String(dt.clone())),
 
-        FhirPathValue::Time(t) => {
-            // Remove the leading 'T' from time format for string conversion
-            let time_str = if let Some(stripped) = t.strip_prefix('T') {
-                stripped.to_string()
-            } else {
-                t.clone()
-            };
-            Ok(FhirPathValue::String(time_str))
-        }
+        FhirPathValue::Time(t) => Ok(FhirPathValue::String(
+            t.strip_prefix('T').unwrap_or(t).to_string(),
+        )),
 
         FhirPathValue::Quantity { value, unit } => match unit {
             // Calendar-duration words are emitted unquoted (`1 week`),
@@ -800,13 +794,9 @@ fn to_time(value: &FhirPathValue) -> FhirPathResult<FhirPathValue> {
         FhirPathValue::String(s) => {
             // Validate time format: HH:MM:SS or HH:MM:SS.sss
             if is_valid_time_string(s) {
-                // Add leading 'T' for internal representation
-                let time_with_t = if s.starts_with('T') {
-                    s.clone()
-                } else {
-                    format!("T{s}")
-                };
-                Ok(FhirPathValue::Time(time_with_t))
+                Ok(FhirPathValue::Time(
+                    s.strip_prefix('T').unwrap_or(s).to_string(),
+                ))
             } else {
                 Ok(FhirPathValue::Empty)
             }
@@ -815,7 +805,7 @@ fn to_time(value: &FhirPathValue) -> FhirPathResult<FhirPathValue> {
         FhirPathValue::DateTime(dt) => {
             // Extract time part from datetime
             if let Some(time_part) = extract_time_from_datetime(dt) {
-                Ok(FhirPathValue::Time(format!("T{time_part}")))
+                Ok(FhirPathValue::Time(time_part))
             } else {
                 Ok(FhirPathValue::Empty)
             }
@@ -998,8 +988,8 @@ fn is_valid_datetime_string(s: &str) -> bool {
 }
 
 /// Per FHIRPath spec, Time accepts hh, hh:mm, hh:mm:ss, or hh:mm:ss.fff.
-/// Storage form has a leading T; user-supplied strings often do not, so we
-/// normalise before delegating to the temporal parser.
+/// FHIRPath time literals use `@T`, but Time values are represented without the
+/// literal prefix. Normalize before delegating to the temporal parser.
 fn is_valid_time_string(s: &str) -> bool {
     if s.ends_with('Z')
         || s.contains('+')

--- a/crates/rh-fhirpath/src/evaluator/operations/arithmetic.rs
+++ b/crates/rh-fhirpath/src/evaluator/operations/arithmetic.rs
@@ -1119,9 +1119,9 @@ impl ArithmeticEvaluator {
             })?;
 
         let result_str = if has_fraction || nanos != 0 {
-            format!("T{}", result.format("%H:%M:%S%.3f"))
+            result.format("%H:%M:%S%.3f").to_string()
         } else {
-            format!("T{}", result.format("%H:%M:%S"))
+            result.format("%H:%M:%S").to_string()
         };
         Ok(FhirPathValue::Time(result_str))
     }

--- a/crates/rh-fhirpath/src/evaluator/operations/collection.rs
+++ b/crates/rh-fhirpath/src/evaluator/operations/collection.rs
@@ -850,7 +850,9 @@ impl CollectionEvaluator {
             (FhirPathValue::Boolean(a), FhirPathValue::Boolean(b)) => a == b,
             (FhirPathValue::DateTime(a), FhirPathValue::DateTime(b)) => a == b,
             (FhirPathValue::Date(a), FhirPathValue::Date(b)) => a == b,
-            (FhirPathValue::Time(a), FhirPathValue::Time(b)) => a == b,
+            (FhirPathValue::Time(a), FhirPathValue::Time(b)) => {
+                a.strip_prefix('T').unwrap_or(a) == b.strip_prefix('T').unwrap_or(b)
+            }
             (
                 FhirPathValue::Quantity {
                     value: a_val,

--- a/crates/rh-fhirpath/src/evaluator/operations/comparison.rs
+++ b/crates/rh-fhirpath/src/evaluator/operations/comparison.rs
@@ -19,8 +19,16 @@ pub struct ComparisonEvaluator;
 /// start/end fields accessed without typed metadata).
 fn try_temporal(v: &FhirPathValue) -> Option<TemporalParts> {
     match v {
-        FhirPathValue::Date(s) | FhirPathValue::DateTime(s) | FhirPathValue::Time(s) => {
-            parse_temporal(s)
+        FhirPathValue::Date(s) | FhirPathValue::DateTime(s) => parse_temporal(s),
+        FhirPathValue::Time(s) => {
+            let normalized;
+            let temporal_text = if s.starts_with('T') {
+                s.as_str()
+            } else {
+                normalized = format!("T{s}");
+                normalized.as_str()
+            };
+            parse_temporal(temporal_text)
         }
         FhirPathValue::String(s) => parse_temporal(s),
         _ => None,

--- a/crates/rh-fhirpath/src/evaluator/operations/datetime.rs
+++ b/crates/rh-fhirpath/src/evaluator/operations/datetime.rs
@@ -230,7 +230,7 @@ impl DateTimeEvaluator {
             }
             FhirPathValue::DateTime(dt_str) => {
                 if let Some(time) = dt_str.split_once('T').map(|(_, time)| time) {
-                    Ok(FhirPathValue::Time(format!("T{}", strip_timezone(time))))
+                    Ok(FhirPathValue::Time(strip_timezone(time).to_string()))
                 } else {
                     Ok(FhirPathValue::Empty)
                 }
@@ -484,12 +484,12 @@ mod tests {
     fn test_time_of() {
         let datetime_value = FhirPathValue::DateTime("2023-07-15T14:30:25.123Z".to_string());
         let result = DateTimeEvaluator::time_of(&datetime_value).unwrap();
-        assert_eq!(result, FhirPathValue::Time("T14:30:25.123".to_string()));
+        assert_eq!(result, FhirPathValue::Time("14:30:25.123".to_string()));
 
         // With timezone
         let datetime_tz = FhirPathValue::DateTime("2023-12-25T09:15:30.500+02:00".to_string());
         let result = DateTimeEvaluator::time_of(&datetime_tz).unwrap();
-        assert_eq!(result, FhirPathValue::Time("T09:15:30.500".to_string()));
+        assert_eq!(result, FhirPathValue::Time("09:15:30.500".to_string()));
     }
 
     #[test]

--- a/crates/rh-fhirpath/src/evaluator/types/values.rs
+++ b/crates/rh-fhirpath/src/evaluator/types/values.rs
@@ -62,6 +62,10 @@ pub enum FhirPathValue {
 }
 
 impl FhirPathValue {
+    fn canonical_time(value: &str) -> &str {
+        value.strip_prefix('T').unwrap_or(value)
+    }
+
     /// Returns `true` if this is an `UnorderedCollection`.
     pub fn is_unordered(&self) -> bool {
         matches!(self, FhirPathValue::UnorderedCollection(_))
@@ -143,7 +147,9 @@ impl FhirPathValue {
                 FhirPathValue::TypedDateTime { value: a, .. },
                 FhirPathValue::TypedDateTime { value: b, .. },
             ) => a == b,
-            (FhirPathValue::Time(a), FhirPathValue::Time(b)) => a == b,
+            (FhirPathValue::Time(a), FhirPathValue::Time(b)) => {
+                Self::canonical_time(a) == Self::canonical_time(b)
+            }
             (FhirPathValue::DateTimePrecision(a), FhirPathValue::DateTimePrecision(b)) => a == b,
             (FhirPathValue::Date(a), FhirPathValue::String(b))
             | (FhirPathValue::Date(a), FhirPathValue::TypedString { value: b, .. }) => a == b,
@@ -164,9 +170,13 @@ impl FhirPathValue {
                 FhirPathValue::TypedDateTime { value: b, .. },
             ) => a == b,
             (FhirPathValue::Time(a), FhirPathValue::String(b))
-            | (FhirPathValue::Time(a), FhirPathValue::TypedString { value: b, .. }) => a == b,
+            | (FhirPathValue::Time(a), FhirPathValue::TypedString { value: b, .. }) => {
+                Self::canonical_time(a) == Self::canonical_time(b)
+            }
             (FhirPathValue::String(a), FhirPathValue::Time(b))
-            | (FhirPathValue::TypedString { value: a, .. }, FhirPathValue::Time(b)) => a == b,
+            | (FhirPathValue::TypedString { value: a, .. }, FhirPathValue::Time(b)) => {
+                Self::canonical_time(a) == Self::canonical_time(b)
+            }
             (FhirPathValue::Empty, FhirPathValue::Empty) => true,
             (FhirPathValue::Collection(a), FhirPathValue::Collection(b)) => {
                 a.len() == b.len()
@@ -257,7 +267,7 @@ impl FhirPathValue {
             FhirPathValue::Date(d) => Ok(d.clone()),
             FhirPathValue::DateTime(dt) => Ok(dt.clone()),
             FhirPathValue::TypedDateTime { value, .. } => Ok(value.clone()),
-            FhirPathValue::Time(t) => Ok(t.clone()),
+            FhirPathValue::Time(t) => Ok(Self::canonical_time(t).to_string()),
             FhirPathValue::Empty => Ok("".to_string()),
             _ => Err(FhirPathError::EvaluationError {
                 message: format!("Cannot convert {self:?} to string"),
@@ -312,7 +322,7 @@ impl FhirPathValue {
             FhirPathValue::Date(s) => Value::String(s.clone()),
             FhirPathValue::DateTime(s) => Value::String(s.clone()),
             FhirPathValue::TypedDateTime { value, .. } => Value::String(value.clone()),
-            FhirPathValue::Time(s) => Value::String(s.clone()),
+            FhirPathValue::Time(s) => Value::String(Self::canonical_time(s).to_string()),
             FhirPathValue::Quantity { value, unit: _ } => {
                 let fval = value.to_f64().unwrap_or(0.0);
                 Value::Number(
@@ -405,7 +415,9 @@ impl FhirPathValue {
                 FhirPathValue::TypedDateTime { value: a, .. },
                 FhirPathValue::TypedDateTime { value: b, .. },
             ) => Ok(a.cmp(b) as i32),
-            (FhirPathValue::Time(a), FhirPathValue::Time(b)) => Ok(a.cmp(b) as i32),
+            (FhirPathValue::Time(a), FhirPathValue::Time(b)) => {
+                Ok(Self::canonical_time(a).cmp(Self::canonical_time(b)) as i32)
+            }
 
             // Date/Time comparisons with implicit string conversion
             (FhirPathValue::Date(a), _) if right_str.is_some() => {
@@ -427,10 +439,10 @@ impl FhirPathValue {
                 Ok(left_str.unwrap().cmp(value.as_str()) as i32)
             }
             (FhirPathValue::Time(a), _) if right_str.is_some() => {
-                Ok(a.as_str().cmp(right_str.unwrap()) as i32)
+                Ok(Self::canonical_time(a).cmp(Self::canonical_time(right_str.unwrap())) as i32)
             }
             (_, FhirPathValue::Time(b)) if left_str.is_some() => {
-                Ok(left_str.unwrap().cmp(b.as_str()) as i32)
+                Ok(Self::canonical_time(left_str.unwrap()).cmp(Self::canonical_time(b)) as i32)
             }
 
             // Quantity comparisons with unit conversion

--- a/crates/rh-fhirpath/testlab/run_r5_testlab.py
+++ b/crates/rh-fhirpath/testlab/run_r5_testlab.py
@@ -584,6 +584,23 @@ def render_markdown(payload: dict[str, Any]) -> str:
         for rationale, count in rationale_counts.items():
             lines.append(f"| {md(rationale)} | {count} |")
 
+    lines.extend(
+        [
+            "",
+            "## Result Index",
+            "",
+            "| Test | Outcome | Input | Expression | Expectation | Actual |",
+            "|---|---|---|---|---|---|",
+        ]
+    )
+    for item in payload["results"]:
+        test_id = f"{item['group']}::{item['name']}"
+        lines.append(
+            f"| {md_inline(test_id)} | {md_inline(item['outcome'])} | "
+            f"{md_inline(item['inputfile'])} | {md_inline(item['expression'])} | "
+            f"{md_inline(item['expectation'])} | {md_inline(item['actual'])} |"
+        )
+
     lines.extend(["", "## Results", ""])
     for item in payload["results"]:
         lines.extend(
@@ -631,6 +648,10 @@ def grouped_rationales_from_payload(results: list[dict[str, Any]]) -> dict[str, 
 
 def md(value: str) -> str:
     return value.replace("|", "\\|")
+
+
+def md_inline(value: str) -> str:
+    return md(value).replace("\n", " ").replace("\r", " ")
 
 
 def main() -> int:

--- a/crates/rh-fhirpath/tests/datetime_component_integration_test.rs
+++ b/crates/rh-fhirpath/tests/datetime_component_integration_test.rs
@@ -175,7 +175,7 @@ fn test_date_time_extraction_integration() {
 
     let value = extract_single_value(result);
     if let FhirPathValue::Time(time) = value {
-        assert_eq!(time.to_string(), "T14:30:25");
+        assert_eq!(time.to_string(), "14:30:25");
     } else {
         panic!("Expected Time value, got: {value:?}");
     }

--- a/crates/rh-fhirpath/tests/time_conversion_test.rs
+++ b/crates/rh-fhirpath/tests/time_conversion_test.rs
@@ -12,42 +12,42 @@ fn test_to_time_function() {
     // Test Time to Time (identity)
     let expr = parser.parse("@T10:30:45.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T10:30:45".to_string()));
+    assert_eq!(result, FhirPathValue::Time("10:30:45".to_string()));
 
     let expr = parser.parse("@T23:59:59.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T23:59:59".to_string()));
+    assert_eq!(result, FhirPathValue::Time("23:59:59".to_string()));
 
     // Test String to Time
     let expr = parser.parse("'10:30:45'.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T10:30:45".to_string()));
+    assert_eq!(result, FhirPathValue::Time("10:30:45".to_string()));
 
     let expr = parser.parse("'23:59:59.123'.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T23:59:59.123".to_string()));
+    assert_eq!(result, FhirPathValue::Time("23:59:59.123".to_string()));
 
     let expr = parser.parse("'00:00:00'.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T00:00:00".to_string()));
+    assert_eq!(result, FhirPathValue::Time("00:00:00".to_string()));
 
     // Test String with T prefix to Time
     let expr = parser.parse("'T14:25:36'.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T14:25:36".to_string()));
+    assert_eq!(result, FhirPathValue::Time("14:25:36".to_string()));
 
     // Test DateTime to Time (extract time part)
     let expr = parser.parse("@2023-01-15T10:30:45.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T10:30:45".to_string()));
+    assert_eq!(result, FhirPathValue::Time("10:30:45".to_string()));
 
     let expr = parser.parse("@2023-01-15T23:59:59Z.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T23:59:59".to_string()));
+    assert_eq!(result, FhirPathValue::Time("23:59:59".to_string()));
 
     let expr = parser.parse("@2023-01-15T14:25:36+05:30.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T14:25:36".to_string()));
+    assert_eq!(result, FhirPathValue::Time("14:25:36".to_string()));
 
     // Test invalid strings (should return empty)
     let expr = parser.parse("'not-a-time'.toTime()").unwrap();
@@ -195,7 +195,7 @@ fn test_time_conversion_edge_cases() {
     // Test single item collection
     let expr = parser.parse("('10:30:45').toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T10:30:45".to_string()));
+    assert_eq!(result, FhirPathValue::Time("10:30:45".to_string()));
 
     let expr = parser.parse("('10:30:45').convertsToTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
@@ -213,7 +213,7 @@ fn test_time_conversion_edge_cases() {
 
     let expr = parser.parse("'00:00:00'.toTime()").unwrap();
     let result = evaluator.evaluate(&expr, &context).unwrap();
-    assert_eq!(result, FhirPathValue::Time("T00:00:00".to_string()));
+    assert_eq!(result, FhirPathValue::Time("00:00:00".to_string()));
 
     // Test fractional seconds variations
     let expr = parser.parse("'12:30:45.1'.convertsToTime()").unwrap();
@@ -244,19 +244,19 @@ fn test_time_conversion_comprehensive() {
     // Test all valid time conversion patterns
     let test_cases = vec![
         // Time literals (identity)
-        ("@T10:30:45", "T10:30:45", true),
-        ("@T00:00:00", "T00:00:00", true),
-        ("@T23:59:59", "T23:59:59", true),
+        ("@T10:30:45", "10:30:45", true),
+        ("@T00:00:00", "00:00:00", true),
+        ("@T23:59:59", "23:59:59", true),
         // String time formats
-        ("'10:30:45'", "T10:30:45", true),
-        ("'00:00:00'", "T00:00:00", true),
-        ("'23:59:59'", "T23:59:59", true),
-        ("'12:30:45.123'", "T12:30:45.123", true),
-        ("'T14:25:36'", "T14:25:36", true),
+        ("'10:30:45'", "10:30:45", true),
+        ("'00:00:00'", "00:00:00", true),
+        ("'23:59:59'", "23:59:59", true),
+        ("'12:30:45.123'", "12:30:45.123", true),
+        ("'T14:25:36'", "14:25:36", true),
         // DateTime extraction
-        ("@2023-01-15T10:30:45", "T10:30:45", true),
-        ("@2023-01-15T00:00:00Z", "T00:00:00", true),
-        ("@2023-01-15T23:59:59+05:30", "T23:59:59", true),
+        ("@2023-01-15T10:30:45", "10:30:45", true),
+        ("@2023-01-15T00:00:00Z", "00:00:00", true),
+        ("@2023-01-15T23:59:59+05:30", "23:59:59", true),
     ];
 
     for (input, expected_time, should_convert) in test_cases {
@@ -297,4 +297,23 @@ fn test_time_conversion_comprehensive() {
         let result = evaluator.evaluate(&expr, &context).unwrap();
         assert_eq!(result, FhirPathValue::Boolean(false));
     }
+}
+
+#[test]
+fn test_time_json_output_omits_literal_t_prefix() {
+    let parser = FhirPathParser::new();
+    let evaluator = FhirPathEvaluator::new();
+    let context = EvaluationContext::new(json!({}));
+
+    let expr = parser
+        .parse("@2012-01-01T12:30:00.000-07:00.timeOf()")
+        .unwrap();
+    let result = evaluator.evaluate(&expr, &context).unwrap();
+    assert_eq!(result, FhirPathValue::Time("12:30:00.000".to_string()));
+    assert_eq!(result.to_json(), json!("12:30:00.000"));
+
+    let expr = parser.parse("@T10:30:00.000").unwrap();
+    let result = evaluator.evaluate(&expr, &context).unwrap();
+    assert_eq!(result, FhirPathValue::Time("10:30:00.000".to_string()));
+    assert_eq!(result.to_json(), json!("10:30:00.000"));
 }

--- a/packages/cql/package.json
+++ b/packages/cql/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonhealth/cql",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Typed TypeScript wrappers for the Reason Health CQL WebAssembly package.",
   "license": "MIT OR Apache-2.0",
   "type": "module",

--- a/packages/fhirpath/package.json
+++ b/packages/fhirpath/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonhealth/fhirpath",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Typed TypeScript wrappers for the Reason Health FHIRPath WebAssembly package.",
   "license": "MIT OR Apache-2.0",
   "type": "module",

--- a/packages/vcl/package.json
+++ b/packages/vcl/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@reasonhealth/vcl",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Typed TypeScript wrappers for the Reason Health VCL WebAssembly package.",
   "license": "MIT OR Apache-2.0",
   "type": "module",


### PR DESCRIPTION
## Summary
- normalize FHIRPath Time values to external `HH:mm...` form instead of leaking literal `T` prefixes
- keep `@T...` as accepted literal syntax while normalizing `timeOf()`, `toTime()`, literals, arithmetic, comparisons, distinct/equality, CLI JSON, and WASM JSON output
- add a testlab result index so selected expressions are easier to find in the Markdown report

## Verification
- `cargo test -p rh-fhirpath`
- `cargo run -q -p rh-cli -- --format json --quiet fhirpath eval --display-format json -- '@2012-01-01T12:30:00.000-07:00.timeOf()'` returns `"12:30:00.000"`\n- `python3 crates/rh-fhirpath/testlab/run_r5_testlab.py --no-baseline-check` -> `1618 selected, 1488 pass, 23 fail, 99 not implemented, 8 skipped`