### PR TITLE
Improve validator conformance signal and string limits

### DIFF
--- a/crates/rh-fhirpath/TRACE.md
+++ b/crates/rh-fhirpath/TRACE.md
@@ -21,9 +21,8 @@ The `trace()` function adds a String representation of the input collection to a
 
 1. **Logs diagnostic information** to help debug expression evaluation
 2. **Returns input unchanged** - never modifies the data flowing through the expression
-3. **Outputs to two destinations**:
-   - `stderr` via `eprintln!` for immediate visibility
-   - `EvaluationContext.trace_logs` for programmatic access
+3. **Captures trace output** in `EvaluationContext.trace_logs` for programmatic access
+4. **Can also write to stderr** when `RH_FHIRPATH_TRACE_STDERR` is set
 
 ## Usage Examples
 

--- a/crates/rh-fhirpath/src/evaluator/core/evaluator.rs
+++ b/crates/rh-fhirpath/src/evaluator/core/evaluator.rs
@@ -919,10 +919,10 @@ impl FhirPathEvaluator {
             target.clone()
         };
 
-        // Log the value to stderr for diagnostic purposes (backward compatibility)
-        eprintln!("[TRACE:{name}] {value_to_log:?}");
+        if std::env::var_os("RH_FHIRPATH_TRACE_STDERR").is_some() {
+            eprintln!("[TRACE:{name}] {value_to_log:?}");
+        }
 
-        // Also add to context trace logs for programmatic access
         context.add_trace_log(name, format!("{value_to_log:?}"));
 
         // Return the original input unchanged

--- a/crates/rh-validator/src/validator.rs
+++ b/crates/rh-validator/src/validator.rs
@@ -1326,19 +1326,17 @@ fn validate_fhir_string_lengths(value: &Value, current_path: &str) -> Vec<Valida
                 issues.extend(validate_fhir_string_lengths(item, &child_path));
             }
         }
-        Value::String(s) => {
-            if s.len() > MAX_FHIR_STRING_BYTES {
-                issues.push(
-                    ValidationIssue::error(
-                        IssueCode::TooLong,
-                        format!(
-                            "String value at '{current_path}' exceeds the FHIR maximum length of 1 MB ({} bytes)",
-                            s.len()
-                        ),
-                    )
-                    .with_path(current_path),
-                );
-            }
+        Value::String(s) if s.len() > MAX_FHIR_STRING_BYTES => {
+            issues.push(
+                ValidationIssue::error(
+                    IssueCode::TooLong,
+                    format!(
+                        "String value at '{current_path}' exceeds the FHIR maximum length of 1 MB ({} bytes)",
+                        s.len()
+                    ),
+                )
+                .with_path(current_path),
+            );
         }
         _ => {}
     }

--- a/crates/rh-validator/src/validator.rs
+++ b/crates/rh-validator/src/validator.rs
@@ -331,6 +331,11 @@ impl FhirValidator {
             }
         }
 
+        let structural_issues = validate_fhir_string_lengths(resource, resource_type_name);
+        for issue in structural_issues {
+            result = result.with_issue(issue);
+        }
+
         // Validate JSON structure (empty arrays are invalid in FHIR)
         let empty_array_issues = validate_json_structure(resource, resource_type_name);
         for issue in empty_array_issues {
@@ -1296,6 +1301,49 @@ fn validate_id_format(id: &str, path: &str) -> Option<ValidationIssue> {
         }
     }
     None
+}
+
+const MAX_FHIR_STRING_BYTES: usize = 1024 * 1024;
+
+fn validate_fhir_string_lengths(value: &Value, current_path: &str) -> Vec<ValidationIssue> {
+    let mut issues = Vec::new();
+
+    match value {
+        Value::Object(obj) => {
+            for (key, v) in obj {
+                let child_path = if current_path.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{current_path}.{key}")
+                };
+
+                issues.extend(validate_fhir_string_lengths(v, &child_path));
+            }
+        }
+        Value::Array(arr) => {
+            for (idx, item) in arr.iter().enumerate() {
+                let child_path = format!("{current_path}[{idx}]");
+                issues.extend(validate_fhir_string_lengths(item, &child_path));
+            }
+        }
+        Value::String(s) => {
+            if s.len() > MAX_FHIR_STRING_BYTES {
+                issues.push(
+                    ValidationIssue::error(
+                        IssueCode::TooLong,
+                        format!(
+                            "String value at '{current_path}' exceeds the FHIR maximum length of 1 MB ({} bytes)",
+                            s.len()
+                        ),
+                    )
+                    .with_path(current_path),
+                );
+            }
+        }
+        _ => {}
+    }
+
+    issues
 }
 
 fn validate_json_structure(value: &Value, current_path: &str) -> Vec<ValidationIssue> {

--- a/crates/rh-validator/tests/integration_test.rs
+++ b/crates/rh-validator/tests/integration_test.rs
@@ -40,6 +40,24 @@ fn test_basic_validation_valid_structure() {
 }
 
 #[test]
+fn test_basic_validation_rejects_oversized_strings() {
+    let validator = FhirValidator::new(rh_validator::FhirVersion::R4, None).unwrap();
+    let oversized = "a".repeat(1024 * 1024 + 1);
+    let resource = json!({
+        "resourceType": "Location",
+        "id": "example",
+        "description": oversized
+    });
+
+    let result = validator.validate(&resource).unwrap();
+    assert!(!result.valid);
+    assert!(result.issues.iter().any(|issue| {
+        issue.path.as_deref() == Some("Location.description")
+            || issue.message.contains("Location.description")
+    }));
+}
+
+#[test]
 fn test_basic_validation_not_json_object() {
     let validator = FhirValidator::new(rh_validator::FhirVersion::R4, None).unwrap();
     let resource = json!("not an object");


### PR DESCRIPTION
## Summary
- make FHIRPath trace stderr output opt-in via RH_FHIRPATH_TRACE_STDERR while preserving structured trace logs
- add recursive FHIR string length validation for the 1 MB ceiling
- add regression coverage for oversized FHIR strings

## Conformance
- Baseline full R4 Java agreement: 295/386 (76.4%), 417 R4 tests run
- After changes: 296/386 (76.7%), 417 R4 tests run
- False positives reduced from 78 to 77; false negatives remain 13
- Confirmed resource-invalid-eid-2 now matches Java INVALID while resource-invalid-eid-0/1 remain VALID

## Remaining Gap Plan
- Add a real registered CodeSystem lookup path for terminology property/filter validation, covering cs-filter-bad and vs-filter-property-bad cases
- Improve profile/slicing/package-versioning checks for the large false-positive cluster
- Audit false negatives from over-applied invariants/extensions before relaxing validation
- Keep using exact full R4 conformance logs for each validator behavior iteration

## Verification
- cargo test -p rh-fhirpath --test trace_function_test --test trace_logs_test
- cargo test -p rh-validator --test integration_test
- cargo test --features fhir-test-cases -p rh-validator fhir_test_cases::runner::tests::test_runner_all -- --exact --nocapture --ignored
- just check