### PR TITLE
fix validator choice and recursive backbone checks

### DIFF
--- a/crates/rh-validator/CONFORMANCE_CI.md
+++ b/crates/rh-validator/CONFORMANCE_CI.md
@@ -17,10 +17,23 @@ This subset validates:
 - UCUM/unit skip-note behavior when terminology is unavailable
 - UCUM/unit terminology path activation when terminology is configured
 
+## Latest Local Run
+
+Last updated: 2026-07-11
+
+```text
+Command: cargo test -p rh-validator --test conformance_quick_wins_test
+Result: 72 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
 ## Scenario Traceability Matrix
 
 | Scenario | Evidence |
 |----------|----------|
+| Invalid concrete choice suffix is rejected | `base_profile_rejects_invalid_concrete_choice_suffix` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |
+| Unknown nested backbone property is rejected | `base_profile_rejects_unknown_nested_backbone_property` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |
+| Unknown recursively nested backbone property is rejected | `base_profile_rejects_unknown_deeply_nested_backbone_property` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |
+| Valid nested backbone property remains accepted | `base_profile_accepts_valid_nested_backbone_property` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |
 | Security checks disabled uses informational severity | `security_checks_disabled_reports_information` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |
 | Security checks enabled uses error severity | `security_checks_enabled_reports_error` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |
 | Duplicate fullUrl in Bundle is reported | `document_bundle_duplicate_fullurl_is_reported` in `crates/rh-validator/tests/conformance_quick_wins_test.rs` |

--- a/crates/rh-validator/src/rules.rs
+++ b/crates/rh-validator/src/rules.rs
@@ -26,6 +26,7 @@ pub struct UnknownPropertyPlan {
     pub resource_roots: HashSet<String>,
     pub allowed_children: HashMap<String, HashSet<String>>,
     pub allowed_choice_prefixes: HashMap<String, Vec<String>>,
+    pub allowed_choice_fields: HashMap<String, HashSet<String>>,
 }
 
 #[derive(Debug, Clone)]
@@ -310,7 +311,7 @@ impl RuleCompiler {
 
             let rules = Arc::new(CompiledValidationRules {
                 profile_url: profile_url.clone(),
-                unknown_properties: build_unknown_property_plan(&element_paths),
+                unknown_properties: build_unknown_property_plan(&element_paths, &type_rules),
                 element_paths,
                 cardinality_rules,
                 type_rules,
@@ -334,7 +335,7 @@ impl RuleCompiler {
 
         let rules = Arc::new(CompiledValidationRules {
             profile_url: profile_url.clone(),
-            unknown_properties: build_unknown_property_plan(&element_paths),
+            unknown_properties: build_unknown_property_plan(&element_paths, &type_rules),
             element_paths,
             cardinality_rules,
             type_rules,
@@ -377,10 +378,14 @@ impl RuleCompiler {
     }
 }
 
-fn build_unknown_property_plan(element_paths: &[String]) -> UnknownPropertyPlan {
+fn build_unknown_property_plan(
+    element_paths: &[String],
+    type_rules: &[TypeRule],
+) -> UnknownPropertyPlan {
     let mut resource_roots = HashSet::new();
     let mut allowed_children: HashMap<String, HashSet<String>> = HashMap::new();
     let mut allowed_choice_prefixes: HashMap<String, Vec<String>> = HashMap::new();
+    let mut allowed_choice_fields: HashMap<String, HashSet<String>> = HashMap::new();
 
     for element_path in element_paths {
         let parts: Vec<&str> = element_path.split('.').collect();
@@ -400,9 +405,17 @@ fn build_unknown_property_plan(element_paths: &[String]) -> UnknownPropertyPlan 
             .unwrap_or(parts[parts.len() - 1]);
         if let Some(prefix) = child.strip_suffix("[x]") {
             allowed_choice_prefixes
-                .entry(parent)
+                .entry(parent.clone())
                 .or_default()
                 .push(prefix.to_string());
+            if let Some(rule) = type_rules.iter().find(|rule| rule.path == *element_path) {
+                let fields = allowed_choice_fields.entry(parent.clone()).or_default();
+                for type_code in &rule.types {
+                    if let Some(field_name) = choice_field_name(prefix, type_code) {
+                        fields.insert(field_name);
+                    }
+                }
+            }
         } else {
             allowed_children
                 .entry(parent)
@@ -415,7 +428,23 @@ fn build_unknown_property_plan(element_paths: &[String]) -> UnknownPropertyPlan 
         resource_roots,
         allowed_children,
         allowed_choice_prefixes,
+        allowed_choice_fields,
     }
+}
+
+fn choice_field_name(prefix: &str, type_code: &str) -> Option<String> {
+    let type_name = type_code
+        .rsplit(['/', '.'])
+        .next()
+        .filter(|name| !name.is_empty())?;
+    let mut chars = type_name.chars();
+    let first = chars.next()?;
+    Some(format!(
+        "{}{}{}",
+        prefix,
+        first.to_ascii_uppercase(),
+        chars.as_str()
+    ))
 }
 
 fn add_differential_binding_rules(

--- a/crates/rh-validator/src/validator.rs
+++ b/crates/rh-validator/src/validator.rs
@@ -5643,6 +5643,7 @@ fn validate_unknown_properties_against_rules(
         resource_type,
         &rules.unknown_properties.allowed_children,
         &rules.unknown_properties.allowed_choice_prefixes,
+        &rules.unknown_properties.allowed_choice_fields,
         &mut issues,
     );
     issues
@@ -5653,11 +5654,15 @@ fn validate_unknown_properties_recursive(
     path: &str,
     allowed_children: &HashMap<String, HashSet<String>>,
     allowed_choice_prefixes: &HashMap<String, Vec<String>>,
+    allowed_choice_fields: &HashMap<String, HashSet<String>>,
     issues: &mut Vec<ValidationIssue>,
 ) {
     match value {
         Value::Object(obj) => {
-            let Some(allowed) = allowed_children.get(path) else {
+            let Some(allowed_path) = resolve_allowed_children_path(path, allowed_children) else {
+                return;
+            };
+            let Some(allowed) = allowed_children.get(&allowed_path) else {
                 return;
             };
 
@@ -5665,12 +5670,19 @@ fn validate_unknown_properties_recursive(
                 if key == "resourceType" || key.starts_with('_') {
                     continue;
                 }
-                let known_child = allowed.contains(key)
-                    || allowed_choice_prefixes.get(path).is_some_and(|prefixes| {
-                        prefixes
-                            .iter()
-                            .any(|prefix| key.starts_with(prefix) && key.len() > prefix.len())
-                    });
+                let known_choice_child =
+                    if let Some(fields) = allowed_choice_fields.get(&allowed_path) {
+                        fields.contains(key)
+                    } else {
+                        allowed_choice_prefixes
+                            .get(&allowed_path)
+                            .is_some_and(|prefixes| {
+                                prefixes.iter().any(|prefix| {
+                                    key.starts_with(prefix) && key.len() > prefix.len()
+                                })
+                            })
+                    };
+                let known_child = allowed.contains(key) || known_choice_child;
                 if !known_child {
                     issues.push(
                         ValidationIssue::error(
@@ -5686,6 +5698,7 @@ fn validate_unknown_properties_recursive(
                     &format!("{path}.{key}"),
                     allowed_children,
                     allowed_choice_prefixes,
+                    allowed_choice_fields,
                     issues,
                 );
             }
@@ -5697,12 +5710,39 @@ fn validate_unknown_properties_recursive(
                     path,
                     allowed_children,
                     allowed_choice_prefixes,
+                    allowed_choice_fields,
                     issues,
                 );
             }
         }
         _ => {}
     }
+}
+
+fn resolve_allowed_children_path(
+    path: &str,
+    allowed_children: &HashMap<String, HashSet<String>>,
+) -> Option<String> {
+    if allowed_children.contains_key(path) {
+        return Some(path.to_string());
+    }
+
+    let mut parts: Vec<&str> = path.split('.').collect();
+    while parts.len() > 2 {
+        let duplicate_index = parts
+            .windows(2)
+            .position(|window| window[0] == window[1])
+            .map(|index| index + 1);
+        let index = duplicate_index?;
+
+        parts.remove(index);
+        let normalized = parts.join(".");
+        if allowed_children.contains_key(&normalized) {
+            return Some(normalized);
+        }
+    }
+
+    None
 }
 
 fn get_value_at_path<'a>(resource: &'a Value, path: &str) -> Option<&'a Value> {

--- a/crates/rh-validator/tests/conformance_quick_wins_test.rs
+++ b/crates/rh-validator/tests/conformance_quick_wins_test.rs
@@ -2424,7 +2424,7 @@ fn base_profile_rejects_unknown_resource_property() {
 
 #[test]
 fn base_profile_rejects_invalid_concrete_choice_suffix() {
-    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+    let validator = validator_with_observation_choice_profile();
 
     let observation = json!({
         "resourceType": "Observation",
@@ -2453,7 +2453,7 @@ fn base_profile_rejects_invalid_concrete_choice_suffix() {
 
 #[test]
 fn base_profile_rejects_unknown_nested_backbone_property() {
-    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+    let validator = validator_with_plan_definition_backbone_profile();
 
     let plan_definition = json!({
         "resourceType": "PlanDefinition",
@@ -2480,7 +2480,7 @@ fn base_profile_rejects_unknown_nested_backbone_property() {
 
 #[test]
 fn base_profile_rejects_unknown_deeply_nested_backbone_property() {
-    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+    let validator = validator_with_plan_definition_backbone_profile();
 
     let plan_definition = json!({
         "resourceType": "PlanDefinition",
@@ -2510,7 +2510,7 @@ fn base_profile_rejects_unknown_deeply_nested_backbone_property() {
 
 #[test]
 fn base_profile_accepts_valid_nested_backbone_property() {
-    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+    let validator = validator_with_plan_definition_backbone_profile();
 
     let plan_definition = json!({
         "resourceType": "PlanDefinition",
@@ -2535,6 +2535,96 @@ fn base_profile_accepts_valid_nested_backbone_property() {
             && i.code == IssueCode::Structure
             && i.path.as_deref() == Some("PlanDefinition.action.relatedAction")
     }));
+}
+
+fn validator_with_observation_choice_profile() -> FhirValidator {
+    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+    validator.register_profile(&json!({
+        "resourceType": "StructureDefinition",
+        "url": "http://hl7.org/fhir/StructureDefinition/Observation",
+        "name": "Observation",
+        "type": "Observation",
+        "snapshot": {
+            "element": [
+                {"id": "Observation", "path": "Observation", "min": 0, "max": "*"},
+                {"id": "Observation.status", "path": "Observation.status", "min": 1, "max": "1"},
+                {"id": "Observation.code", "path": "Observation.code", "min": 1, "max": "1"},
+                {
+                    "id": "Observation.value[x]",
+                    "path": "Observation.value[x]",
+                    "min": 0,
+                    "max": "1",
+                    "type": [
+                        {"code": "Quantity"},
+                        {"code": "CodeableConcept"},
+                        {"code": "string"},
+                        {"code": "boolean"},
+                        {"code": "integer"},
+                        {"code": "Range"},
+                        {"code": "Ratio"},
+                        {"code": "SampledData"},
+                        {"code": "time"},
+                        {"code": "dateTime"},
+                        {"code": "Period"}
+                    ]
+                }
+            ]
+        }
+    }));
+    validator
+}
+
+fn validator_with_plan_definition_backbone_profile() -> FhirValidator {
+    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+    validator.register_profile(&json!({
+        "resourceType": "StructureDefinition",
+        "url": "http://hl7.org/fhir/StructureDefinition/PlanDefinition",
+        "name": "PlanDefinition",
+        "type": "PlanDefinition",
+        "snapshot": {
+            "element": [
+                {"id": "PlanDefinition", "path": "PlanDefinition", "min": 0, "max": "*"},
+                {"id": "PlanDefinition.status", "path": "PlanDefinition.status", "min": 1, "max": "1"},
+                {"id": "PlanDefinition.action", "path": "PlanDefinition.action", "min": 0, "max": "*"},
+                {"id": "PlanDefinition.action.id", "path": "PlanDefinition.action.id", "min": 0, "max": "1"},
+                {
+                    "id": "PlanDefinition.action.action",
+                    "path": "PlanDefinition.action.action",
+                    "min": 0,
+                    "max": "*"
+                },
+                {
+                    "id": "PlanDefinition.action.relatedAction",
+                    "path": "PlanDefinition.action.relatedAction",
+                    "min": 0,
+                    "max": "*"
+                },
+                {
+                    "id": "PlanDefinition.action.relatedAction.actionId",
+                    "path": "PlanDefinition.action.relatedAction.actionId",
+                    "min": 1,
+                    "max": "1"
+                },
+                {
+                    "id": "PlanDefinition.action.relatedAction.relationship",
+                    "path": "PlanDefinition.action.relatedAction.relationship",
+                    "min": 1,
+                    "max": "1"
+                },
+                {
+                    "id": "PlanDefinition.action.relatedAction.offset[x]",
+                    "path": "PlanDefinition.action.relatedAction.offset[x]",
+                    "min": 0,
+                    "max": "1",
+                    "type": [
+                        {"code": "Duration"},
+                        {"code": "Range"}
+                    ]
+                }
+            ]
+        }
+    }));
+    validator
 }
 
 #[test]

--- a/crates/rh-validator/tests/conformance_quick_wins_test.rs
+++ b/crates/rh-validator/tests/conformance_quick_wins_test.rs
@@ -2423,6 +2423,121 @@ fn base_profile_rejects_unknown_resource_property() {
 }
 
 #[test]
+fn base_profile_rejects_invalid_concrete_choice_suffix() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+
+    let observation = json!({
+        "resourceType": "Observation",
+        "status": "final",
+        "code": {
+            "coding": [{
+                "system": "http://loinc.org",
+                "code": "8302-2"
+            }]
+        },
+        "valueNotAType": "72"
+    });
+
+    let result = validator.validate_auto(&observation).unwrap();
+
+    assert!(
+        result.issues.iter().any(|i| {
+            i.severity == Severity::Error
+                && i.code == IssueCode::Structure
+                && i.message.contains("valueNotAType")
+        }),
+        "expected valueNotAType structure error, got: {:?}",
+        result.issues
+    );
+}
+
+#[test]
+fn base_profile_rejects_unknown_nested_backbone_property() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+
+    let plan_definition = json!({
+        "resourceType": "PlanDefinition",
+        "status": "draft",
+        "action": [{
+            "id": "assess",
+            "relatedAction": [{
+                "actionId": "other-action",
+                "relationship": "before-start",
+                "description": "R4 relatedAction has no description field"
+            }]
+        }]
+    });
+
+    let result = validator.validate_auto(&plan_definition).unwrap();
+
+    assert!(result.issues.iter().any(|i| {
+        i.severity == Severity::Error
+            && i.code == IssueCode::Structure
+            && i.message.contains("description")
+            && i.path.as_deref() == Some("PlanDefinition.action.relatedAction")
+    }));
+}
+
+#[test]
+fn base_profile_rejects_unknown_deeply_nested_backbone_property() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+
+    let plan_definition = json!({
+        "resourceType": "PlanDefinition",
+        "status": "draft",
+        "action": [{
+            "id": "parent",
+            "action": [{
+                "id": "child",
+                "relatedAction": [{
+                    "actionId": "other-action",
+                    "relationship": "before-start",
+                    "description": "R4 relatedAction has no description field"
+                }]
+            }]
+        }]
+    });
+
+    let result = validator.validate_auto(&plan_definition).unwrap();
+
+    assert!(result.issues.iter().any(|i| {
+        i.severity == Severity::Error
+            && i.code == IssueCode::Structure
+            && i.message.contains("description")
+            && i.path.as_deref() == Some("PlanDefinition.action.action.relatedAction")
+    }));
+}
+
+#[test]
+fn base_profile_accepts_valid_nested_backbone_property() {
+    let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
+
+    let plan_definition = json!({
+        "resourceType": "PlanDefinition",
+        "status": "draft",
+        "action": [{
+            "id": "assess",
+            "relatedAction": [{
+                "actionId": "other-action",
+                "relationship": "before-start",
+                "offsetDuration": {
+                    "value": 1,
+                    "unit": "day"
+                }
+            }]
+        }]
+    });
+
+    let result = validator.validate_auto(&plan_definition).unwrap();
+
+    assert!(!result.issues.iter().any(|i| {
+        i.severity == Severity::Error
+            && i.code == IssueCode::Structure
+            && i.path.as_deref() == Some("PlanDefinition.action.relatedAction")
+    }));
+}
+
+#[test]
 fn primitive_date_format_rejects_non_date_text() {
     let validator = FhirValidator::new(FhirVersion::R4, None).unwrap();
 


### PR DESCRIPTION
Fixes two generic R4 resource validation gaps in rh-validator:

  - Rejects invalid concrete choice-element fields by deriving allowed JSON field names from
    snapshot type.code metadata.

  - Improves recursive backbone unknown-property validation so nested/repeated backbone
    elements are checked against the correct snapshot path.

  This intentionally does not add resource-specific validators or package validation changes.

  Concrete Examples

  Choice-element validation:

```
  {
    "resourceType": "Observation",
    "status": "final",
    "code": {
      "coding": [{ "system": "http://loinc.org", "code": "8302-2" }]
    },
    "valueNotAType": "72"
  }

```
  Before: accepted because valueNotAType matched the value[x] prefix.
  After: reports an unknown/invalid structure error because NotAType is not an allowed
  Observation.value[x] type suffix.

  Nested backbone validation:

  ```
{
    "resourceType": "PlanDefinition",
    "status": "draft",
    "action": [{
      "id": "parent",
      "action": [{
        "id": "child",
        "relatedAction": [{
          "actionId": "other-action",
          "relationship": "before-start",
          "description": "not valid in R4"
        }]
      }]
    }]
  }
```

  Before: description under deeply nested action.relatedAction could be missed.
  After: reports an unknown property at PlanDefinition.action.action.relatedAction.

  Valid nested R4 fields still pass:

 ```
 {
    "relatedAction": [{
      "actionId": "other-action",
      "relationship": "before-start",
      "offsetDuration": { "value": 1, "unit": "day" }
    }]
  }

```
  Validation

  cargo test -p rh-validator --test conformance_quick_wins_test
  cargo clippy -p rh-validator --all-targets -- -D warnings

