### PR TITLE
[codex] Consolidate CQL compile/validate CLI duplication

### DIFF
--- a/apps/rh-cli/docs/CQL.md
+++ b/apps/rh-cli/docs/CQL.md
@@ -21,15 +21,19 @@ rh cql compile [OPTIONS] <FILE>
 - `<FILE>` - Path to a CQL file, or `-` to read from stdin
 
 **Options:**
+- `--format <FORMAT>` - Output format: `human` (default), `json`, or `ndjson`
 - `-o, --output <OUTPUT>` - Output file path (defaults to stdout)
 - `--compact` - Output compact JSON (no pretty-printing)
 - `--debug` - Enable debug mode (includes annotations, locators, and result types in output)
 - `--result-types` - Include result type metadata in output
 - `--strict` - Enable strict mode (disable implicit conversions)
 - `--signatures` - Include all signatures in output
+- `--lib-path <DIR>` - Additional directory to search for included CQL libraries; may be specified multiple times
 - `--source-map` - Also emit a source-map sidecar file alongside the ELM output
 - `--source-map-output <PATH>` - Path for source-map output (defaults to `<output>.sourcemap.json` or stderr)
-- `-v, --verbose` - Enable verbose logging
+- `-q, --quiet` - Suppress informational output on stderr
+- `-v, --verbose...` - Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace)
+- `--color <WHEN>` - Color output policy: `auto` (default), `always`, or `never`
 - `-h, --help` - Print help
 
 **Examples:**
@@ -144,6 +148,28 @@ Output:
 }
 ```
 
+Compile with included libraries from another directory:
+
+```bash
+# Compile with an additional include search path
+rh cql compile measure.cql --lib-path cql/includes
+```
+
+Output:
+
+```json
+{
+  "library": {
+    "identifier": {
+      "id": "Measure",
+      "version": "1.0.0"
+    },
+    "includes": { "...": "..." },
+    "statements": { "...": "..." }
+  }
+}
+```
+
 Emit compact JSON with a source map:
 
 ```bash
@@ -187,14 +213,19 @@ Validate CQL source without generating ELM output.
 
 **Usage:**
 ```bash
-rh cql validate [OPTIONS] <FILE>
+rh cql validate [OPTIONS] [FILE]...
 ```
 
 **Arguments:**
-- `<FILE>` - Path to a CQL file, or `-` to read from stdin
+- `[FILE]...` - Path(s) to CQL file(s) or glob pattern(s), or `-` to read from stdin
 
 **Options:**
-- `-v, --verbose` - Enable verbose logging
+- `--format <FORMAT>` - Output format: `human` (default), `json`, or `ndjson`
+- `--lib-path <DIR>` - Additional directory to search for included CQL libraries; may be specified multiple times
+- `--details` - Show detailed error information, including locations and annotations
+- `-q, --quiet` - Suppress informational output on stderr
+- `-v, --verbose...` - Increase verbosity (`-v` info, `-vv` debug, `-vvv` trace)
+- `--color <WHEN>` - Color output policy: `auto` (default), `always`, or `never`
 - `-h, --help` - Print help
 
 **Examples:**
@@ -210,6 +241,64 @@ Output:
 
 ```text
 ✓ CQL is valid
+```
+
+Validate multiple CQL files:
+
+```bash
+# Validate every CQL file under measures/
+rh cql validate 'measures/**/*.cql'
+```
+
+Output:
+
+```text
+[measures/diabetes.cql]
+✓ CQL is valid
+
+[measures/hypertension.cql]
+✓ CQL is valid
+```
+
+Validate with detailed diagnostics:
+
+```bash
+# Include source locations for validation diagnostics
+rh cql validate library.cql --details
+```
+
+Output:
+
+```text
+✗ CQL has errors
+
+Errors (1):
+  ✗ Undefined symbol: MissingExpression (line 8, col 12)
+```
+
+Validate with a JSON envelope for automation:
+
+```bash
+# Emit the standard rh JSON envelope
+rh cql validate library.cql --format json
+```
+
+Output:
+
+```json
+{
+  "ok": true,
+  "result": [
+    {
+      "file": "library.cql",
+      "valid": true,
+      "errors": [],
+      "warnings": []
+    }
+  ],
+  "errors": [],
+  "meta": { "...": "..." }
+}
 ```
 
 Validate from stdin:

--- a/apps/rh-cli/src/cql.rs
+++ b/apps/rh-cli/src/cql.rs
@@ -21,9 +21,10 @@ use rh_cql::options::CompilerOption;
 use rh_cql::{
     compile, compile_to_elm_with_sourcemap_and_libraries, compile_with_libraries,
     elm::AccessModifier, evaluate_elm_with_libraries, evaluate_elm_with_trace, explain_compile,
-    explain_parse, get_default_packages_dir, CompilationError, CompilerOptions, CqlDateTime,
-    Diagnostic, EvalContextBuilder, EvalError, FileLibrarySourceProvider, FixedClock,
-    InMemoryDataProvider, PackageLibrarySourceProvider, SignatureLevel, Value,
+    explain_parse, get_default_packages_dir, CompilationError, CompilationResult, CompilerOptions,
+    CqlDateTime, Diagnostic, EvalContextBuilder, EvalError, FileLibrarySourceProvider, FixedClock,
+    InMemoryDataProvider, PackageLibrarySourceProvider, SignatureLevel, SourceMapCompilationResult,
+    Value,
 };
 
 #[derive(Serialize)]
@@ -398,16 +399,18 @@ pub async fn handle_command(cmd: CqlCommands, ctx: &OutputContext) -> Result<()>
             source_map_output,
         } => {
             compile_cql(
-                &input,
-                output.as_deref(),
-                compact,
-                debug,
-                strict,
-                result_types,
-                signatures,
-                &lib_path,
-                source_map,
-                source_map_output.as_deref(),
+                &CompileRequest {
+                    input,
+                    output,
+                    compact,
+                    debug,
+                    strict,
+                    result_types,
+                    signatures,
+                    lib_path,
+                    source_map,
+                    source_map_output,
+                },
                 ctx,
             )?;
         }
@@ -698,130 +701,174 @@ fn read_source(input: &str) -> Result<String> {
 // Compile service
 // ---------------------------------------------------------------------------
 
-/// Compile CQL source to ELM JSON
-#[allow(clippy::too_many_arguments)]
-fn compile_cql(
-    input: &str,
-    output: Option<&Path>,
+/// Parsed flags for `cql compile`, grouped to keep [`compile_cql`] focused on
+/// orchestration rather than a long parameter list.
+struct CompileRequest {
+    input: String,
+    output: Option<PathBuf>,
     compact: bool,
     debug: bool,
     strict: bool,
     result_types: bool,
     signatures: bool,
-    lib_paths: &[PathBuf],
-    emit_source_map: bool,
-    source_map_output: Option<&Path>,
-    ctx: &OutputContext,
-) -> Result<()> {
-    let source = read_source(input)?;
+    lib_path: Vec<PathBuf>,
+    source_map: bool,
+    source_map_output: Option<PathBuf>,
+}
 
-    // Build options
-    let options = if debug {
-        let mut opts = CompilerOptions::debug();
-        if signatures {
-            opts = opts.with_signature_level(SignatureLevel::All);
-        }
-        opts
+/// Read-only access to the ELM-serializable portion of a compilation outcome.
+///
+/// Implemented for both [`CompilationResult`] and [`SourceMapCompilationResult`]
+/// so the compile pipeline can serialize either through a single code path.
+trait ElmOutcome {
+    fn errors(&self) -> &[Diagnostic];
+    fn warnings(&self) -> &[Diagnostic];
+    fn to_json(&self) -> std::result::Result<String, CompilationError>;
+    fn to_compact_json(&self) -> std::result::Result<String, CompilationError>;
+}
+
+impl ElmOutcome for CompilationResult {
+    fn errors(&self) -> &[Diagnostic] {
+        &self.errors
+    }
+    fn warnings(&self) -> &[Diagnostic] {
+        &self.warnings
+    }
+    fn to_json(&self) -> std::result::Result<String, CompilationError> {
+        CompilationResult::to_json(self)
+    }
+    fn to_compact_json(&self) -> std::result::Result<String, CompilationError> {
+        CompilationResult::to_compact_json(self)
+    }
+}
+
+impl ElmOutcome for SourceMapCompilationResult {
+    fn errors(&self) -> &[Diagnostic] {
+        &self.errors
+    }
+    fn warnings(&self) -> &[Diagnostic] {
+        &self.warnings
+    }
+    fn to_json(&self) -> std::result::Result<String, CompilationError> {
+        SourceMapCompilationResult::to_json(self)
+    }
+    fn to_compact_json(&self) -> std::result::Result<String, CompilationError> {
+        SourceMapCompilationResult::to_compact_json(self)
+    }
+}
+
+/// Resolve the [`CompilerOptions`] for a `cql compile` run from its flags.
+///
+/// `debug` mode already enables result types, so `--result-types` is only
+/// honored outside of debug mode to match the previous per-branch behavior.
+fn build_compiler_options(
+    debug: bool,
+    strict: bool,
+    result_types: bool,
+    signatures: bool,
+) -> CompilerOptions {
+    let mut opts = if debug {
+        CompilerOptions::debug()
     } else if strict {
-        let mut opts = CompilerOptions::strict();
-        if result_types {
-            opts = opts.with_option(CompilerOption::EnableResultTypes);
-        }
-        if signatures {
-            opts = opts.with_signature_level(SignatureLevel::All);
-        }
-        opts
+        CompilerOptions::strict()
     } else {
-        let mut opts = CompilerOptions::default();
-        if result_types {
-            opts = opts.with_option(CompilerOption::EnableResultTypes);
-        }
-        if signatures {
-            opts = opts.with_signature_level(SignatureLevel::All);
-        }
-        opts
+        CompilerOptions::default()
     };
+    if result_types && !debug {
+        opts = opts.with_option(CompilerOption::EnableResultTypes);
+    }
+    if signatures {
+        opts = opts.with_signature_level(SignatureLevel::All);
+    }
+    opts
+}
+
+/// Print a fatal pipeline error to stderr and exit with the parse-error code.
+fn exit_on_compile_error(e: impl std::fmt::Display) -> ! {
+    eprintln!("✗ {e}");
+    ExitCode::ParseError.exit();
+}
+
+/// Report a failed (non-success) compilation outcome and exit.
+fn exit_on_compile_failure(outcome: &impl ElmOutcome) -> ! {
+    let err = report_compile_failure(outcome.errors(), outcome.warnings());
+    error!("{err}");
+    ExitCode::ParseError.exit();
+}
+
+/// Serialize an ELM outcome to JSON, honoring compact mode.
+fn serialize_elm(outcome: &impl ElmOutcome, compact: bool) -> Result<String> {
+    let json = if compact {
+        outcome.to_compact_json()
+    } else {
+        outcome.to_json()
+    }
+    .context("Failed to serialize ELM to JSON")?;
+    Ok(json)
+}
+
+/// Compile CQL source to ELM JSON
+fn compile_cql(req: &CompileRequest, ctx: &OutputContext) -> Result<()> {
+    let source = read_source(&req.input)?;
+    let options = build_compiler_options(req.debug, req.strict, req.result_types, req.signatures);
 
     // Run the pipeline once. Source-map compilation still uses the
     // library-aware path so `--lib-path` and package-cache includes behave the
     // same as ordinary ELM compilation.
-    let (json, sm_json_opt) = if emit_source_map {
+    let (json, sm_json_opt) = if req.source_map {
         let result = match compile_with_search_dirs_and_sourcemap(
             &source,
-            input,
-            lib_paths,
+            &req.input,
+            &req.lib_path,
             Some(options),
             None,
         ) {
             Ok(r) => r,
-            Err(e) => {
-                eprintln!("✗ {e}");
-                ExitCode::ParseError.exit();
-            }
+            Err(e) => exit_on_compile_error(e),
         };
-
         if !result.is_success() {
-            let err = report_compile_failure(&result.errors, &result.warnings);
-            error!("{err}");
-            ExitCode::ParseError.exit();
+            exit_on_compile_failure(&result);
         }
-
-        let json = if compact {
-            result.to_compact_json()
-        } else {
-            result.to_json()
-        }
-        .context("Failed to serialize ELM to JSON")?;
+        let json = serialize_elm(&result, req.compact)?;
         let sm_json = result
             .source_map_json()
             .context("Failed to serialize source map")?;
         (json, Some(sm_json))
     } else {
-        let result = match compile_with_search_dirs(&source, input, lib_paths, Some(options)) {
-            Ok(r) => r,
-            Err(e) => {
-                eprintln!("✗ {e}");
-                ExitCode::ParseError.exit();
+        let result =
+            match compile_with_search_dirs(&source, &req.input, &req.lib_path, Some(options)) {
+                Ok(r) => r,
+                Err(e) => exit_on_compile_error(e),
             }
-        }
-        .result;
-
+            .result;
         if !result.is_success() {
-            let err = report_compile_failure(&result.errors, &result.warnings);
-            error!("{err}");
-            ExitCode::ParseError.exit();
+            exit_on_compile_failure(&result);
         }
-
-        let json = if compact {
-            result.to_compact_json()
-        } else {
-            result.to_json()
-        }
-        .context("Failed to serialize ELM to JSON")?;
+        let json = serialize_elm(&result, req.compact)?;
         (json, None)
     };
 
     // Write ELM output
-    if let Some(path) = output {
+    if let Some(path) = req.output.as_deref() {
         fs::write(path, &json).with_context(|| format!("Failed to write to {}", path.display()))?;
         info!("✓ Compiled to {}", path.display());
     }
     if ctx.is_json() {
         let elm_value = serde_json::from_str::<serde_json::Value>(&json)?;
         print_envelope(ctx, &Envelope::ok(elm_value, "cql compile"))?;
-    } else if output.is_none() {
+    } else if req.output.is_none() {
         println!("{json}");
     }
 
     // Write source-map output (only present when --source-map was requested)
     if let Some(sm_json) = sm_json_opt {
-        match source_map_output {
+        match req.source_map_output.as_deref() {
             Some(path) => {
                 fs::write(path, &sm_json)
                     .with_context(|| format!("Failed to write source map to {}", path.display()))?;
                 info!("✓ Source map written to {}", path.display());
             }
-            None => match output {
+            None => match req.output.as_deref() {
                 Some(elm_path) => {
                     let sm_path = format!("{}.sourcemap.json", elm_path.display());
                     fs::write(&sm_path, &sm_json)
@@ -1751,6 +1798,18 @@ fn add_fhir_resource(provider: &mut InMemoryDataProvider, resource: serde_json::
     }
 }
 
+/// Print validation warnings to stdout. Each warning is annotated with its
+/// source location only when `verbose` is true.
+fn print_validation_warnings(warnings: &[Diagnostic], verbose: bool) {
+    if warnings.is_empty() {
+        return;
+    }
+    println!("\nWarnings ({}):", warnings.len());
+    for warning in warnings {
+        println!("  ⚠ {}", format_diagnostic_message(warning, verbose));
+    }
+}
+
 /// Validate CQL source
 fn validate_cql(input: &str, lib_paths: &[PathBuf], verbose: bool) -> Result<()> {
     let source = read_source(input)?;
@@ -1762,52 +1821,16 @@ fn validate_cql(input: &str, lib_paths: &[PathBuf], verbose: bool) -> Result<()>
 
     if valid {
         println!("✓ CQL is valid");
-
-        if !warnings.is_empty() {
-            println!("\nWarnings ({}):", warnings.len());
-            for warning in &warnings {
-                if verbose {
-                    if let Some(span) = &warning.span {
-                        println!(
-                            "  ⚠ {} (line {}, col {})",
-                            warning.message, span.start.line, span.start.column
-                        );
-                        continue;
-                    }
-                }
-                println!("  ⚠ {}", warning.message);
-            }
-        }
+        print_validation_warnings(&warnings, verbose);
     } else {
         println!("✗ CQL has errors\n");
 
         println!("Errors ({}):", errors.len());
         for err in &errors {
-            if let Some(span) = &err.span {
-                println!(
-                    "  ✗ {} (line {}, col {})",
-                    err.message, span.start.line, span.start.column
-                );
-            } else {
-                println!("  ✗ {}", err.message);
-            }
+            println!("  ✗ {}", format_diagnostic_message(err, true));
         }
 
-        if !warnings.is_empty() {
-            println!("\nWarnings ({}):", warnings.len());
-            for warning in &warnings {
-                if verbose {
-                    if let Some(span) = &warning.span {
-                        println!(
-                            "  ⚠ {} (line {}, col {})",
-                            warning.message, span.start.line, span.start.column
-                        );
-                        continue;
-                    }
-                }
-                println!("  ⚠ {}", warning.message);
-            }
-        }
+        print_validation_warnings(&warnings, verbose);
 
         anyhow::bail!("CQL validation failed");
     }

--- a/docs/cql-elm-result-types-report.md
+++ b/docs/cql-elm-result-types-report.md
@@ -130,9 +130,9 @@ For functions with a body, derive metadata from `body.data_type`. If a function 
 
 Function parameters already carry parser-level type specifiers. `OperandDef` should emit `operandTypeName` for named parameter types and `operandTypeSpecifier` for structural parameter types. This is adjacent to result types, but downstream ELM inspection usually expects both return and operand typing.
 
-5. Consider an explicit CLI flag
+5. Keep the explicit CLI flag documented
 
-`--debug` currently enables result types. For reference parity, add `rh cql compile --result-types` as an independent flag, while keeping `--debug` behavior unchanged.
+`--debug` currently enables result types. For reference parity, `rh cql compile --result-types` is also available as an independent flag, while `--debug` behavior remains unchanged.
 
 ## Test Plan
 
@@ -145,7 +145,7 @@ Add focused tests before touching broad golden files:
 - Property/member access returning `FHIR.Reference` emits `resultTypeName` for the named `FHIR.Reference` result.
 - Tuple expression emits `TupleTypeSpecifier` with per-element type specifiers.
 - Function return and operand definitions emit the same named-vs-structural split.
-- `rh cql compile --result-types` works independently of `--debug` if that flag is added.
+- `rh cql compile --result-types` works independently of `--debug`.
 
 Then add a Java reference comparison fixture that compiles with `EnableResultTypes` and checks metadata shape rather than exact local IDs or locator placement.
 
@@ -163,7 +163,7 @@ Then add a Java reference comparison fixture that compiles with `EnableResultTyp
 2. Unit-test the conversion layer directly for system, model, list, interval, tuple, choice, and type parameter cases.
 3. Wire `ElmEmitter::element_fields()` to use the conversion layer.
 4. Wire `ExpressionDef`, `FunctionDef`, and `OperandDef`.
-5. Add CLI `--result-types` and docs if independent control is desired.
+5. Keep the CLI `--result-types` documentation and tests in sync with emitter behavior.
 6. Add one or two Java reference fixtures for structural result type parity.
 
 ## Recommendation


### PR DESCRIPTION
## Summary

This PR refactors the CQL CLI compile/validate flow without changing user-facing behavior.

Changes:
- Groups `rh cql compile` options into a `CompileRequest` so `compile_cql` no longer carries an 11-argument signature.
- Centralizes compiler option construction for debug, strict, `--result-types`, and `--signatures` handling.
- Shares ELM serialization and compile-failure handling across normal compilation and source-map compilation.
- Reuses common validation diagnostic formatting and removes duplicated warning-printing logic from `rh cql validate`.

## Goals Achieved

- Reduced CQL CLI orchestration duplication in `apps/rh-cli/src/cql.rs`.
- Removed the `clippy::too_many_arguments` allowance from the compile path by introducing a small request object.
- Preserved the existing compile/source-map/validate behavior while making the control flow easier to maintain.
- Kept the change scoped to the CLI layer; the `rh-cql` compiler semantics are unchanged.

## Validation

- `cargo test -p rh-cli --test cql_integration_test`
