### PR TITLE
Fix validator slicing and versioned profile checks

### DIFF
--- a/crates/rh-foundation/benches/snapshot.rs
+++ b/crates/rh-foundation/benches/snapshot.rs
@@ -29,6 +29,7 @@ fn element(path: &str, min: u32, max: &str) -> ElementDefinition {
         is_modifier_reason: None,
         slicing: None,
         slice_name: None,
+        additional: std::collections::HashMap::new(),
     }
 }
 

--- a/crates/rh-foundation/src/snapshot/merger.rs
+++ b/crates/rh-foundation/src/snapshot/merger.rs
@@ -214,8 +214,18 @@ impl ElementMerger {
                 .or_else(|| base.is_modifier_reason.clone()),
             slicing: diff.slicing.clone().or_else(|| base.slicing.clone()),
             slice_name: diff.slice_name.clone().or_else(|| base.slice_name.clone()),
+            additional: merge_additional_fields(&base.additional, &diff.additional),
         })
     }
+}
+
+fn merge_additional_fields(
+    base: &std::collections::HashMap<String, serde_json::Value>,
+    diff: &std::collections::HashMap<String, serde_json::Value>,
+) -> std::collections::HashMap<String, serde_json::Value> {
+    let mut merged = base.clone();
+    merged.extend(diff.clone());
+    merged
 }
 
 #[cfg(test)]
@@ -241,6 +251,7 @@ mod tests {
             is_modifier_reason: None,
             slicing: None,
             slice_name: slice_name.map(|slice| slice.to_string()),
+            additional: std::collections::HashMap::new(),
         }
     }
 

--- a/crates/rh-foundation/src/snapshot/types.rs
+++ b/crates/rh-foundation/src/snapshot/types.rs
@@ -1,4 +1,6 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct StructureDefinition {
@@ -48,6 +50,8 @@ pub struct ElementDefinition {
     pub slicing: Option<ElementSlicing>,
     #[serde(rename = "sliceName")]
     pub slice_name: Option<String>,
+    #[serde(flatten)]
+    pub additional: HashMap<String, Value>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -69,6 +73,8 @@ pub struct ElementDiscriminator {
 pub struct ElementType {
     pub code: String,
     pub profile: Option<Vec<String>>,
+    #[serde(rename = "targetProfile")]
+    pub target_profile: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/rh-validator/src/profile.rs
+++ b/crates/rh-validator/src/profile.rs
@@ -87,7 +87,9 @@ impl ProfileRegistry {
     }
 
     pub fn get_snapshot(&self, profile_url: &str) -> Result<Option<StructureDefinition>> {
-        if let Some(cached) = self.snapshot_cache.write().unwrap().get(profile_url) {
+        let lookup_url = canonical_url_without_version(profile_url);
+
+        if let Some(cached) = self.snapshot_cache.write().unwrap().get(lookup_url) {
             *self.cache_hits.write().unwrap() += 1;
             return Ok(Some(cached.clone()));
         }
@@ -99,34 +101,34 @@ impl ProfileRegistry {
             .dynamic_profiles
             .read()
             .unwrap()
-            .get(profile_url)
+            .get(lookup_url)
             .cloned()
         {
             self.snapshot_cache
                 .write()
                 .unwrap()
-                .put(profile_url.to_string(), profile.clone());
+                .put(lookup_url.to_string(), profile.clone());
             return Ok(Some(profile));
         }
 
         // Then check statically loaded profiles
-        if !self.profiles.contains_key(profile_url) {
+        if !self.profiles.contains_key(lookup_url) {
             return Ok(None);
         }
 
         let snapshot = self
             .generator
-            .generate_snapshot(profile_url)
+            .generate_snapshot(lookup_url)
             .context("Failed to generate snapshot")?;
 
-        let profile = self.profiles.get(profile_url).unwrap().clone();
+        let profile = self.profiles.get(lookup_url).unwrap().clone();
         let mut profile_with_snapshot = profile;
         profile_with_snapshot.snapshot = Some(std::sync::Arc::unwrap_or_clone(snapshot));
 
         self.snapshot_cache
             .write()
             .unwrap()
-            .put(profile_url.to_string(), profile_with_snapshot.clone());
+            .put(lookup_url.to_string(), profile_with_snapshot.clone());
 
         Ok(Some(profile_with_snapshot))
     }
@@ -218,6 +220,10 @@ impl ProfileRegistry {
 
         urls
     }
+}
+
+fn canonical_url_without_version(url: &str) -> &str {
+    url.split('|').next().unwrap_or(url)
 }
 
 impl Default for ProfileRegistry {

--- a/crates/rh-validator/src/rules.rs
+++ b/crates/rh-validator/src/rules.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use lru::LruCache;
-use rh_foundation::snapshot::StructureDefinition;
+use rh_foundation::snapshot::{ElementDefinition, StructureDefinition};
+use serde_json::Value;
+use std::collections::HashMap;
 use std::num::NonZeroUsize;
 use std::sync::Mutex;
 
@@ -73,6 +75,14 @@ pub struct SliceDefinition {
     pub name: String,
     pub min: u32,
     pub max: String,
+    pub discriminator_constraints: Vec<DiscriminatorConstraint>,
+    pub target_profiles: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct DiscriminatorConstraint {
+    pub path: String,
+    pub value: Value,
 }
 
 pub struct RuleCompiler {
@@ -198,6 +208,18 @@ impl RuleCompiler {
                     for slice_element in &snapshot_data.element {
                         if slice_element.path == element.path {
                             if let Some(slice_name) = &slice_element.slice_name {
+                                let discriminator_constraints = collect_discriminator_constraints(
+                                    &snapshot_data.element,
+                                    element,
+                                    slice_name,
+                                    &discriminators,
+                                );
+                                let target_profiles = collect_profile_constraints(
+                                    &snapshot_data.element,
+                                    element,
+                                    slice_name,
+                                    &discriminators,
+                                );
                                 slices.push(SliceDefinition {
                                     name: slice_name.clone(),
                                     min: slice_element.min.unwrap_or(0),
@@ -205,6 +227,8 @@ impl RuleCompiler {
                                         .max
                                         .clone()
                                         .unwrap_or_else(|| "*".to_string()),
+                                    discriminator_constraints,
+                                    target_profiles,
                                 });
                             }
                         }
@@ -273,6 +297,106 @@ impl RuleCompiler {
         *self.cache_hits.lock().unwrap() = 0;
         *self.cache_misses.lock().unwrap() = 0;
     }
+}
+
+fn collect_discriminator_constraints(
+    elements: &[ElementDefinition],
+    slicing_root: &ElementDefinition,
+    slice_name: &str,
+    discriminators: &[Discriminator],
+) -> Vec<DiscriminatorConstraint> {
+    let mut constraints = Vec::new();
+
+    for element in elements {
+        if element.slice_name.as_deref() != Some(slice_name) {
+            continue;
+        }
+
+        let Some(relative_path) = relative_slice_path(&element.path, &slicing_root.path) else {
+            continue;
+        };
+
+        for discriminator in discriminators {
+            if !path_matches_discriminator(relative_path, &discriminator.path) {
+                continue;
+            }
+
+            for value in fixed_or_pattern_values(&element.additional) {
+                constraints.push(DiscriminatorConstraint {
+                    path: relative_path.to_string(),
+                    value: value.clone(),
+                });
+            }
+        }
+    }
+
+    constraints
+}
+
+fn collect_profile_constraints(
+    elements: &[ElementDefinition],
+    slicing_root: &ElementDefinition,
+    slice_name: &str,
+    discriminators: &[Discriminator],
+) -> Vec<String> {
+    let mut profiles = Vec::new();
+
+    for element in elements {
+        if element.slice_name.as_deref() != Some(slice_name) {
+            continue;
+        }
+
+        let Some(relative_path) = relative_slice_path(&element.path, &slicing_root.path) else {
+            continue;
+        };
+
+        let is_profile_discriminator_path = discriminators.iter().any(|discriminator| {
+            discriminator.type_ == "profile"
+                && path_matches_discriminator(relative_path, &discriminator.path)
+        });
+        if !is_profile_discriminator_path {
+            continue;
+        }
+
+        if let Some(types) = &element.type_ {
+            for type_def in types {
+                if let Some(type_profiles) = &type_def.profile {
+                    profiles.extend(type_profiles.iter().cloned());
+                }
+                if let Some(type_profiles) = &type_def.target_profile {
+                    profiles.extend(type_profiles.iter().cloned());
+                }
+            }
+        }
+    }
+
+    profiles.sort();
+    profiles.dedup();
+    profiles
+}
+
+fn relative_slice_path<'a>(element_path: &'a str, slicing_path: &str) -> Option<&'a str> {
+    if element_path == slicing_path {
+        return Some("$this");
+    }
+
+    element_path
+        .strip_prefix(slicing_path)
+        .and_then(|suffix| suffix.strip_prefix('.'))
+}
+
+fn path_matches_discriminator(element_relative_path: &str, discriminator_path: &str) -> bool {
+    (discriminator_path == "$this" && element_relative_path == "$this")
+        || element_relative_path == discriminator_path
+        || discriminator_path.starts_with(&format!("{element_relative_path}."))
+        || element_relative_path.starts_with(&format!("{discriminator_path}."))
+}
+
+fn fixed_or_pattern_values(additional: &HashMap<String, Value>) -> impl Iterator<Item = &Value> {
+    additional
+        .iter()
+        .filter(|(key, _)| key.starts_with("fixed") || key.starts_with("pattern"))
+        .map(|(_, value)| value)
 }
 
 impl Default for RuleCompiler {

--- a/crates/rh-validator/src/validator.rs
+++ b/crates/rh-validator/src/validator.rs
@@ -3804,11 +3804,28 @@ fn navigate_to_array<'a>(resource: &'a Value, parts: &[&str]) -> Option<&'a Vec<
 
 fn matches_slice(
     element: &Value,
-    _slice: &crate::rules::SliceDefinition,
+    slice: &crate::rules::SliceDefinition,
     discriminators: &[crate::rules::Discriminator],
 ) -> bool {
     if discriminators.is_empty() {
         return true;
+    }
+
+    if !slice.discriminator_constraints.is_empty() {
+        return slice
+            .discriminator_constraints
+            .iter()
+            .all(|constraint| discriminator_constraint_matches(element, constraint));
+    }
+
+    if !slice.target_profiles.is_empty()
+        && discriminators
+            .iter()
+            .any(|discriminator| discriminator.type_ == "profile")
+    {
+        return slice.target_profiles.iter().any(|profile| {
+            element_matches_profile_discriminator(element, profile, discriminators)
+        });
     }
 
     discriminators
@@ -3819,11 +3836,16 @@ fn matches_slice(
             "exists" => navigate_to_discriminator_value(element, &discriminator.path).is_some(),
             "type" => navigate_to_discriminator_value(element, &discriminator.path)
                 .is_some_and(|v| v.is_object()),
+            "profile" => true,
             _ => false,
         })
 }
 
 fn navigate_to_discriminator_value<'a>(element: &'a Value, path: &str) -> Option<&'a Value> {
+    if path == "$this" {
+        return Some(element);
+    }
+
     let parts: Vec<&str> = path.split('.').collect();
     let mut current = element;
 
@@ -3835,6 +3857,98 @@ fn navigate_to_discriminator_value<'a>(element: &'a Value, path: &str) -> Option
     }
 
     Some(current)
+}
+
+fn discriminator_constraint_matches(
+    element: &Value,
+    constraint: &crate::rules::DiscriminatorConstraint,
+) -> bool {
+    if constraint.path == "$this" {
+        return value_matches_pattern(element, &constraint.value);
+    }
+
+    discriminator_values_at_path(element, &constraint.path)
+        .iter()
+        .any(|actual| value_matches_pattern(actual, &constraint.value))
+}
+
+fn discriminator_values_at_path<'a>(value: &'a Value, path: &str) -> Vec<&'a Value> {
+    if path == "$this" {
+        return vec![value];
+    }
+
+    let parts: Vec<&str> = path.split('.').collect();
+    discriminator_values_at_parts(value, &parts)
+}
+
+fn discriminator_values_at_parts<'a>(value: &'a Value, parts: &[&str]) -> Vec<&'a Value> {
+    if parts.is_empty() {
+        return vec![value];
+    }
+
+    match value {
+        Value::Array(items) => items
+            .iter()
+            .flat_map(|item| discriminator_values_at_parts(item, parts))
+            .collect(),
+        Value::Object(object) => object
+            .get(parts[0])
+            .map(|child| discriminator_values_at_parts(child, &parts[1..]))
+            .unwrap_or_default(),
+        _ => Vec::new(),
+    }
+}
+
+fn value_matches_pattern(actual: &Value, expected: &Value) -> bool {
+    match (actual, expected) {
+        (Value::Object(actual_obj), Value::Object(expected_obj)) => {
+            expected_obj.iter().all(|(key, expected_value)| {
+                actual_obj
+                    .get(key)
+                    .is_some_and(|actual_value| value_matches_pattern(actual_value, expected_value))
+            })
+        }
+        (Value::Array(actual_items), Value::Array(expected_items)) => {
+            expected_items.iter().all(|expected_item| {
+                actual_items
+                    .iter()
+                    .any(|actual_item| value_matches_pattern(actual_item, expected_item))
+            })
+        }
+        _ => actual == expected,
+    }
+}
+
+fn element_matches_profile_discriminator(
+    element: &Value,
+    target_profile: &str,
+    discriminators: &[crate::rules::Discriminator],
+) -> bool {
+    discriminators
+        .iter()
+        .filter(|discriminator| discriminator.type_ == "profile")
+        .flat_map(|discriminator| discriminator_values_at_path(element, &discriminator.path))
+        .any(|candidate| resource_declares_profile(candidate, target_profile))
+}
+
+fn resource_declares_profile(candidate: &Value, target_profile: &str) -> bool {
+    candidate
+        .get("meta")
+        .and_then(|meta| meta.get("profile"))
+        .and_then(|profile| profile.as_array())
+        .is_some_and(|profiles| {
+            profiles
+                .iter()
+                .filter_map(|profile| profile.as_str())
+                .any(|profile| {
+                    canonical_url_without_version(profile)
+                        == canonical_url_without_version(target_profile)
+                })
+        })
+}
+
+fn canonical_url_without_version(url: &str) -> &str {
+    url.split('|').next().unwrap_or(url)
 }
 
 /// Information about a collected extension

--- a/crates/rh-validator/tests/slicing_test.rs
+++ b/crates/rh-validator/tests/slicing_test.rs
@@ -1,4 +1,4 @@
-use rh_validator::{FhirValidator, Severity};
+use rh_validator::{FhirValidator, FhirVersion, Severity};
 use serde_json::json;
 
 fn setup_validator_with_us_core() -> Option<FhirValidator> {
@@ -552,5 +552,211 @@ fn test_slicing_validation_basic() {
     assert!(
         actual_errors.is_empty(),
         "Expected no slicing errors, but got: {actual_errors:#?}"
+    );
+}
+
+#[test]
+fn test_versioned_profile_url_resolves_unversioned_registered_profile() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).expect("validator should initialize");
+
+    validator.register_profile(&json!({
+        "resourceType": "StructureDefinition",
+        "url": "http://example.org/fhir/StructureDefinition/versioned-observation",
+        "name": "VersionedObservation",
+        "type": "Observation",
+        "snapshot": {
+            "element": [
+                {"id": "Observation", "path": "Observation", "min": 0, "max": "*"},
+                {"id": "Observation.status", "path": "Observation.status", "min": 1, "max": "1"}
+            ]
+        }
+    }));
+
+    let observation = json!({
+        "resourceType": "Observation"
+    });
+
+    let result = validator
+        .validate_with_profile(
+            &observation,
+            "http://example.org/fhir/StructureDefinition/versioned-observation|1.0.0",
+        )
+        .expect("validation should run");
+
+    assert!(
+        result
+            .issues
+            .iter()
+            .any(|issue| issue.message.contains("Observation.status")),
+        "versioned profile URL should resolve and apply profile rules: {:?}",
+        result.issues
+    );
+    assert!(
+        result
+            .issues
+            .iter()
+            .all(|issue| !issue.message.contains("could not be found")),
+        "versioned profile URL should not produce profile-not-found warning: {:?}",
+        result.issues
+    );
+}
+
+#[test]
+fn test_closed_value_slicing_uses_slice_patterns() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).expect("validator should initialize");
+
+    validator.register_profile(&json!({
+        "resourceType": "StructureDefinition",
+        "url": "http://example.org/fhir/StructureDefinition/sliced-observation",
+        "name": "SlicedObservation",
+        "type": "Observation",
+        "snapshot": {
+            "element": [
+                {"id": "Observation", "path": "Observation", "min": 0, "max": "*"},
+                {
+                    "id": "Observation.component",
+                    "path": "Observation.component",
+                    "min": 0,
+                    "max": "*",
+                    "slicing": {
+                        "discriminator": [{"type": "value", "path": "code"}],
+                        "rules": "closed"
+                    }
+                },
+                {
+                    "id": "Observation.component:a",
+                    "path": "Observation.component",
+                    "sliceName": "a",
+                    "min": 1,
+                    "max": "1"
+                },
+                {
+                    "id": "Observation.component:a.code",
+                    "path": "Observation.component.code",
+                    "sliceName": "a",
+                    "patternCodeableConcept": {
+                        "coding": [{"system": "http://example.org/codes", "code": "a"}]
+                    }
+                },
+                {
+                    "id": "Observation.component:b",
+                    "path": "Observation.component",
+                    "sliceName": "b",
+                    "min": 1,
+                    "max": "1"
+                },
+                {
+                    "id": "Observation.component:b.code",
+                    "path": "Observation.component.code",
+                    "sliceName": "b",
+                    "patternCodeableConcept": {
+                        "coding": [{"system": "http://example.org/codes", "code": "b"}]
+                    }
+                }
+            ]
+        }
+    }));
+
+    let observation = json!({
+        "resourceType": "Observation",
+        "component": [
+            {"code": {"coding": [{"system": "http://example.org/codes", "code": "a"}]}},
+            {"code": {"coding": [{"system": "http://example.org/codes", "code": "b"}]}}
+        ]
+    });
+
+    let result = validator
+        .validate_with_profile(
+            &observation,
+            "http://example.org/fhir/StructureDefinition/sliced-observation",
+        )
+        .expect("validation should run");
+
+    let slicing_errors: Vec<_> = result
+        .issues
+        .iter()
+        .filter(|issue| issue.severity == Severity::Error)
+        .filter(|issue| issue.message.contains("Slice"))
+        .collect();
+
+    assert!(
+        slicing_errors.is_empty(),
+        "components should match distinct slices by pattern: {slicing_errors:?}"
+    );
+}
+
+#[test]
+fn test_closed_profile_slicing_accepts_declared_meta_profile_with_version() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).expect("validator should initialize");
+
+    validator.register_profile(&json!({
+        "resourceType": "StructureDefinition",
+        "url": "http://example.org/fhir/StructureDefinition/sliced-bundle",
+        "name": "SlicedBundle",
+        "type": "Bundle",
+        "snapshot": {
+            "element": [
+                {"id": "Bundle", "path": "Bundle", "min": 0, "max": "*"},
+                {
+                    "id": "Bundle.entry",
+                    "path": "Bundle.entry",
+                    "min": 0,
+                    "max": "*",
+                    "slicing": {
+                        "discriminator": [{"type": "profile", "path": "resource"}],
+                        "rules": "closed"
+                    }
+                },
+                {
+                    "id": "Bundle.entry:patient",
+                    "path": "Bundle.entry",
+                    "sliceName": "patient",
+                    "min": 1,
+                    "max": "1"
+                },
+                {
+                    "id": "Bundle.entry:patient.resource",
+                    "path": "Bundle.entry.resource",
+                    "sliceName": "patient",
+                    "min": 1,
+                    "max": "1",
+                    "type": [{
+                        "code": "Resource",
+                        "targetProfile": ["http://example.org/fhir/StructureDefinition/patient-profile|2.0.0"]
+                    }]
+                }
+            ]
+        }
+    }));
+
+    let bundle = json!({
+        "resourceType": "Bundle",
+        "entry": [{
+            "resource": {
+                "resourceType": "Patient",
+                "meta": {
+                    "profile": ["http://example.org/fhir/StructureDefinition/patient-profile|2.1.0"]
+                }
+            }
+        }]
+    });
+
+    let result = validator
+        .validate_with_profile(
+            &bundle,
+            "http://example.org/fhir/StructureDefinition/sliced-bundle",
+        )
+        .expect("validation should run");
+
+    let closed_slicing_errors: Vec<_> = result
+        .issues
+        .iter()
+        .filter(|issue| issue.severity == Severity::Error)
+        .filter(|issue| issue.message.contains("does not match any slice"))
+        .collect();
+
+    assert!(
+        closed_slicing_errors.is_empty(),
+        "profile discriminator should match declared meta.profile ignoring canonical versions: {closed_slicing_errors:?}"
     );
 }


### PR DESCRIPTION
## Summary
- preserve fixed/pattern and targetProfile snapshot metadata used by validator slicing
- normalize versioned canonical profile URLs for registry lookup
- improve value/profile discriminator matching to reduce closed-slicing false positives

## Verification
- cargo fmt
- cargo test -p rh-validator --test slicing_test
- cargo check -p rh-foundation -p rh-validator -p rh-codegen
- cargo test -p rh-validator