### PR TITLE
Organize rh-cql architecture and CQL WASM helpers

### DIFF
--- a/apps/rh-cli/README.md
+++ b/apps/rh-cli/README.md
@@ -94,6 +94,11 @@ rh validate resource --input patient.json --report-format operationoutcome
 # Compile CQL to ELM
 rh cql compile library.cql --output library.elm.json
 
+# Generate SQL-on-FHIR artifacts from CQL retrieves
+rh cql lower-check measure.cql
+rh cql emit-views measure.cql --out views/
+rh cql emit-sql measure.cql --views views/ --out query-library.json
+
 # Compile FSH to FHIR JSON
 rh fsh compile profiles/*.fsh --output output/
 
@@ -153,6 +158,25 @@ Options (build/pack):
 ```
 
 See [docs/PACKAGER.md](docs/PACKAGER.md) for the full documentation including the step-by-step guide and `packager.toml` configuration reference.
+
+### `rh cql` SQL-on-FHIR helpers
+
+`rh cql` can inspect compiled ELM and emit first-pass SQL-on-FHIR artifacts for
+retrieve-centric measure logic:
+
+```
+rh cql data-requirements measure.cql
+rh cql plan measure.cql --target sql-on-fhir
+rh cql lower-check measure.cql
+rh cql emit-views measure.cql --out views/
+rh cql emit-sql measure.cql --views views/ --out query-library.json
+rh cql emit-runtime measure.cql --query query-library.json --views views/
+```
+
+The lowerer emits deterministic ViewDefinition JSON, SQLQuery Library resources,
+and runtime manifests for supported retrieve patterns. It is intentionally
+reported as a first-pass lowerer; full CQL semantics may still require fallback
+evaluation.
 
 ### `rh validate` subcommands
 

--- a/apps/rh-cli/docs/CQL.md
+++ b/apps/rh-cli/docs/CQL.md
@@ -4,6 +4,12 @@
 
 The `rh cql` command provides tools for working with CQL (Clinical Quality Language), compiling CQL source files to ELM (Expression Logical Model) JSON, evaluating expressions, and inspecting compilation details.
 
+It also includes first-pass SQL-on-FHIR helpers for retrieve-centric measure
+logic: `data-requirements`, `plan`, `lower-check`, `emit-views`, `emit-sql`,
+and `emit-runtime`. These commands expose what a CQL library needs, whether its
+ELM nodes are supported by the current relational lowerer, and the generated
+ViewDefinition, SQLQuery Library, and runtime manifest artifacts.
+
 See the [CQL crate README](../../../crates/rh-cql/README.md) for library-level documentation.
 
 ## Commands

--- a/crates/rh-cql/ARCHITECTURE.md
+++ b/crates/rh-cql/ARCHITECTURE.md
@@ -1,380 +1,346 @@
 # rh-cql Architecture
 
-This document describes the current architecture of `rh-cql`: the CQL compiler,
-ELM model, evaluator, and analytics artifact tooling used by `rh`.
+`rh-cql` is the CQL engine crate in `rh`. It parses Clinical Quality Language
+(CQL), resolves it against model information, emits HL7 Expression Logical Model
+(ELM), and provides a native ELM evaluator for local execution and conformance
+work.
 
-## Overview
+The stable center of the crate is the CQL-to-ELM engine. Experimental analytics
+and SQL-on-FHIR artifact generation live at the bottom of this document because
+they are downstream consumers of ELM, not the core execution architecture.
 
-`rh-cql` has two related responsibilities:
+## Responsibilities
 
-1. Compile Clinical Quality Language (CQL) source into HL7 Expression Logical
-   Model (ELM).
-2. Expose inspectable analysis and artifact boundaries for downstream analytics
-   runtimes.
+`rh-cql` owns these boundaries:
 
-The core compiler pipeline is:
+- CQL parsing into a syntax-preserving parser AST.
+- Semantic analysis into a typed AST with resolved symbols, scopes, types,
+  operators, conversions, retrieves, and diagnostics.
+- ELM emission into serializable HL7 ELM Rust structs and JSON.
+- Optional CQL-to-ELM source maps.
+- Native ELM evaluation for local execution, test fixtures, debugging, and
+  conformance comparison.
+- Inspectable helper artifacts derived from ELM.
 
-```text
-CQL source
-  -> parser AST
-  -> semantic analysis / typed AST
-  -> ELM library
-  -> optional source map
-```
+The crate does not own a production analytics runtime. Production execution over
+large FHIR stores, warehouses, lakehouses, DataFusion, Spark, DuckDB, Trino,
+Postgres, or managed terminology services is an environment-specific concern.
 
-The analytics pipeline starts from the emitted ELM library:
+## Engine Overview
 
-```text
-ELM library
-  -> inspection and data requirements
-  -> relational algebra plan
-  -> lowering support report
-  -> SQL-on-FHIR ViewDefinition artifacts
-  -> SQLQuery Library artifact or SQL text
-  -> ReasonHealthMeasureRuntime manifest
-```
-
-`rh` owns the compiler and artifact producer boundary. Runtime execution over
-FHIR data, Arrow, DataFusion, and measure comparison belongs outside this crate
-in the analytics runtime.
+The main engine is intentionally staged:
 
 ```mermaid
 flowchart LR
-    cql["CQL source"] --> ast["Parser AST"]
-    ast --> typed["Semantic typed AST"]
-    typed --> elm["ELM library"]
-
-    elm --> eval["Native ELM evaluator"]
-    eval --> dev["Artifact development\ntraces, debugging, comparison"]
-
-    elm --> inspect["Inspection + data requirements"]
-    inspect --> rel["Relational algebra IR"]
-    rel --> lower["Lowering support report"]
-    rel --> views["SQL-on-FHIR\nViewDefinitions"]
-    rel --> sql["SQLQuery Library\nor SQL text"]
-    views --> manifest["Measure runtime manifest"]
-    sql --> manifest
-    manifest --> runtime["Commercial / environment-specific\nanalytics runtime"]
-
-    classDef compiler fill:#e8f2ff,stroke:#4b77be,color:#111;
-    classDef dev fill:#f4f4f4,stroke:#777,color:#111;
-    classDef artifact fill:#eaf7ea,stroke:#3f8f46,color:#111;
-    classDef runtime fill:#fff3d6,stroke:#b7791f,color:#111;
-    class cql,ast,typed,elm compiler;
-    class eval,dev dev;
-    class inspect,rel,lower,views,sql,manifest artifact;
-    class runtime runtime;
+    source["CQL source"] --> parser["Parser\nparser/*"]
+    parser --> ast["parser::ast::Library"]
+    ast --> semantics["SemanticAnalyzer\nsemantics/*"]
+    semantics --> typed["TypedLibrary\nTypedNode metadata"]
+    typed --> emitter["ElmEmitter\nemit/*"]
+    emitter --> elm["elm::Library"]
+    elm --> json["ELM JSON\noutput.rs"]
+    elm --> evaluator["Native ELM evaluator\neval/*"]
+    emitter --> sourcemap["SourceMap\noptional"]
 ```
 
-## Motivation
-
-`rh-cql` deliberately separates artifact development from production execution.
-
-The native ELM evaluator exists to support compiler and artifact development.
-It lets us execute CQL/ELM locally, inspect behavior, compare expected results,
-debug source maps and traces, and validate that emitted artifacts preserve the
-clinical intent of a CQL library. That evaluator is valuable engineering
-infrastructure, but it is not the intended production analytics runtime.
-
-The SQL and SQL-on-FHIR tooling is aimed at real-world production execution.
-Production deployments need to run over large FHIR datasets, integrate with
-warehouse/lakehouse/storage choices, use local governance and security models,
-and tune execution for environment-specific cost and performance constraints.
-Those choices are vendor- and environment-specific.
-
-For that reason, open-source `rh` stops at stable, inspectable artifacts:
-
-```text
-CQL / ELM -> relational IR -> ViewDefinition + SQLQuery + runtime manifest
-```
-
-It does not prescribe or embed the production execution engine. Commercially
-supported products can take those artifacts and provide the environment-specific
-runtime: DataFusion, Spark, DuckDB, Trino, Postgres, cloud warehouses, managed
-terminology services, operational monitoring, validation harnesses, and support
-contracts.
-
-This gives users a portable compiler boundary while leaving production runtime
-decisions where they belong: in the deployment environment and supported
-commercial product layer.
-
-```mermaid
-flowchart TB
-    subgraph open["Open-source rh"]
-    cql2["CQL / ELM"]
-    evaluator["Native ELM evaluator"]
-    artifacts["Stable artifacts\nrelational IR, ViewDefinition, SQLQuery, manifest"]
-    cql2 --> evaluator
-    cql2 --> artifacts
-    end
-
-    evaluator --> dev2["Compiler and artifact development\nlocal execution, traces, expected-result checks"]
-    artifacts --> product["Commercially supported runtime products"]
-
-    subgraph env["Deployment environment"]
-    product --> backend["Selected execution backend\nDataFusion, Spark, DuckDB, Trino,\nPostgres, cloud warehouse"]
-    product --> services["Environment-specific services\nterminology, governance, monitoring, support"]
-    end
-
-    classDef open fill:#e8f2ff,stroke:#4b77be,color:#111;
-    classDef artifact fill:#eaf7ea,stroke:#3f8f46,color:#111;
-    classDef runtime fill:#fff3d6,stroke:#b7791f,color:#111;
-    class cql2,evaluator open;
-    class artifacts artifact;
-    class product,backend,services runtime;
-```
+The important architecture choice is that CQL is not translated directly from
+parser nodes to JSON. The typed AST is an explicit middle layer. That keeps
+syntax parsing, semantic resolution, ELM shape, and runtime evaluation separate
+enough to test and evolve independently.
 
 ## Compiler Pipeline
 
-All public compile entry points in `compiler.rs` delegate to a shared internal
-`run_compile_pipeline` function.
+All public compile entry points in `compiler.rs` delegate to the shared internal
+pipeline. The pipeline can stop after validation, emit ELM, or emit ELM plus a
+source map.
 
-```text
-CQL source
-  -> Stage 1: Parser
-     parser/lexer.rs, parser/statement.rs, parser/expression/*
-     output: parser::ast::Library
-  -> Stage 2: Semantic analysis
-     semantics/analyzer.rs, semantics/scope.rs, semantics/typed_ast.rs
-     output: TypedLibrary + diagnostics
-  -> Stage 3: ELM emission
-     emit/mod.rs, emit/{clinical,conditionals,literals,operators,queries,...}
-     output: elm::Library
-  -> Optional source map and output serialization
-     sourcemap.rs, output.rs
-```
+### 1. Parse CQL
 
-The compiler can also stop after semantic analysis for validate-only and
-explain paths. That is why the shared pipeline has an explicit emit mode:
-`None`, `Elm`, or `ElmWithSourceMap`.
+The parser is a hand-written `nom` parser under `parser/`.
 
-```mermaid
-flowchart LR
-    source["CQL source"] --> parser["Parser\nparser::*"]
-    parser --> parsed["parser::ast::Library"]
-    parsed --> sem["SemanticAnalyzer\nsemantics::*"]
-    sem --> typed2["TypedLibrary\nTypedNode metadata"]
-    typed2 --> validate["validate / explain\nemit mode: None"]
-    typed2 --> emitter["ElmEmitter\nemit::*"]
-    emitter --> elm2["elm::Library"]
-    emitter --> smap["SourceMap\noptional side channel"]
-    elm2 --> json["ELM JSON\noutput.rs"]
-    smap --> smap_json["source-map JSON"]
+Input:
 
-    classDef stage fill:#e8f2ff,stroke:#4b77be,color:#111;
-    classDef artifact fill:#eaf7ea,stroke:#3f8f46,color:#111;
-    class source,parser,sem,emitter stage;
-    class parsed,typed2,validate,elm2,smap,json,smap_json artifact;
-```
+- CQL source text.
 
-## Current Public Surfaces
+Output:
 
-The library API exposes:
+- `parser::ast::Library`.
+
+The parser AST preserves source-level CQL structure: library headers, usings,
+includes, declarations, expressions, retrieves, queries, terminology references,
+and source spans. It does not resolve model members or operator overloads.
+
+### 2. Analyze Semantics
+
+Semantic analysis lives under `semantics/` with supporting type and operator
+logic in `datatype.rs`, `types.rs`, `operators.rs`, `conversion.rs`, and
+`modelinfo.rs`.
+
+Input:
+
+- `parser::ast::Library`.
+- `CompilationContext`.
+- `CompilerOptions`.
+- A `ModelInfoProvider`.
+
+Output:
+
+- `TypedLibrary`.
+- Diagnostics.
+
+This stage resolves:
+
+- library and definition scopes;
+- expression references, function references, parameters, codes, value sets,
+  and code systems;
+- model types, members, choice types, and retrieve data types;
+- CQL operator overloads and result types;
+- implicit conversions allowed by the selected options;
+- source spans and node ids carried on `TypedNode<T>`.
+
+The default model boundary is FHIR R4, but callers can supply a different
+`ModelInfoProvider` through `CompilationContext` or `compile_with_model`. The
+parser does not contain FHIR-specific knowledge.
+
+### 3. Emit ELM
+
+ELM emission lives under `emit/`.
+
+Input:
+
+- `TypedLibrary`.
+
+Output:
+
+- `elm::Library`.
+- Optional `SourceMap`.
+
+The emitter converts typed CQL constructs into ELM structs. Because overloads,
+types, scopes, and retrieve metadata are already resolved, emission is mostly a
+structural lowering step rather than a second semantic pass.
+
+`output.rs` serializes the ELM model to JSON. The JSON boundary is used by the
+CLI, tests, downstream tools, and interop checks against other CQL engines.
+
+### 4. Validate, Explain, and Serialize
+
+The same staged pipeline supports multiple public surfaces:
 
 - `compile`, `compile_with_model`, `compile_with_libraries`, and
-  `compile_to_json` for CQL to ELM.
-- `validate` and `explain_*` paths for parser/compiler diagnostics.
-- `compile_to_elm_with_sourcemap` variants for CQL source to ELM source maps.
-- `evaluate_elm`, `evaluate_elm_with_libraries`, and trace-enabled evaluation.
-- Analytics helper functions in `analytics.rs` for inspection, data
-  requirements, relational planning, lowering reports, and artifact emission.
+  `compile_to_json`.
+- `validate` for syntax and semantic checks without ELM output.
+- `explain_parse` and `explain_compile` for human-readable diagnostics.
+- `compile_to_elm_with_sourcemap` for CQL source to ELM source maps.
 
-The CLI exposes these `rh cql` analysis and artifact commands:
+The CLI exposes the same surfaces through `rh cql compile`, `rh cql validate`,
+`rh cql info`, `rh cql explain`, and related subcommands. Use global
+`--format json` when command output is consumed by tools.
+
+## CQL Model
+
+CQL authoring concepts enter the engine through the parser and semantic layers.
+The compiler treats a CQL library as the compilation unit.
+
+Key CQL constructs:
+
+- Library metadata: `library`, `using`, `include`, `context`.
+- Declarations: parameters, value sets, code systems, codes, concepts,
+  expressions, and functions.
+- Expressions: literals, operators, calls, references, conditionals, intervals,
+  lists, tuples, queries, retrieves, and type operations.
+- Clinical data access: retrieves such as `[Condition: "Diabetes"]`, resolved
+  against model information and terminology references.
+
+The parser records the shape. Semantic analysis decides what names mean, what
+types expressions produce, and what ELM operation should represent each
+construct.
+
+## ELM Model
+
+The `elm.rs` and `elm/` modules define the serializable ELM object model used by
+the compiler and evaluator.
+
+ELM is the engine's durable semantic artifact:
+
+- It is independent of the CQL parser AST.
+- It can be serialized to and parsed from JSON.
+- It can be evaluated by `eval/`.
+- It can be inspected by analytics helper code.
+- It is the fixture and interop boundary for comparison with other CQL tooling.
+
+The compiler may include annotations, locators, result type names, and source
+map correlation depending on options. Those are side channels over the same ELM
+library structure; they should not be required for semantic execution.
+
+## Native ELM Evaluation
+
+The `eval/` module executes ELM directly. It is used for local execution,
+compiler development, conformance fixtures, debugging, and artifact comparison.
+
+Major pieces:
+
+- Runtime values for CQL primitives, intervals, lists, tuples, quantities, and
+  model-backed data.
+- `EvalContext` and builder APIs for clock, parameters, data providers,
+  terminology providers, and included libraries.
+- Operator implementations split by domain: arithmetic, comparison, logic,
+  strings, temporal values, conversions, intervals, lists, queries, and
+  clinical/model access.
+- Retrieve and query evaluation over provider-supplied data.
+- Trace-enabled evaluation through `evaluate_elm_with_trace`.
+
+The evaluator consumes ELM, not parser AST:
+
+```text
+CQL source -> parser AST -> typed AST -> ELM library -> eval::evaluate_elm
+```
+
+That boundary keeps runtime behavior aligned with the serialized artifact that
+other tools also consume.
+
+## Library and Dependency Handling
+
+The `library/` module provides source providers and compiled library management
+for includes. Compilation and evaluation both need a stable way to resolve
+library identifiers and versions without binding the parser to filesystem or
+package layout assumptions.
+
+Includes are resolved into compiled libraries before dependent expressions are
+used. Public APIs such as `compile_with_libraries` and
+`evaluate_elm_with_libraries` expose this boundary explicitly.
+
+## Diagnostics
+
+Diagnostics flow through `reporting.rs` and are collected where possible rather
+than stopping at the first recoverable issue.
+
+Important diagnostic boundaries:
+
+- parser errors from `parser/`;
+- semantic, type, conversion, and operator errors from `semantics/`, `types.rs`,
+  `conversion.rs`, and `operators.rs`;
+- ELM/source-map serialization errors from output surfaces;
+- evaluator errors from `eval/`;
+- experimental lowering diagnostics from analytics helpers.
+
+CLI JSON output wraps diagnostics in the standard `rh` envelope, which makes the
+commands suitable for scripting and agent workflows.
+
+## Module Map
+
+```text
+src/
+|-- analytics.rs          # Experimental inspection/planning/artifact helpers
+|-- compiler.rs           # Public compiler API and shared pipeline
+|-- conversion.rs         # FHIRHelpers-style conversion lookup/wrapping
+|-- datatype.rs           # Internal semantic type model
+|-- elm.rs, elm/          # ELM structs and serialization model
+|-- emit/                 # Typed AST -> ELM emission
+|-- eval/                 # Native ELM evaluator
+|-- explain/              # Explain helpers
+|-- library/              # Source providers and compiled library handling
+|-- modelinfo.rs          # ModelInfo model
+|-- modelinfo_xml/        # ModelInfo XML loading helpers
+|-- operators.rs          # Semantic operator resolution
+|-- options.rs            # Compiler options
+|-- output.rs             # ELM JSON output
+|-- parser/               # CQL parser and parser AST
+|-- preprocessor.rs       # Library info extraction
+|-- provider.rs           # ModelInfo providers
+|-- reporting.rs          # Diagnostics
+|-- semantics/            # Semantic analyzer, scopes, typed AST
+|-- sourcemap.rs          # CQL source to ELM source maps
+|-- types.rs              # Type resolution helpers
+`-- wasm.rs               # WASM-specific entry points
+```
+
+## Extension Points
+
+### Adding CQL Language Support
+
+1. Add syntax and AST shape in `parser/`.
+2. Add semantic resolution, typing, and diagnostics in `semantics/`, `types.rs`,
+   `operators.rs`, or `conversion.rs`.
+3. Add ELM emission in `emit/`.
+4. Add native evaluator support in `eval/` when the construct should execute
+   locally.
+5. Add conformance or golden fixture coverage.
+
+### Adding Model Support
+
+Model-specific knowledge should enter through `ModelInfoProvider` and model
+metadata, not through parser rules. New model work usually belongs in
+`modelinfo.rs`, `modelinfo_xml/`, `provider.rs`, and semantic type/member
+resolution.
+
+### Adding Evaluator Support
+
+Evaluator work should consume ELM nodes and runtime values. Avoid reaching back
+into parser AST or source text. When a feature needs external data, add or
+extend provider traits instead of embedding storage assumptions into operator
+code.
+
+## Experimental SQL-on-FHIR Support
+
+The SQL-on-FHIR path is experimental. It is a downstream artifact and planning
+layer over ELM, not the core CQL execution engine.
+
+Current goals:
+
+- inspect compiled ELM;
+- extract data requirements;
+- build an inspectable relational plan;
+- report what can and cannot lower;
+- emit deterministic SQL-on-FHIR ViewDefinition artifacts;
+- emit SQLQuery `Library` artifacts or raw SQL for backend experiments;
+- emit a runtime manifest that references generated artifacts.
+
+Current CLI path:
 
 ```bash
-rh cql compile measure.cql --output measure.elm.json
-rh cql validate measure.cql
-rh cql info measure.cql
-rh cql explain measure.cql
 rh cql elm inspect measure.elm.json
 rh cql elm deps measure.elm.json
 rh cql data-requirements measure.cql --format json
 rh cql plan measure.cql --target relational --display-format pretty
-rh cql plan measure.cql --target relational --display-format json --format json
 rh cql lower-check measure.cql --target sql-on-fhir
 rh cql emit-views measure.cql --out views/
 rh cql emit-sql measure.cql --views views/ --out query-library.json
-rh cql emit-sql measure.cql --sql-only
 rh cql emit-runtime measure.cql --views views/ --query query-library.json --out measure-runtime.json
-rh cql eval measure.cql "Expression Name" --data data.ndjson
 ```
 
-Use global `--format json` when the command output is consumed by tools. The
-CLI wraps JSON results in the standard `rh` envelope.
+### Analytics Helper Layer
 
-## Module Structure
+`analytics.rs` provides JSON-serializable helper artifacts:
+
+- `ElmInspection` for library identity, usings, includes, parameters,
+  terminology declarations, definitions, retrieves, node counts, and dependency
+  information.
+- `DataRequirements` for resources, retrieves, value sets, code systems, and
+  parameters required by a library.
+- `RelationalPlan` for the experimental CQL/ELM-to-relational boundary.
+- `LowerCheckReport` for supported and unsupported ELM node kinds.
+- `ViewDefinitionArtifact`, SQLQuery Library output, SQL text, and runtime
+  manifest output.
+
+These artifacts are intended to be reviewed in git, tested as fixtures, and
+consumed by external runtimes without linking to compiler internals.
+
+### Experimental Relational Algebra
+
+The relational plan is the experimental IR between ELM and SQL-on-FHIR-oriented
+artifacts:
 
 ```text
-src/
-├── analytics.rs          # Inspection, data requirements, relational IR, artifact emission
-├── compiler.rs           # Public compiler API and shared pipeline
-├── conversion.rs         # FHIRHelpers-style conversion lookup/wrapping
-├── datatype.rs           # Internal semantic type model
-├── elm.rs, elm/          # ELM structs and serialization model
-├── emit/                 # Typed AST -> ELM emission
-├── eval/                 # CQL/ELM evaluator, runtime values, operators, queries
-├── explain/              # Explain helpers
-├── library/              # Library source providers and compiled library management
-├── modelinfo.rs          # ModelInfo model
-├── modelinfo_xml/        # ModelInfo XML loading helpers
-├── operators.rs          # Semantic operator resolution
-├── options.rs            # Compiler options
-├── output.rs             # ELM JSON output
-├── parser/               # CQL parser and parser AST
-├── preprocessor.rs       # Library info extraction
-├── provider.rs           # ModelInfo providers
-├── reporting.rs          # Diagnostics and exception reporting
-├── semantics/            # Semantic analyzer, scopes, typed AST
-├── sourcemap.rs          # CQL source to ELM source maps
-├── types.rs              # Type resolution helpers
-└── wasm.rs               # WASM-specific entry points
+ELM library
+  -> data requirements
+  -> relational plan
+  -> lowerability report
+  -> ViewDefinition artifacts
+  -> SQLQuery Library / SQL text
+  -> runtime manifest
 ```
 
-## Design Principles
-
-### Separate Syntax, Semantics, and ELM
-
-The parser AST preserves CQL syntax. Semantic analysis resolves names, scopes,
-types, model members, operators, conversions, and diagnostics into a typed AST.
-The ELM emitter consumes the typed AST and produces HL7 ELM.
-
-This separation matters because later surfaces, such as explain, validation,
-source maps, ELM emission, and analytics inspection, can share earlier pipeline
-stages without coupling to one large translator.
-
-### Typed AST Before Emission
-
-The current architecture is not a single-pass AST-to-ELM translator. The typed
-AST is an explicit compiler boundary:
-
-```text
-parser::ast::Library -> semantics::TypedLibrary -> elm::Library
-```
-
-`TypedNode<T>` carries semantic metadata such as node ids, source spans, result
-types, and resolved expression structure. This makes ELM emission simpler and
-keeps semantic diagnostics independent of output serialization.
-
-### Explicit ModelInfo Boundary
-
-Semantic analysis uses a `ModelInfoProvider`. The default provider is FHIR R4,
-but callers can supply another provider through `CompilationContext` or
-`compile_with_model`.
-
-This keeps model-specific knowledge out of the parser and allows FHIR package
-or custom model resolution to be swapped without changing the syntax layer.
-
-### Serializable Artifacts
-
-Every analytics-facing boundary is JSON-serializable:
-
-- ELM JSON
-- source-map JSON
-- ELM inspection summaries
-- data requirements
-- relational plans
-- lower-check reports
-- ViewDefinition artifacts
-- SQLQuery Library artifacts
-- measure runtime manifests
-
-This is intentional. These artifacts are meant to be reviewed in git, used in
-fixtures, and consumed by runtimes without linking to compiler internals.
-
-## Analytics Tooling
-
-`analytics.rs` is the inspection and artifact layer over compiled ELM. It does
-not execute analytics workloads. It turns compiler output into stable, portable
-contracts intended to scale into production runtimes without requiring those
-runtimes to live in open-source `rh`.
-
-### ELM Inspection
-
-`inspect_elm` summarizes an ELM library for humans and automation:
-
-- library identity and version;
-- using declarations and includes;
-- parameters, value sets, and code systems;
-- expression and function definitions;
-- retrieve requirements;
-- expression node counts;
-- dependency information for named definitions.
-
-The CLI surfaces this through `rh cql elm inspect` and `rh cql elm deps`.
-
-### Data Requirements
-
-`data_requirements` extracts the FHIR resources, retrieves, terminology
-references, code systems, value sets, and parameters needed by a library.
-
-This is the first artifact boundary used by SQL-on-FHIR emission. For example,
-retrieves of `[Condition]` become requirements for a `Condition` view.
-
-### Lowering Support Reports
-
-`lower_check` reports whether the current first-pass relational lowerer
-recognizes the ELM node kinds present in a library. It is intentionally scoped:
-it is not a claim that all CQL semantics are executable as SQL.
-
-The report separates supported and unsupported ELM node kinds, with notes about
-known semantic gaps such as terminology expansion, complete interval precision,
-quantity normalization, and complex list behavior.
-
-## Relational Algebra IR
-
-The relational algebra plan is the inspectable compiler IR between clinical CQL
-semantics and backend artifacts.
-
-```text
-CQL / ELM
-  -> relational algebra IR
-  -> SQL-on-FHIR ViewDefinitions + SQLQuery
-  -> analytics runtime execution
-```
-
-SQL-on-FHIR is an artifact target, not the core internal model. The relational
-IR is the place where CQL retrieves, filters, joins, projections, aggregates,
-and clinical expression predicates are normalized before choosing an output
-target.
-
-```mermaid
-flowchart TB
-    elm3["ELM library"] --> plan["rh cql plan\nRelationalPlan"]
-    elm3 --> req["data_requirements\nRetrieveRequirement"]
-
-    plan --> core["Core relational nodes\nScan, Filter, Project,\nSemiJoin, AntiJoin,\nAggregate, Exists"]
-    plan --> expr["CQL/FHIR expression extensions\nExpr.kind, dataType, resource,\nrelationship, Unsupported"]
-
-    req --> views2["rh cql emit-views\nViewDefinition JSON"]
-    plan --> check["rh cql lower-check\nsupported / unsupported nodes"]
-    core --> sql2["rh cql emit-sql\nSQLQuery Library or SQL text"]
-    expr --> sql2
-    views2 --> manifest2["rh cql emit-runtime\nReasonHealthMeasureRuntime"]
-    sql2 --> manifest2
-
-    classDef input fill:#e8f2ff,stroke:#4b77be,color:#111;
-    classDef ir fill:#f4f4f4,stroke:#777,color:#111;
-    classDef artifact fill:#eaf7ea,stroke:#3f8f46,color:#111;
-    class elm3 input;
-    class plan,req,core,expr,check ir;
-    class views2,sql2,manifest2 artifact;
-```
-
-### Core Relational Algebra
-
-The core is conventional relational algebra:
-
-| Core node | Meaning | Typical backend mapping |
-|---|---|---|
-| `Scan` | Read a logical source relation | SQL table or generated ViewDefinition table |
-| `Filter` | Keep rows matching a predicate | SQL `WHERE` |
-| `Project` | Shape or select columns/expressions | SQL `SELECT` |
-| `SemiJoin` | Keep left rows that have matching right rows | SQL `EXISTS` or semi join |
-| `AntiJoin` | Keep left rows that do not have matching right rows | SQL `NOT EXISTS` or anti join |
-| `Aggregate` | Group and aggregate rows | SQL `GROUP BY` |
-| `Exists` | Boolean existence over an input relation | SQL `EXISTS` |
-
-The current serialized shape is deliberately simple:
+The serialized `RelNode` shape is deliberately simple while the lowerer matures:
 
 ```json
 {
@@ -387,26 +353,28 @@ The current serialized shape is deliberately simple:
 }
 ```
 
-`RelNode` is an operation name, a string detail map, and child inputs. This
-keeps the first IR stable and easy to inspect while the lowerer matures.
+The current algebra uses conventional relational operators and extends them
+with CQL/FHIR-specific metadata:
 
-### RH/CQL Extensions
+| Node or extension | Relation to relational algebra | Current purpose |
+|---|---|---|
+| `Scan` | Base relation | Reads a logical FHIR resource/table, usually derived from an ELM retrieve. |
+| `Filter` | Selection | Keeps rows matching a CQL predicate. |
+| `Project` | Projection | Shapes output columns or scalar expressions. |
+| `SemiJoin` | Semijoin | Represents CQL `with`, usually lowered as `EXISTS`. |
+| `AntiJoin` | Antijoin | Represents CQL `without`, usually lowered as `NOT EXISTS`. |
+| `Aggregate` | Grouping/aggregation | Represents grouped population or aggregate computations. |
+| `Exists` | Existential quantification over a relation | Produces a boolean existence result from an input relation. |
+| `Expr.kind` | CQL expression extension | Holds predicate/scalar expression kinds before they have a richer typed relational representation. |
+| `Scan.detail.dataType` | FHIR/CQL metadata extension | Preserves the ELM model type such as `{http://hl7.org/fhir}Condition`. |
+| `Scan.detail.resource` | FHIR/CQL metadata extension | Normalizes model types to resource/table names such as `Condition`. |
+| `SemiJoin.detail.relationship` | CQL query extension | Preserves the source relationship intent for `with`. |
+| `AntiJoin.detail.relationship` | CQL query extension | Preserves the source relationship intent for `without`. |
+| `Unsupported.detail.elmType` | Lowering diagnostic extension | Makes unsupported ELM shapes explicit and testable. |
+| `target` | Planning metadata extension | Names the backend vocabulary being inspected, such as `relational` or `sql-on-fhir`. |
 
-Clinical CQL needs more than textbook relational algebra. We extend the core
-with CQL/FHIR-aware details and expression placeholders:
-
-| Extension | Why it exists |
-|---|---|
-| `Scan.detail.dataType` | Preserves the ELM model type such as `{http://hl7.org/fhir}Condition`. |
-| `Scan.detail.resource` | Normalizes FHIR model types to runtime resource/table names such as `Condition`. |
-| `Expr.kind` | Represents clinical predicate and scalar expression nodes without prematurely forcing them into SQL syntax. |
-| `SemiJoin.detail.relationship` | Preserves CQL `with` relationship intent. |
-| `AntiJoin.detail.relationship` | Preserves CQL `without` relationship intent. |
-| `Unsupported.detail.elmType` | Makes lowering gaps explicit and testable instead of silently dropping semantics. |
-| `target` on `RelationalPlan` | Names the backend vocabulary being inspected, such as `relational` or `sql-on-fhir`. |
-
-The currently recognized expression kinds include common boolean, comparison,
-terminology, timing, property, literal, and reference forms:
+Currently recognized expression kinds include boolean, comparison, terminology,
+timing, property, literal, and reference forms:
 
 ```text
 And, Or, Not,
@@ -418,198 +386,39 @@ Property, Literal,
 ValueSetRef, CodeRef, ExpressionRef, ParameterRef, AliasRef
 ```
 
-These are serialized as `Expr` nodes today because the first-pass IR is focused
-on making the CQL-to-relational boundary visible and reviewable. As lowering
-becomes more complete, selected `Expr` nodes can be expanded into richer typed
-predicate structs without changing the high-level relational core.
+These are placeholders for an evolving typed predicate model. They make the
+lowering boundary visible without pretending the first-pass IR captures all CQL
+semantics.
 
-### Why Not Emit SQL Directly?
-
-Direct SQL emission would tie CQL lowering to one backend too early. The
-relational IR gives us:
-
-- an inspectable debugging surface via `rh cql plan`;
-- a stable fixture target for tests;
-- a place to report unsupported semantics before SQL generation;
-- a common source for SQL-on-FHIR, raw SQL, and future runtime-specific
-  backends;
-- a product boundary where open-source `rh` emits artifacts and closed-source
-  analytics runtimes execute them.
-
-### Current Limits
-
-The current relational plan is a first-pass lowerer. It is useful for
-inspection and artifact generation, but it is not a complete CQL semantic model.
-
-Known limits include:
-
-- incomplete terminology expansion semantics;
-- incomplete interval precision handling;
-- incomplete quantity and UCUM normalization;
-- partial list semantics;
-- no full query optimization;
-- simple expression nodes rather than fully typed relational predicates.
-
-Those limits are surfaced by `lower_check` and by `Unsupported` IR nodes.
-
-## SQL-on-FHIR and Runtime Artifacts
-
-The current artifact path is:
-
-```text
-rh cql emit-views
-rh cql emit-sql
-rh cql emit-runtime
-```
-
-### ViewDefinition Emission
+### ViewDefinition, SQLQuery, and Runtime Manifest Output
 
 `emit_view_definitions` derives deterministic SQL-on-FHIR ViewDefinition
-artifacts from retrieve requirements. Each resource gets a view with stable,
-runtime-friendly columns currently used by analytics fixtures:
+artifacts from retrieve requirements. Each resource gets stable columns used by
+the current analytics fixtures, including `id`, `patient_id`, selected scalar
+paths, and code coding expansions when needed.
 
-- `getResourceKey()` as `id`;
-- `subject.getReferenceKey(Patient)` as `patient_id`;
-- common scalar paths when required;
-- `forEachOrNull: code.coding` with `system` and `code` columns.
+`emit_sql_text` and `emit_sql_query_library` generate raw SQL text or a FHIR
+`Library` containing SQLQuery metadata and dependencies on emitted views.
 
-The generated view names and paths are deterministic so artifacts can be
-checked into fixtures and reviewed.
+`emit_measure_runtime_manifest` writes a JSON manifest that references the query
+and views rather than embedding compiler internals. Runtime consumers can load
+the manifest, bind parameters, execute the selected backend, and collect named
+result columns.
 
-### SQLQuery Emission
+### Experimental Limits
 
-`emit_sql_text` and `emit_sql_query_library` generate:
+The current SQL-on-FHIR support is retrieve-oriented and incomplete. Known gaps
+include:
 
-- raw SQL text for inspection and backend experiments;
-- a FHIR `Library` artifact containing SQLQuery metadata;
-- `relatedArtifact` dependencies on emitted ViewDefinitions;
-- parameter metadata derived from CQL parameters;
-- SQL text in the SQL-on-FHIR extension plus base64 attachment data.
+- complete CQL query semantics;
+- terminology expansion and value-set membership semantics;
+- interval precision rules;
+- quantity and UCUM normalization;
+- complex list semantics;
+- query optimization;
+- backend-specific planning;
+- full measure population extraction.
 
-The initial SQL generator is intentionally conservative and retrieve-oriented.
-More complete relational lowering should happen through the relational IR
-rather than by adding ad hoc SQL generation directly from ELM.
-
-The emitted SQL artifacts are designed as execution contracts, not as a claim
-that `rh` itself is the production execution engine. The same artifacts can be
-run by commercial or local products that choose an appropriate backend for the
-deployment environment.
-
-### Measure Runtime Manifest
-
-`emit_measure_runtime_manifest` writes the first ReasonHealth runtime manifest:
-
-```json
-{
-  "resourceType": "ReasonHealthMeasureRuntime",
-  "id": "examplemeasure",
-  "measure": "ExampleMeasure",
-  "query": "query-library.json",
-  "views": ["views/condition_view.json"],
-  "parameters": [
-    {
-      "name": "condition_code",
-      "type": "string",
-      "required": false
-    }
-  ],
-  "results": [
-    {
-      "name": "initialPopulation",
-      "kind": "population",
-      "source": "query",
-      "column": "patient_id"
-    }
-  ]
-}
-```
-
-The manifest is path-oriented and JSON-serializable. It intentionally references
-artifacts instead of embedding compiler internals. Runtime consumers can load
-the manifest, load the referenced views and query, bind parameters, and collect
-named result populations.
-
-The CLI accepts `--result name=column` to map result names to query result
-columns. If omitted, it defaults to `initialPopulation=patient_id`.
-
-## Evaluation Engine
-
-The `eval/` module provides an optional CQL/ELM runtime used for local
-artifact-development, debugging, and comparison workflows. It includes:
-
-- CQL runtime `Value` types;
-- three-valued logic helpers;
-- arithmetic, comparison, string, temporal, conversion, interval, list, and
-  query operators;
-- `EvalContext` and data/terminology provider traits;
-- trace-enabled evaluation for debugging.
-
-The evaluator is separate from analytics artifact execution. The evaluator
-executes CQL/ELM semantics directly so compiler authors and artifact developers
-can test behavior without a warehouse or commercial runtime. Production
-analytics runtimes execute emitted relational artifacts over projected FHIR
-tables and are expected to make environment-specific backend choices outside
-this crate.
-
-## Error Handling and Diagnostics
-
-Diagnostics flow through `reporting.rs` and carry stage, severity, source
-location, and structured details where available. The compiler collects
-multiple diagnostics when possible instead of stopping at the first recoverable
-problem.
-
-Important diagnostic boundaries:
-
-- parser errors from `parser/`;
-- semantic/type/operator errors from `semantics/`, `types.rs`, and
-  `operators.rs`;
-- emitted diagnostics exposed by `compile`, `validate`, and CLI JSON envelopes;
-- lowerability diagnostics exposed separately by `lower_check`.
-
-## Extension Points
-
-### Adding CQL Syntax
-
-1. Add parser AST support in `parser/ast.rs` and parser modules.
-2. Add semantic analysis and type resolution in `semantics/`, `types.rs`, and
-   `operators.rs`.
-3. Add ELM emission in `emit/`.
-4. Add evaluator support if runtime evaluation is expected.
-5. Add analytics lowering support if the construct should participate in
-   relational artifact emission.
-
-### Adding Relational IR Support
-
-1. Teach `plan_expression` or `plan_query` how to lower the ELM shape.
-2. Preserve CQL/FHIR-specific information in `detail` or a richer serializable
-   node shape.
-3. Update `is_supported_for_first_pass` so `lower_check` reflects the new
-   support.
-4. Add formatted and JSON fixture coverage for `rh cql plan`.
-5. Add SQL-on-FHIR or SQLQuery emission only after the IR representation is
-   reviewable.
-
-### Adding Artifact Targets
-
-New targets should consume the relational IR or data requirements rather than
-re-walking CQL source directly. This keeps the compiler boundary stable:
-
-```text
-CQL -> ELM -> relational IR -> artifact target
-```
-
-## Future Work
-
-Near-term work should focus on:
-
-1. Expanding relational expression nodes beyond `Expr.kind` placeholders.
-2. Lowering more CQL query relationships, projections, and population
-   operations.
-3. Improving terminology and value-set handling at the artifact boundary.
-4. Emitting richer measure runtime manifests for multiple populations directly
-   from CQL measure structure.
-5. Keeping `lower_check` precise as support broadens.
-
-Longer-term work can add optimization, backend-specific planning, richer source
-maps across analytics artifacts, and more complete fallback coordination between
-relational execution and direct CQL evaluation.
+These limits should be surfaced through `lower_check` and `Unsupported` plan
+nodes. New artifact targets should consume ELM, data requirements, or the
+relational plan rather than re-walking CQL source directly.

--- a/crates/rh-cql/README.md
+++ b/crates/rh-cql/README.md
@@ -12,6 +12,7 @@ This crate provides:
 - **Source Maps**: CQL source span → ELM node correlation via `compile_to_elm_with_sourcemap`
 - **Explain Output**: Human-readable parse tree and compilation details (`explain_parse`, `explain_compile`)
 - **ELM Evaluator**: Pure Rust evaluation engine (`evaluate_elm`, `evaluate_elm_with_trace`)
+- **Analytics and SQL-on-FHIR**: Data requirements, relational planning, lowerability checks, ViewDefinition generation, and SQLQuery Library emission
 - **ModelInfo Types**: FHIR and custom model definitions for type resolution
 - **DataType System**: Type checking, compatibility, and implicit conversions
 
@@ -241,6 +242,66 @@ for event in &trace {
     println!("  op={} inputs={:?} output={}", event.op, event.inputs, event.output);
 }
 ```
+
+### Analytics and SQL-on-FHIR
+
+`rh-cql` includes first-pass analytics helpers for inspecting compiled ELM and
+generating SQL-on-FHIR artifacts from supported CQL retrieve patterns. These
+APIs expose what was found, what can lower, and where fallback evaluation may
+still be needed.
+
+```rust
+use rh_cql::{
+    analytics::{
+        data_requirements, emit_sql_query_library, emit_sql_text,
+        emit_view_definitions, lower_check, relational_plan,
+    },
+    compile,
+};
+
+let source = r#"
+library DiabetesMeasure version '1.0.0'
+using FHIR version '4.0.1'
+valueset "Diabetes": 'http://example.org/fhir/ValueSet/diabetes'
+parameter MeasurementPeriod Interval<DateTime>
+context Patient
+define "Diabetes Conditions":
+  [Condition: "Diabetes"]
+define "Has Diabetes":
+  exists "Diabetes Conditions"
+"#;
+
+let compiled = compile(source, None).unwrap();
+assert!(compiled.is_success());
+
+let requirements = data_requirements(&compiled.library);
+assert_eq!(requirements.resources, vec!["Condition"]);
+
+let plan = relational_plan(&compiled.library, "sql-on-fhir");
+let report = lower_check(&compiled.library, "sql-on-fhir");
+assert!(report.supported);
+
+let views = emit_view_definitions(
+    &compiled.library,
+    "https://reason.health/rh/generated/sql-on-fhir",
+).views;
+let sql = emit_sql_text(&compiled.library, &views);
+let sql_library = emit_sql_query_library(
+    &compiled.library,
+    &views,
+    "https://reason.health/rh/generated/sql-on-fhir",
+).library;
+
+println!("plan expressions: {}", plan.expressions.len());
+println!("{sql}");
+println!("{}", serde_json::to_string_pretty(&sql_library).unwrap());
+```
+
+The SQL-on-FHIR lowerer is currently a first-pass bridge for retrieve-centric
+measure logic. It can emit deterministic ViewDefinition JSON, SQL text, and
+FHIR `Library` resources carrying SQLQuery content. Complete CQL semantics,
+terminology expansion, interval precision, quantity handling, and complex list
+semantics may still require runtime fallback evaluation.
 
 ### Working with CompilationResult
 

--- a/crates/rh-cql/src/wasm.rs
+++ b/crates/rh-cql/src/wasm.rs
@@ -292,12 +292,17 @@ where
     };
 
     if !result.is_success() {
-        let response = json!({
-            "success": false,
-            "errors": result.errors.iter().map(diagnostic_to_json).collect::<Vec<_>>(),
-            "warnings": result.warnings.iter().map(diagnostic_to_json).collect::<Vec<_>>(),
+        let message = result
+            .errors
+            .iter()
+            .map(|diagnostic| diagnostic.message.as_str())
+            .collect::<Vec<_>>()
+            .join("\n");
+        return WasmResult::err(if message.is_empty() {
+            "Failed to compile CQL".to_string()
+        } else {
+            format!("Failed to compile CQL: {message}")
         });
-        return json_result(response, pretty);
     }
 
     json_result(json!(f(&result.library)), pretty)

--- a/crates/rh-cql/src/wasm.rs
+++ b/crates/rh-cql/src/wasm.rs
@@ -6,10 +6,14 @@ use serde::{Deserialize, Serialize};
 use serde_json::json;
 use wasm_bindgen::prelude::*;
 
+use crate::analytics::{
+    data_requirements, emit_sql_query_library, emit_sql_text, emit_view_definitions, inspect_elm,
+    lower_check, relational_plan, ViewDefinitionArtifact,
+};
 use crate::eval::value::{CqlCode, CqlConcept, CqlDate, CqlDateTime, CqlQuantity, CqlTime, Value};
 use crate::{
-    compile_to_elm_with_sourcemap, compile_to_json, evaluate_elm, explain_compile, explain_parse,
-    CompilerOptions, EvalContextBuilder, FixedClock, InMemoryDataProvider,
+    compile, compile_to_elm_with_sourcemap, compile_to_json, evaluate_elm, explain_compile,
+    explain_parse, CompilerOptions, EvalContextBuilder, FixedClock, InMemoryDataProvider,
 };
 
 pub use rh_foundation::wasm::WasmResult;
@@ -186,6 +190,69 @@ pub fn explain_cql_compile(source: &str, _options: &CompileOptions) -> WasmResul
     result.map_or_else(compile_explain_err, WasmResult::ok)
 }
 
+#[wasm_bindgen]
+pub fn inspect_cql(source: &str, options: &CompileOptions) -> WasmResult {
+    with_compiled_library(source, options.pretty, |library| inspect_elm(library))
+}
+
+#[wasm_bindgen]
+pub fn cql_data_requirements(source: &str, options: &CompileOptions) -> WasmResult {
+    with_compiled_library(source, options.pretty, data_requirements)
+}
+
+#[wasm_bindgen]
+pub fn cql_relational_plan(source: &str, target: &str, options: &CompileOptions) -> WasmResult {
+    with_compiled_library(source, options.pretty, |library| {
+        relational_plan(library, target)
+    })
+}
+
+#[wasm_bindgen]
+pub fn cql_lower_check(source: &str, target: &str, options: &CompileOptions) -> WasmResult {
+    with_compiled_library(source, options.pretty, |library| {
+        lower_check(library, target)
+    })
+}
+
+#[wasm_bindgen]
+pub fn cql_emit_view_definitions(
+    source: &str,
+    canonical_base: &str,
+    options: &CompileOptions,
+) -> WasmResult {
+    with_compiled_library(source, options.pretty, |library| {
+        emit_view_definitions(library, canonical_base)
+    })
+}
+
+#[wasm_bindgen]
+pub fn cql_emit_sql(source: &str, canonical_base: &str, options: &CompileOptions) -> WasmResult {
+    with_compiled_library(source, options.pretty, |library| {
+        let views = emit_view_definitions(library, canonical_base).views;
+        SqlTextResponse {
+            sql: emit_sql_text(library, &views),
+            views,
+        }
+    })
+}
+
+#[wasm_bindgen]
+pub fn cql_emit_sql_query_library(
+    source: &str,
+    canonical_base: &str,
+    options: &CompileOptions,
+) -> WasmResult {
+    with_compiled_library(source, options.pretty, |library| {
+        let views = emit_view_definitions(library, canonical_base).views;
+        let generation = emit_sql_query_library(library, &views, canonical_base);
+        SqlQueryResponse {
+            sql: generation.sql,
+            library: generation.library,
+            views,
+        }
+    })
+}
+
 fn parse_explain_err(err: crate::CompilationError) -> WasmResult {
     WasmResult::err(format!("Failed to explain CQL parse: {err}"))
 }
@@ -197,6 +264,43 @@ fn compile_explain_err(err: crate::CompilationError) -> WasmResult {
 #[wasm_bindgen]
 pub fn get_version() -> String {
     env!("CARGO_PKG_VERSION").to_string()
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SqlTextResponse {
+    sql: String,
+    views: Vec<ViewDefinitionArtifact>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct SqlQueryResponse {
+    sql: String,
+    library: crate::analytics::SqlQueryLibraryArtifact,
+    views: Vec<ViewDefinitionArtifact>,
+}
+
+fn with_compiled_library<T, F>(source: &str, pretty: bool, f: F) -> WasmResult
+where
+    T: Serialize,
+    F: FnOnce(&crate::elm::Library) -> T,
+{
+    let result = match compile(source, Some(CompilerOptions::default())) {
+        Ok(result) => result,
+        Err(err) => return WasmResult::err(format!("Failed to compile CQL: {err}")),
+    };
+
+    if !result.is_success() {
+        let response = json!({
+            "success": false,
+            "errors": result.errors.iter().map(diagnostic_to_json).collect::<Vec<_>>(),
+            "warnings": result.warnings.iter().map(diagnostic_to_json).collect::<Vec<_>>(),
+        });
+        return json_result(response, pretty);
+    }
+
+    json_result(json!(f(&result.library)), pretty)
 }
 
 fn json_result(value: serde_json::Value, pretty: bool) -> WasmResult {

--- a/examples/playground/src/main.ts
+++ b/examples/playground/src/main.ts
@@ -14,9 +14,16 @@ import {
 } from "@reasonhealth/vcl/web";
 import {
   compile as compileCql,
+  dataRequirements as cqlDataRequirements,
+  emitSql as cqlEmitSql,
+  emitSqlQueryLibrary as cqlEmitSqlQueryLibrary,
+  emitViewDefinitions as cqlEmitViewDefinitions,
   explainCompile as explainCqlCompile,
   explainParse as explainCqlParse,
   initCql,
+  inspect as inspectCql,
+  lowerCheck as cqlLowerCheck,
+  relationalPlan as cqlRelationalPlan,
   version as cqlVersion
 } from "@reasonhealth/cql/web";
 import "./styles.css";
@@ -127,6 +134,13 @@ app.innerHTML = `
             <button type="submit">Compile</button>
 <button type="button" class="secondary" id="cql-explain-compile">Explain Compile</button>
 <button type="button" class="secondary" id="cql-explain-parse">Explain Parse</button>
+<button type="button" class="secondary" id="cql-inspect">Inspect</button>
+<button type="button" class="secondary" id="cql-data-requirements">Data Requirements</button>
+<button type="button" class="secondary" id="cql-plan">Plan</button>
+<button type="button" class="secondary" id="cql-lower-check">Lower Check</button>
+<button type="button" class="secondary" id="cql-emit-views">Emit Views</button>
+<button type="button" class="secondary" id="cql-emit-sql">Emit SQL</button>
+<button type="button" class="secondary" id="cql-emit-sql-library">SQL Library</button>
             <label class="toggle"><input type="checkbox" id="cql-source-map" /> Source map</label>
           </div>
         </form>
@@ -328,26 +342,64 @@ function bindVcl(): void {
 }
 
 function bindCql(): void {
+  const cqlSourceText = () => textValue("cql-source");
+  const compileOptions = () => ({
+    sourceMap: requiredElement<HTMLInputElement>("cql-source-map").checked
+  });
+
   requiredElement<HTMLFormElement>("cql-form").addEventListener("submit", (event) => {
     event.preventDefault();
     renderResult(
       "cql-output",
-      compileCql(textValue("cql-source"), {
-        sourceMap: requiredElement<HTMLInputElement>("cql-source-map").checked
-      }),
+      compileCql(cqlSourceText(), compileOptions()),
       { title: "CQL ELM output" }
     );
   });
   requiredElement<HTMLButtonElement>("cql-explain-compile").addEventListener("click", () => {
     renderResult(
       "cql-output",
-      explainCqlCompile(textValue("cql-source"), { sourceMap: requiredElement<HTMLInputElement>("cql-source-map").checked }),
+      explainCqlCompile(cqlSourceText(), compileOptions()),
       { title: "CQL compile explanation" }
     );
   });
   requiredElement<HTMLButtonElement>("cql-explain-parse").addEventListener("click", () => {
-    renderResult("cql-output", explainCqlParse(textValue("cql-source")), {
+    renderResult("cql-output", explainCqlParse(cqlSourceText()), {
       title: "CQL parse explanation"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-inspect").addEventListener("click", () => {
+    renderResult("cql-output", inspectCql(cqlSourceText()), {
+      title: "CQL inspection"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-data-requirements").addEventListener("click", () => {
+    renderResult("cql-output", cqlDataRequirements(cqlSourceText()), {
+      title: "CQL data requirements"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-plan").addEventListener("click", () => {
+    renderResult("cql-output", cqlRelationalPlan(cqlSourceText()), {
+      title: "CQL relational plan"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-lower-check").addEventListener("click", () => {
+    renderResult("cql-output", cqlLowerCheck(cqlSourceText()), {
+      title: "SQL-on-FHIR lower check"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-emit-views").addEventListener("click", () => {
+    renderResult("cql-output", cqlEmitViewDefinitions(cqlSourceText()), {
+      title: "SQL-on-FHIR ViewDefinitions"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-emit-sql").addEventListener("click", () => {
+    renderResult("cql-output", cqlEmitSql(cqlSourceText()), {
+      title: "SQL-on-FHIR SQL"
+    });
+  });
+  requiredElement<HTMLButtonElement>("cql-emit-sql-library").addEventListener("click", () => {
+    renderResult("cql-output", cqlEmitSqlQueryLibrary(cqlSourceText()), {
+      title: "SQLQuery Library"
     });
   });
 }
@@ -443,6 +495,15 @@ function renderPayload(payload: unknown): string {
   if (isElmLibraryPayload(payload)) {
     return renderElmLibrary(payload);
   }
+  if (isSqlTextPayload(payload)) {
+    return renderSqlTextPayload(payload);
+  }
+  if (isLowerCheckPayload(payload)) {
+    return renderLowerCheckPayload(payload);
+  }
+  if (isViewGenerationPayload(payload)) {
+    return renderViewGenerationPayload(payload);
+  }
   if (isValueSetComposePayload(payload)) {
     return renderValueSetCompose(payload);
   }
@@ -535,6 +596,54 @@ function renderValueSetCompose(payload: { include?: unknown[]; exclude?: unknown
   `;
 }
 
+function renderLowerCheckPayload(payload: { target: string; supported: boolean; supportedNodes?: unknown[]; unsupportedNodes?: unknown[]; notes?: unknown[] }): string {
+  const unsupported = Array.isArray(payload.unsupportedNodes) ? payload.unsupportedNodes : [];
+  const supported = Array.isArray(payload.supportedNodes) ? payload.supportedNodes : [];
+  const notes = Array.isArray(payload.notes) ? payload.notes : [];
+  const rows = [...supported.map((node) => renderSupportRow("supported", node)), ...unsupported.map((node) => renderSupportRow("unsupported", node))].join("");
+
+  return `
+    <section class="rendered-block ${payload.supported ? "success" : "danger"}">
+      <h3>${escapeHtml(payload.target)} lower check</h3>
+      <p>${payload.supported ? "All encountered node kinds are supported by the first-pass lowerer." : `${unsupported.length} unsupported node kind${unsupported.length === 1 ? "" : "s"} found.`}</p>
+      ${rows ? `<table><thead><tr><th>Status</th><th>ELM node</th><th>Count</th></tr></thead><tbody>${rows}</tbody></table>` : ""}
+      ${notes.length ? `<ul>${notes.map((note) => `<li>${escapeHtml(String(note))}</li>`).join("")}</ul>` : ""}
+    </section>
+  `;
+}
+
+function renderSupportRow(status: string, node: unknown): string {
+  const row = isRecord(node) ? node : {};
+  return `<tr><td>${escapeHtml(status)}</td><td>${escapeHtml(String(row.nodeType ?? ""))}</td><td>${escapeHtml(String(row.count ?? ""))}</td></tr>`;
+}
+
+function renderViewGenerationPayload(payload: { views: unknown[] }): string {
+  const rows = payload.views.map((view) => {
+    const row = isRecord(view) ? view : {};
+    return `<tr><td>${escapeHtml(String(row.name ?? ""))}</td><td>${escapeHtml(String(row.resource ?? ""))}</td><td>${escapeHtml(String(row.url ?? ""))}</td></tr>`;
+  }).join("");
+
+  return `
+    <section class="rendered-block">
+      <h3>SQL-on-FHIR ViewDefinitions</h3>
+      <p>${payload.views.length} view${payload.views.length === 1 ? "" : "s"} generated from CQL retrieves.</p>
+      ${rows ? `<table><thead><tr><th>Name</th><th>Resource</th><th>Canonical URL</th></tr></thead><tbody>${rows}</tbody></table>` : ""}
+    </section>
+  `;
+}
+
+function renderSqlTextPayload(payload: { sql: string; views?: unknown[]; library?: unknown }): string {
+  const views = Array.isArray(payload.views) ? payload.views : [];
+  const title = isRecord(payload.library) ? "SQLQuery Library" : "SQL-on-FHIR SQL";
+  return `
+    <section class="rendered-block">
+      <h3>${title}</h3>
+      <p>${views.length} ViewDefinition dependenc${views.length === 1 ? "y" : "ies"}.</p>
+      <pre class="explanation-pre">${escapeHtml(payload.sql)}</pre>
+    </section>
+  `;
+}
+
 function renderComposeRow(mode: string, entry: unknown): string {
   const row = isRecord(entry) ? entry : {};
   const filters = Array.isArray(row.filter)
@@ -613,6 +722,18 @@ function isCqlSourceMapPayload(value: unknown): value is { library: unknown; sou
 
 function isValueSetComposePayload(value: unknown): value is { include?: unknown[]; exclude?: unknown[] } {
   return isRecord(value) && (Array.isArray(value.include) || Array.isArray(value.exclude));
+}
+
+function isLowerCheckPayload(value: unknown): value is { target: string; supported: boolean; supportedNodes?: unknown[]; unsupportedNodes?: unknown[]; notes?: unknown[] } {
+  return isRecord(value) && typeof value.target === "string" && typeof value.supported === "boolean";
+}
+
+function isViewGenerationPayload(value: unknown): value is { views: unknown[] } {
+  return isRecord(value) && Array.isArray(value.views) && !("sql" in value);
+}
+
+function isSqlTextPayload(value: unknown): value is { sql: string; views?: unknown[]; library?: unknown } {
+  return isRecord(value) && typeof value.sql === "string";
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/examples/playground/src/samples.ts
+++ b/examples/playground/src/samples.ts
@@ -37,12 +37,18 @@ export const vclExamples = [
 ] as const;
 
 export const cqlSource = `library Playground version '1.0.0'
+using FHIR version '4.0.1'
 
-define "Greeting":
-  'hello'
+valueset "Diabetes": 'http://example.org/fhir/ValueSet/diabetes'
+parameter MeasurementPeriod Interval<DateTime>
 
-define "Score":
-  40 + 2
+context Patient
+
+define "Diabetes Conditions":
+  [Condition: "Diabetes"]
+
+define "Has Diabetes":
+  exists "Diabetes Conditions"
 `;
 
 export function formatJson(value: unknown): string {

--- a/packages/cql/README.md
+++ b/packages/cql/README.md
@@ -9,8 +9,50 @@ const compiled = compile("library Test version '1.0' define X: 1 + 2");
 const result = evaluate(compiled.data!, { expression: "X" });
 ```
 
+SQL-on-FHIR helpers are also exposed from each entry point:
+
+```ts
+import {
+  dataRequirements,
+  emitSql,
+  emitSqlQueryLibrary,
+  emitViewDefinitions,
+  lowerCheck,
+  relationalPlan
+} from "@reasonhealth/cql/node";
+
+const source = `
+library DiabetesMeasure version '1.0.0'
+using FHIR version '4.0.1'
+valueset "Diabetes": 'http://example.org/fhir/ValueSet/diabetes'
+context Patient
+define "Diabetes Conditions":
+  [Condition: "Diabetes"]
+`;
+
+const requirements = dataRequirements(source);
+const report = lowerCheck(source);
+const plan = relationalPlan(source);
+const views = emitViewDefinitions(source);
+const sql = emitSql(source);
+const sqlLibrary = emitSqlQueryLibrary(source);
+```
+
 Exports:
 
 - `@reasonhealth/cql/node` for Node.js.
 - `@reasonhealth/cql/web` for direct browser loading. Call `initCql()` before invoking wrapper functions.
 - `@reasonhealth/cql/bundler` for Vite, webpack, Rollup, and similar bundlers.
+
+Main functions:
+
+- `compile(source, options?)` compiles CQL to ELM JSON.
+- `evaluate(elmJson, options)` evaluates a named ELM expression.
+- `explainParse(source)` and `explainCompile(source, options?)` return human-readable diagnostics.
+- `inspect(source, options?)` summarizes compiled ELM.
+- `dataRequirements(source, options?)` extracts resource, retrieve, terminology, and parameter requirements.
+- `relationalPlan(source, options?)` builds the first-pass relational plan.
+- `lowerCheck(source, options?)` reports whether the library can lower to the target, defaulting to `sql-on-fhir`.
+- `emitViewDefinitions(source, options?)` emits SQL-on-FHIR ViewDefinition JSON.
+- `emitSql(source, options?)` emits SQL text plus the generated ViewDefinition dependencies.
+- `emitSqlQueryLibrary(source, options?)` emits a SQLQuery FHIR Library artifact plus SQL text and ViewDefinition dependencies.

--- a/packages/cql/src/bundler.ts
+++ b/packages/cql/src/bundler.ts
@@ -1,12 +1,13 @@
 import * as wasm from "../wasm-bundler/rh_cql.js";
 import {
+  type AnalyticsOptions,
   type CompileOptions,
   type EvaluateOptions,
   type WasmCallResult,
   toPlainResult
 } from "./common.js";
 
-export type { CompileOptions, EvaluateOptions, WasmCallResult } from "./common.js";
+export type { AnalyticsOptions, CompileOptions, EvaluateOptions, WasmCallResult } from "./common.js";
 
 function compileOptions(options: CompileOptions = {}): wasm.CompileOptions {
   const raw = new wasm.CompileOptions();
@@ -21,6 +22,9 @@ function evaluateOptions(options: EvaluateOptions): wasm.EvaluateOptions {
   raw.parameters_json = JSON.stringify(options.parameters ?? {});
   return raw;
 }
+
+const defaultSqlOnFhirTarget = "sql-on-fhir";
+const defaultCanonicalBase = "https://reason.health/rh/generated/sql-on-fhir";
 
 export function compile<T = unknown>(
   source: string,
@@ -58,6 +62,105 @@ export function evaluate<T = unknown>(
   const elm = normalizeElmInput(elmJson);
   try {
     return toPlainResult<T>(wasm.evaluate_cql_elm(elm, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function inspect<T = unknown>(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(wasm.inspect_cql(source, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function dataRequirements<T = unknown>(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(wasm.cql_data_requirements(source, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function relationalPlan<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_relational_plan(source, options.target ?? defaultSqlOnFhirTarget, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function lowerCheck<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_lower_check(source, options.target ?? defaultSqlOnFhirTarget, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitViewDefinitions<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_view_definitions(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitSql<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_sql(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitSqlQueryLibrary<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_sql_query_library(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
   } finally {
     rawOptions.free();
   }

--- a/packages/cql/src/common.ts
+++ b/packages/cql/src/common.ts
@@ -9,6 +9,11 @@ export interface EvaluateOptions {
   parameters?: Record<string, unknown>;
 }
 
+export interface AnalyticsOptions extends CompileOptions {
+  target?: string;
+  canonicalBase?: string;
+}
+
 export interface WasmCallResult<T = unknown> {
   success: boolean;
   data?: string;

--- a/packages/cql/src/node.ts
+++ b/packages/cql/src/node.ts
@@ -1,13 +1,14 @@
 import { createRequire } from "node:module";
 import type * as Raw from "../wasm-node/rh_cql.js";
 import {
+  type AnalyticsOptions,
   type CompileOptions,
   type EvaluateOptions,
   type WasmCallResult,
   toPlainResult
 } from "./common.js";
 
-export type { CompileOptions, EvaluateOptions, WasmCallResult } from "./common.js";
+export type { AnalyticsOptions, CompileOptions, EvaluateOptions, WasmCallResult } from "./common.js";
 
 const require = createRequire(import.meta.url);
 const wasm = require("../wasm-node/rh_cql.js") as typeof Raw;
@@ -25,6 +26,9 @@ function evaluateOptions(options: EvaluateOptions): Raw.EvaluateOptions {
   raw.parameters_json = JSON.stringify(options.parameters ?? {});
   return raw;
 }
+
+const defaultSqlOnFhirTarget = "sql-on-fhir";
+const defaultCanonicalBase = "https://reason.health/rh/generated/sql-on-fhir";
 
 export function compile<T = unknown>(
   source: string,
@@ -62,6 +66,105 @@ export function evaluate<T = unknown>(
   const elm = normalizeElmInput(elmJson);
   try {
     return toPlainResult<T>(wasm.evaluate_cql_elm(elm, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function inspect<T = unknown>(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(wasm.inspect_cql(source, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function dataRequirements<T = unknown>(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(wasm.cql_data_requirements(source, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function relationalPlan<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_relational_plan(source, options.target ?? defaultSqlOnFhirTarget, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function lowerCheck<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_lower_check(source, options.target ?? defaultSqlOnFhirTarget, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitViewDefinitions<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_view_definitions(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitSql<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_sql(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitSqlQueryLibrary<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_sql_query_library(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
   } finally {
     rawOptions.free();
   }

--- a/packages/cql/src/web.ts
+++ b/packages/cql/src/web.ts
@@ -1,12 +1,13 @@
 import initWasm, * as wasm from "../wasm/rh_cql.js";
 import {
+  type AnalyticsOptions,
   type CompileOptions,
   type EvaluateOptions,
   type WasmCallResult,
   toPlainResult
 } from "./common.js";
 
-export type { CompileOptions, EvaluateOptions, WasmCallResult } from "./common.js";
+export type { AnalyticsOptions, CompileOptions, EvaluateOptions, WasmCallResult } from "./common.js";
 
 export const initCql = initWasm;
 
@@ -23,6 +24,9 @@ function evaluateOptions(options: EvaluateOptions): wasm.EvaluateOptions {
   raw.parameters_json = JSON.stringify(options.parameters ?? {});
   return raw;
 }
+
+const defaultSqlOnFhirTarget = "sql-on-fhir";
+const defaultCanonicalBase = "https://reason.health/rh/generated/sql-on-fhir";
 
 export function compile<T = unknown>(
   source: string,
@@ -60,6 +64,105 @@ export function evaluate<T = unknown>(
   const elm = normalizeElmInput(elmJson);
   try {
     return toPlainResult<T>(wasm.evaluate_cql_elm(elm, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function inspect<T = unknown>(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(wasm.inspect_cql(source, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function dataRequirements<T = unknown>(
+  source: string,
+  options: CompileOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(wasm.cql_data_requirements(source, rawOptions), true);
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function relationalPlan<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_relational_plan(source, options.target ?? defaultSqlOnFhirTarget, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function lowerCheck<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_lower_check(source, options.target ?? defaultSqlOnFhirTarget, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitViewDefinitions<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_view_definitions(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitSql<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_sql(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
+  } finally {
+    rawOptions.free();
+  }
+}
+
+export function emitSqlQueryLibrary<T = unknown>(
+  source: string,
+  options: AnalyticsOptions = {}
+): WasmCallResult<T> {
+  const rawOptions = compileOptions(options);
+  try {
+    return toPlainResult<T>(
+      wasm.cql_emit_sql_query_library(source, options.canonicalBase ?? defaultCanonicalBase, rawOptions),
+      true
+    );
   } finally {
     rawOptions.free();
   }

--- a/packages/cql/test/bundler.test.ts
+++ b/packages/cql/test/bundler.test.ts
@@ -1,0 +1,41 @@
+import { execFileSync } from "node:child_process";
+import { pathToFileURL } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const retrieveSource = `library DiabetesMeasure version '1.0.0'
+using FHIR version '4.0.1'
+valueset "Diabetes": 'http://example.org/fhir/ValueSet/diabetes'
+context Patient
+define "Diabetes Conditions":
+  [Condition: "Diabetes"]
+define "Has Diabetes":
+  exists "Diabetes Conditions"
+`;
+
+describe("@reasonhealth/cql bundler wrapper", () => {
+  it("runs analytics helpers from the bundler dist output", () => {
+    const entry = pathToFileURL(new URL("../dist/bundler.js", import.meta.url).pathname).href;
+    const script = `
+      const cql = await import(${JSON.stringify(entry)});
+      const result = cql.dataRequirements(${JSON.stringify(retrieveSource)});
+      console.log(JSON.stringify({
+        success: result.success,
+        resources: result.value?.resources
+      }));
+    `;
+
+    const stdout = execFileSync(
+      process.execPath,
+      ["--experimental-wasm-modules", "--input-type=module", "--eval", script],
+      {
+        encoding: "utf8"
+      }
+    );
+    const result = JSON.parse(stdout);
+
+    expect(result).toMatchObject({
+      success: true,
+      resources: ["Condition"]
+    });
+  });
+});

--- a/packages/cql/test/node.test.ts
+++ b/packages/cql/test/node.test.ts
@@ -1,7 +1,29 @@
 import { describe, expect, it } from "vitest";
-import { compile, evaluate, explainCompile, explainParse, version } from "../dist/node.js";
+import {
+  compile,
+  dataRequirements,
+  emitSql,
+  emitSqlQueryLibrary,
+  emitViewDefinitions,
+  evaluate,
+  explainCompile,
+  explainParse,
+  inspect,
+  lowerCheck,
+  relationalPlan,
+  version
+} from "../dist/node.js";
 
 const source = "library Test version '1.0' define X: 1 + 2";
+const retrieveSource = `library DiabetesMeasure version '1.0.0'
+using FHIR version '4.0.1'
+valueset "Diabetes": 'http://example.org/fhir/ValueSet/diabetes'
+context Patient
+define "Diabetes Conditions":
+  [Condition: "Diabetes"]
+define "Has Diabetes":
+  exists "Diabetes Conditions"
+`;
 
 describe("@reasonhealth/cql node wrapper", () => {
   it("compiles CQL to ELM JSON", () => {
@@ -48,5 +70,66 @@ describe("@reasonhealth/cql node wrapper", () => {
 
   it("exposes the crate version", () => {
     expect(version()).toMatch(/^\d+\.\d+\.\d+/);
+  });
+
+  it("inspects compiled ELM", () => {
+    const result = inspect(retrieveSource);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({
+      library: "DiabetesMeasure",
+      retrieves: [{ resource: "Condition" }]
+    });
+  });
+
+  it("extracts CQL data requirements", () => {
+    const result = dataRequirements(retrieveSource);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({
+      library: "DiabetesMeasure",
+      resources: ["Condition"]
+    });
+  });
+
+  it("builds a relational plan and lower check", () => {
+    const plan = relationalPlan(retrieveSource);
+    const report = lowerCheck(retrieveSource);
+
+    expect(plan.success).toBe(true);
+    expect(plan.value).toMatchObject({
+      library: "DiabetesMeasure",
+      target: "sql-on-fhir"
+    });
+    expect(report.success).toBe(true);
+    expect(report.value).toMatchObject({
+      target: "sql-on-fhir",
+      supported: true
+    });
+  });
+
+  it("emits SQL-on-FHIR artifacts", () => {
+    const views = emitViewDefinitions(retrieveSource);
+    const sql = emitSql(retrieveSource);
+    const sqlLibrary = emitSqlQueryLibrary(retrieveSource);
+
+    expect(views.success).toBe(true);
+    expect(views.value).toMatchObject({
+      views: [{ name: "condition_view", resource: "Condition" }]
+    });
+    expect(sql.success).toBe(true);
+    expect(sql.value).toMatchObject({
+      views: [{ name: "condition_view" }]
+    });
+    expect(JSON.stringify(sql.value)).toContain("condition_view");
+    expect(sqlLibrary.success).toBe(true);
+    expect(sqlLibrary.value).toMatchObject({
+      library: {
+        resourceType: "Library",
+        type: {
+          coding: [{ code: "sql-query" }]
+        }
+      }
+    });
   });
 });

--- a/packages/cql/test/web.test.ts
+++ b/packages/cql/test/web.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { dataRequirements, initCql, inspect } from "../dist/web.js";
+
+const retrieveSource = `library DiabetesMeasure version '1.0.0'
+using FHIR version '4.0.1'
+valueset "Diabetes": 'http://example.org/fhir/ValueSet/diabetes'
+context Patient
+define "Diabetes Conditions":
+  [Condition: "Diabetes"]
+define "Has Diabetes":
+  exists "Diabetes Conditions"
+`;
+
+let initialized = false;
+
+async function initWebWasm(): Promise<void> {
+  if (initialized) {
+    return;
+  }
+
+  const wasmBytes = readFileSync(new URL("../wasm/rh_cql_bg.wasm", import.meta.url));
+  await initCql(wasmBytes);
+  initialized = true;
+}
+
+describe.sequential("@reasonhealth/cql web wrapper", () => {
+  it("requires initialization before calling helpers", () => {
+    expect(() => inspect(retrieveSource)).toThrow();
+  });
+
+  it("runs analytics helpers after initCql", async () => {
+    await initWebWasm();
+
+    const result = dataRequirements(retrieveSource);
+
+    expect(result.success).toBe(true);
+    expect(result.value).toMatchObject({
+      library: "DiabetesMeasure",
+      resources: ["Condition"]
+    });
+  });
+
+  it("surfaces invalid CQL as a wrapper error", async () => {
+    await initWebWasm();
+
+    const result = dataRequirements("library Broken version '1.0' define X");
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain("Failed to compile CQL");
+    expect(result.value).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What changed

- Reorganized `crates/rh-cql/ARCHITECTURE.md` around the stable CQL engine architecture: parsing, semantic analysis, ELM emission, and native ELM evaluation.
- Kept SQL-on-FHIR documentation together in a final experimental section, including a relational algebra table that distinguishes conventional operators from RH/CQL extensions.
- Exposed the CQL analytics and SQL-on-FHIR helpers through the JS/WASM package surfaces already present on this branch.
- Fixed analytics helper WASM error handling so invalid CQL returns `WasmResult.error` instead of a successful wrapper result containing `{ "success": false }` JSON.
- Added package tests for the web and bundler entry points covering the new helper APIs and web initialization/error behavior.

## Why

The architecture document had mixed stable engine architecture with experimental downstream artifact/runtime strategy and repeated similar diagrams. The PR now makes the core CQL -> typed AST -> ELM -> execution flow easier to review, while clearly marking SQL-on-FHIR support as experimental.

The JS/WASM review feedback also identified a result-shape inconsistency and missing coverage for non-Node package entry points. The follow-up commit addresses those issues directly.

## Validation

- `cargo fmt -p rh-cql --check`
- `pnpm --filter @reasonhealth/cql build`
- `pnpm --filter @reasonhealth/cql test`
