### PR TITLE
Fix CQL parser conformance gaps

### DIFF
--- a/apps/rh-cli/src/cql.rs
+++ b/apps/rh-cli/src/cql.rs
@@ -8,7 +8,9 @@ use std::io::{self, Read};
 use std::path::{Path, PathBuf};
 use tracing::{error, info};
 
-use crate::output::{Envelope, ExitCode, OutputContext, OutputFormat};
+use crate::output::{
+    error_envelope, Envelope, EnvelopeError, ExitCode, OutputContext, OutputFormat,
+};
 
 use rh_cql::analytics::{
     data_requirements, emit_measure_runtime_manifest, emit_sql_query_library, emit_sql_text,
@@ -783,17 +785,67 @@ fn build_compiler_options(
     opts
 }
 
-/// Print a fatal pipeline error to stderr and exit with the parse-error code.
-fn exit_on_compile_error(e: impl std::fmt::Display) -> ! {
-    eprintln!("✗ {e}");
+fn parse_error_location(message: &str) -> Option<(usize, usize)> {
+    let (_, location) = message.split_once("line ")?;
+    let (line, location) = location.split_once(", column ")?;
+    let column = location
+        .split(|character: char| !character.is_ascii_digit())
+        .next()?;
+    Some((line.parse().ok()?, column.parse().ok()?))
+}
+
+fn compile_envelope_error(
+    code: &'static str,
+    message: impl Into<String>,
+    location: Option<(usize, usize)>,
+) -> EnvelopeError {
+    let error = EnvelopeError::new(code, message);
+    match location {
+        Some((line, column)) => error.with_span(format!("{line}:{column}")),
+        None => error,
+    }
+}
+
+fn exit_with_compile_envelope(
+    ctx: &OutputContext,
+    errors: Vec<EnvelopeError>,
+    human_report: impl FnOnce(),
+) -> ! {
+    if ctx.is_json() {
+        let envelope = error_envelope(errors, "cql compile");
+        if let Err(error) = print_envelope(ctx, &envelope) {
+            eprintln!("error: {error}");
+        }
+    } else {
+        human_report();
+    }
     ExitCode::ParseError.exit();
 }
 
+/// Print a fatal pipeline error and exit with the parse-error code.
+fn exit_on_compile_error(e: impl std::fmt::Display, ctx: &OutputContext) -> ! {
+    let message = e.to_string();
+    let error = compile_envelope_error("parse_error", &message, parse_error_location(&message));
+    exit_with_compile_envelope(ctx, vec![error], || eprintln!("✗ {message}"));
+}
+
 /// Report a failed (non-success) compilation outcome and exit.
-fn exit_on_compile_failure(outcome: &impl ElmOutcome) -> ! {
-    let err = report_compile_failure(outcome.errors(), outcome.warnings());
-    error!("{err}");
-    ExitCode::ParseError.exit();
+fn exit_on_compile_failure(outcome: &impl ElmOutcome, ctx: &OutputContext) -> ! {
+    let errors = outcome
+        .errors()
+        .iter()
+        .map(|diagnostic| {
+            let location = diagnostic
+                .span
+                .as_ref()
+                .map(|span| (span.start.line, span.start.column));
+            compile_envelope_error("compilation_error", &diagnostic.message, location)
+        })
+        .collect();
+    exit_with_compile_envelope(ctx, errors, || {
+        let err = report_compile_failure(outcome.errors(), outcome.warnings());
+        error!("{err}");
+    });
 }
 
 /// Serialize an ELM outcome to JSON, honoring compact mode.
@@ -824,10 +876,10 @@ fn compile_cql(req: &CompileRequest, ctx: &OutputContext) -> Result<()> {
             None,
         ) {
             Ok(r) => r,
-            Err(e) => exit_on_compile_error(e),
+            Err(e) => exit_on_compile_error(e, ctx),
         };
         if !result.is_success() {
-            exit_on_compile_failure(&result);
+            exit_on_compile_failure(&result, ctx);
         }
         let json = serialize_elm(&result, req.compact)?;
         let sm_json = result
@@ -838,11 +890,11 @@ fn compile_cql(req: &CompileRequest, ctx: &OutputContext) -> Result<()> {
         let result =
             match compile_with_search_dirs(&source, &req.input, &req.lib_path, Some(options)) {
                 Ok(r) => r,
-                Err(e) => exit_on_compile_error(e),
+                Err(e) => exit_on_compile_error(e, ctx),
             }
             .result;
         if !result.is_success() {
-            exit_on_compile_failure(&result);
+            exit_on_compile_failure(&result, ctx);
         }
         let json = serialize_elm(&result, req.compact)?;
         (json, None)

--- a/apps/rh-cli/tests/cql_integration_test.rs
+++ b/apps/rh-cli/tests/cql_integration_test.rs
@@ -9,6 +9,16 @@ fn rh_cmd() -> Command {
     Command::new(PathBuf::from(bin_path))
 }
 
+fn compile_json(input: &str, exit_code: i32) -> serde_json::Value {
+    let assert = rh_cmd()
+        .args(["--format", "json", "cql", "compile", "-"])
+        .write_stdin(input)
+        .assert()
+        .code(exit_code)
+        .stderr(predicate::str::is_empty());
+    serde_json::from_slice(&assert.get_output().stdout).expect("stdout must be one JSON value")
+}
+
 // ---------------------------------------------------------------------------
 // Fixtures
 // ---------------------------------------------------------------------------
@@ -321,6 +331,8 @@ define Result: H.Answer + 1
 // ---------------------------------------------------------------------------
 
 const INVALID_CQL: &str = "this is not valid CQL !!!###";
+
+const NESTED_SYNTAX_ERROR_CQL: &str = "library Bad\ndefine X: true and (false or )";
 
 /// CQL that parses correctly but contains a semantic error (undefined reference).
 /// This causes `validate` to return a `ValidationResult` with errors rather
@@ -670,6 +682,42 @@ fn test_compile_exits_nonzero_on_invalid_cql() {
         .failure()
         // Error message is reported on stderr
         .stderr(predicate::str::contains("✗").or(predicate::str::contains("error")));
+}
+
+#[test]
+fn test_compile_syntax_error_uses_parse_exit_code_and_location() {
+    rh_cmd()
+        .args(["cql", "compile", "-"])
+        .write_stdin(NESTED_SYNTAX_ERROR_CQL)
+        .assert()
+        .code(4)
+        .stderr(predicate::str::contains("line 2, column 30"));
+}
+
+#[test]
+fn test_compile_syntax_error_json_envelope() {
+    let envelope = compile_json(NESTED_SYNTAX_ERROR_CQL, 4);
+
+    assert_eq!(envelope["ok"], false);
+    assert!(envelope.get("result").is_none());
+    assert_eq!(envelope["errors"].as_array().map(Vec::len), Some(1));
+    assert_eq!(envelope["errors"][0]["code"], "parse_error");
+    assert!(envelope["errors"][0]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("line 2, column 30")));
+    assert_eq!(envelope["errors"][0]["span"], "2:30");
+    assert_eq!(envelope["meta"]["command"], "cql compile");
+    assert!(envelope["meta"]["version"].is_string());
+}
+
+#[test]
+fn test_compile_valid_cql_json_success_envelope() {
+    let envelope = compile_json(SIMPLE_CQL, 0);
+
+    assert_eq!(envelope["ok"], true);
+    assert!(envelope["result"].is_object());
+    assert!(envelope["errors"].as_array().is_some_and(Vec::is_empty));
+    assert_eq!(envelope["meta"]["command"], "cql compile");
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rh-cql/CONFORMANCE.md
+++ b/crates/rh-cql/CONFORMANCE.md
@@ -1,6 +1,6 @@
 # rh-cql Conformance
 
-Last updated: 2026-06-23
+Last updated: 2026-07-15
 
 This is the current high-level conformance summary for `rh-cql`. It answers
 three questions:
@@ -22,14 +22,14 @@ The strongest spec-facing signal is the HL7 CQL expression test suite:
 | Signal | Result |
 |---|---:|
 | HL7 parsed expression cases | 1 426 |
-| Correct evaluated results | 1 241 |
+| Correct evaluated results | 1 258 |
 | Invalid expressions correctly rejected | 28 |
 | Wrong answers | 0 |
 | Skipped expected-output/expression cases | 45 |
-| Compile errors | 89 |
+| Compile errors | 72 |
 | Runtime eval errors | 23 |
 | Invalid expressions incorrectly accepted | 0 |
-| Remaining unimplemented outcomes | 112 |
+| Remaining unimplemented outcomes | 95 |
 
 Interpretation:
 
@@ -39,13 +39,35 @@ Interpretation:
 - Invalid-input enforcement is clean in this suite: invalid expressions are not
   being accepted as successes.
 
+### 2026-07-15 Parser Conformance Checkpoints
+
+The command `cargo test -p rh-cql --test hl7_eval_tests -- --nocapture` produced:
+
+| Checkpoint | Pass | Compile Error | Eval Error | Fail | Skip |
+|---|---:|---:|---:|---:|---:|
+| Baseline | 1 241 | 89 | 23 | 0 | 45 |
+| Canonical null/Boolean tests | 1 241 | 89 | 23 | 0 | 45 |
+| Zero-offset temporal relationships | 1 258 | 72 | 23 | 0 | 45 |
+| Logical precedence and parse diagnostics | 1 258 | 72 | 23 | 0 | 45 |
+
+- Canonical source `is null`, `is true`, and `is false` forms did not change the suite totals
+  because the bundled fixtures use function-call forms. Focused tests cover canonical AST, ELM,
+  evaluation, negation, named-type controls, and legacy ELM compatibility.
+- All 17 affected interval/date-time cases moved from compile errors to passing results. Focused
+  tests cover all eight zero-offset relationship spellings, point and interval operands, and
+  optional `month of` and `hour of` precision.
+- Logical-precedence regressions cover all 12 ordered mixed pairings of `and`, `or`, `xor`, and
+  `implies`, left-associative chains, parenthesized overrides, a function body, and a query
+  `where` clause. Parse-diagnostic tests cover committed nested locations and human/JSON CLI
+  failures without changing the conformance totals.
+
 ## Three-Engine Matrix
 
 The same 1 426 HL7 rows are also used as an implementation comparison matrix.
 
 | Implementation | What It Measures | Pass | Compile Error | Eval Error | Fail | Skip |
 |---|---|---:|---:|---:|---:|---:|
-| `rh-cql` | Compile and evaluate with Reason Health | 1 269 | 89 | 23 | 0 | 45 |
+| `rh-cql` | Compile and evaluate with Reason Health | 1 286 | 72 | 23 | 0 | 45 |
 | Java CQL-to-ELM | Translate CQL to ELM with CQFramework Java | 1 410 | 16 | 0 | 0 | 0 |
 | JavaScript `cql-execution` | Execute `rh-cql` ELM in JS | 601 | 89 | 502 | 68 | 166 |
 
@@ -145,7 +167,7 @@ just check
 
 At a high level, the remaining conformance work is:
 
-- Reduce the 89 HL7 compile errors.
+- Reduce the 72 HL7 compile errors.
 - Reduce the 23 HL7 runtime eval errors.
 - Expand Java-inclusive corpus triage when source validity matters.
 - Add more FHIR bundle evaluation cases once retrieve/query semantics are ready.

--- a/crates/rh-cql/SPEC_COVERAGE.md
+++ b/crates/rh-cql/SPEC_COVERAGE.md
@@ -53,9 +53,15 @@ A ➖ in **Parse** means the operator is invoked with function-call syntax in CQ
 
 > Counts apply to the **source stage only** (➖ not counted as either present or absent).  
 > **✅ Impl** = operators with full end-to-end evaluation support (Eval count); **Coverage %** = ✅ Impl / total operators.  
-> Last updated: wave-2 (2026-03-09) — added Precision, LowBoundary, HighBoundary, TimeOfDay, Size, Product, GeometricMean, fixed Coalesce list-overload, registered aggregate/nullological semantic signatures.
-> 2026-06-12 — clinical age operators complete: `AgeIn<unit>[At]` (patient context) and `CalculateAgeIn<unit>[At]` (explicit birthDate); Clinical 0% → 100%, total 161 → 169 (97%).
-> 2026-06-12 (wave 2) — task 2.5: Ratio literals (`1 'mg' : 2 'mL'`, `1:128`) parse/emit/eval end-to-end; ELM `Quantity`/`Ratio` nodes evaluate; `ToRatio`, 1-arg `Combine`, `Message` (Error severity raises, others log via `tracing`), `Children`, `Descendants` implemented via FunctionRef dispatch. Error category 0% → 100%; total 170/175.
+>
+> - **2026-07-15** — Canonical source `is null`, `is true`, and `is false` forms lower to unary
+>   AST/ELM nodes; `is not` lowers to `Not` around the canonical test. Focused tests cover positive,
+>   negative, named-type, and legacy ELM paths.
+> - **2026-07-15** — Zero-offset temporal relationships now parse, emit canonical ELM, and
+>   evaluate across point/interval combinations. Logical precedence now follows CQL 1.5.3 as
+>   `implies`, `or`/`xor`, `and`, then comparisons, with all ordered mixed pairings covered.
+> - **2026-06-12** — Clinical age operators reached 100%; Ratio literals, `ToRatio`, one-argument
+>   `Combine`, `Message`, `Children`, and `Descendants` brought total coverage to 170/175 (97%).
 
 ---
 
@@ -65,11 +71,11 @@ A ➖ in **Parse** means the operator is invoked with function-call syntax in CQ
 
 | Operator | CQL Syntax | Parse | Semantic | Emit | Eval | Notes |
 |----------|-----------|-------|----------|------|------|-------|
-| And | `A and B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::And` |
-| Or | `A or B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Or` |
+| And | `A and B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::And`; mixed-pairing and left-associativity parser/eval evidence cited above |
+| Or | `A or B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Or`; mixed-pairing and left-associativity parser/eval evidence cited above |
 | Not | `not A` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::Not` |
-| Xor | `A xor B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Xor` |
-| Implies | `A implies B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Implies` |
+| Xor | `A xor B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Xor`; same precedence as `or`, left-associative, with parser/eval evidence cited above |
+| Implies | `A implies B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Implies`; lowest logical precedence and left-associative per CQL 1.5.3 reference grammar, with parser/eval evidence cited above |
 
 ---
 
@@ -79,9 +85,9 @@ A ➖ in **Parse** means the operator is invoked with function-call syntax in CQ
 
 | Operator | CQL Syntax | Parse | Semantic | Emit | Eval | Notes |
 |----------|-----------|-------|----------|------|------|-------|
-| IsNull | `A is null` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::IsNull` |
-| IsTrue | `A is true` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::IsTrue` |
-| IsFalse | `A is false` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::IsFalse` |
+| IsNull | `A is null` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::IsNull`; parser `test_literal_is_expressions_use_canonical_unary_operators`; ELM `test_literal_is_expressions_emit_canonical_elm`; eval `eval_literal_is_expressions` |
+| IsTrue | `A is true` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::IsTrue`; canonical parser/ELM/eval tests listed for `IsNull` cover all three forms |
+| IsFalse | `A is false` | ✅ | ✅ | ✅ | ✅ | `UnaryOperator::IsFalse`; canonical parser/ELM/eval tests listed for `IsNull` cover all three forms and their negations |
 | Coalesce | `Coalesce(A, B, …)` | ➖ | ✅ | ✅ | ✅ | `Expression::Coalesce`; list-overload handled in eval; signature registered in `operators.rs` (wave-2) |
 
 ---
@@ -174,10 +180,10 @@ A ➖ in **Parse** means the operator is invoked with function-call syntax in CQ
 | DateTime | `DateTime(y, m, d, …)` | ➖ | ❌ | ✅ | ✅ | `Expression::DateTime` constructor |
 | Time | `Time(h, m, s, ms)` | ➖ | ❌ | ✅ | ✅ | `Expression::Time` constructor |
 | SameAs | `A same as B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::SameAs`; datetime timing |
-| SameOrBefore | `A same or before B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::SameOrBefore` |
-| SameOrAfter | `A same or after B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::SameOrAfter` |
-| Before | `A before B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::Before`; via timing expression |
-| After | `A after B` | ✅ | ✅ | ✅ | ✅ | `BinaryOperator::After`; via timing expression |
+| SameOrBefore | `A same or before B` | ✅ | ✅ | ✅ | ✅ | Zero-offset `on or before` / `before or on` lower to `SameOrBefore`; point/interval and precision evidence in parser, emitter, evaluator, and 17-case HL7 regression coverage |
+| SameOrAfter | `A same or after B` | ✅ | ✅ | ✅ | ✅ | Zero-offset `on or after` / `after or on` lower to `SameOrAfter`; point/interval and precision evidence in parser, emitter, evaluator, and 17-case HL7 regression coverage |
+| Before | `A before B` | ✅ | ✅ | ✅ | ✅ | Exclusive zero-offset timing expression; point/interval and precision evidence in focused parser/emitter tests |
+| After | `A after B` | ✅ | ✅ | ✅ | ✅ | Exclusive zero-offset timing expression; point/interval and precision evidence in focused parser/emitter tests |
 | DurationBetween | `duration in P between A and B` | ✅ | ✅ | ✅ | ✅ | `Expression::DurationBetween` |
 | DifferenceBetween | `difference in P between A and B` | ✅ | ❌ | ✅ | ✅ | `Expression::DifferenceBetween`; no operator sig |
 | DateFrom | `date from A` | ✅ | ✅ | ✅ | ✅ | unary signature in `operators.rs` + dispatch in `eval/engine.rs`; covered by `tests/eval_integration_tests.rs::eval_date_from_and_time_from` |

--- a/crates/rh-cql/src/emit/operators.rs
+++ b/crates/rh-cql/src/emit/operators.rs
@@ -1,6 +1,9 @@
 use crate::elm;
 use crate::emit::ElmEmitter;
-use crate::parser::ast::{BinaryOperator, DateTimePrecision, TernaryOperator, UnaryOperator};
+use crate::parser::ast::{
+    BinaryOperator, DateTimePrecision, SameDirection, TernaryOperator, TimingDirection,
+    TimingPhrase, UnaryOperator,
+};
 use crate::semantics::typed_ast::{
     TypedDateTimeComponentFrom, TypedExpression, TypedNode, TypedTimingExpression,
 };
@@ -509,7 +512,7 @@ pub fn emit_timing_expression(
     };
 
     match &te.timing {
-        crate::parser::ast::TimingPhrase::RelativeTiming {
+        TimingPhrase::RelativeTiming {
             left_boundary: None,
             offset: None,
             direction,
@@ -518,23 +521,21 @@ pub fn emit_timing_expression(
         } => {
             let precision = precision.map(|p| datetime_precision_str(p).to_string());
             match direction {
-                crate::parser::ast::TimingDirection::Before
-                | crate::parser::ast::TimingDirection::BeforeOrOn => {
+                TimingDirection::Before => {
                     return elm::Expression::Before(time_binary(precision));
                 }
-                crate::parser::ast::TimingDirection::After
-                | crate::parser::ast::TimingDirection::AfterOrOn => {
+                TimingDirection::After => {
                     return elm::Expression::After(time_binary(precision));
                 }
-                crate::parser::ast::TimingDirection::OnOrBefore => {
+                TimingDirection::OnOrBefore | TimingDirection::BeforeOrOn => {
                     return elm::Expression::SameOrBefore(time_binary(precision));
                 }
-                crate::parser::ast::TimingDirection::OnOrAfter => {
+                TimingDirection::OnOrAfter | TimingDirection::AfterOrOn => {
                     return elm::Expression::SameOrAfter(time_binary(precision));
                 }
             }
         }
-        crate::parser::ast::TimingPhrase::SameTiming {
+        TimingPhrase::SameTiming {
             left_boundary: None,
             precision,
             direction,
@@ -542,13 +543,13 @@ pub fn emit_timing_expression(
         } => {
             let precision = precision.map(|p| datetime_precision_str(p).to_string());
             match direction {
-                crate::parser::ast::SameDirection::As => {
+                SameDirection::As => {
                     return elm::Expression::SameAs(time_binary(precision));
                 }
-                crate::parser::ast::SameDirection::OrBefore => {
+                SameDirection::OrBefore => {
                     return elm::Expression::SameOrBefore(time_binary(precision));
                 }
-                crate::parser::ast::SameDirection::OrAfter => {
+                SameDirection::OrAfter => {
                     return elm::Expression::SameOrAfter(time_binary(precision));
                 }
             }

--- a/crates/rh-cql/src/eval/engine.rs
+++ b/crates/rh-cql/src/eval/engine.rs
@@ -12,8 +12,11 @@ use super::operators::*;
 use super::tvl::{tvl_and, tvl_implies, tvl_not, tvl_or, tvl_xor};
 use super::value::Value;
 use crate::elm::{
-    BinaryExpression, Expression, Library, NaryExpression, StatementDef, UnaryExpression,
+    BinaryExpression, Expression, Library, NaryExpression, StatementDef, TimeBinaryExpression,
+    UnaryExpression,
 };
+
+type TemporalRelationEvaluator = fn(&Value, &Value, Option<&str>) -> Result<Value, EvalError>;
 
 // ---------------------------------------------------------------------------
 // TraceEvent (Task 9.20)
@@ -1191,34 +1194,26 @@ impl<'lib, 'ctx> Engine<'lib, 'ctx> {
                 let b = self.eval_expr_opt(tb.operand.get(1))?;
                 super::operators::same_as(&a, &b, tb.precision.as_deref())
             }
-            Expression::SameOrBefore(tb) => {
-                let a = self.eval_expr_opt(tb.operand.first())?;
-                let b = self.eval_expr_opt(tb.operand.get(1))?;
-                super::operators::same_or_before(&a, &b, tb.precision.as_deref())
-            }
-            Expression::SameOrAfter(tb) => {
-                let a = self.eval_expr_opt(tb.operand.first())?;
-                let b = self.eval_expr_opt(tb.operand.get(1))?;
-                super::operators::same_or_after(&a, &b, tb.precision.as_deref())
-            }
-            Expression::Before(tb) => {
-                let a = self.eval_expr_opt(tb.operand.first())?;
-                let b = self.eval_expr_opt(tb.operand.get(1))?;
-                if matches!(a, Value::Interval { .. }) || matches!(b, Value::Interval { .. }) {
-                    super::intervals::before(&a, &b)
-                } else {
-                    super::operators::before(&a, &b, tb.precision.as_deref())
-                }
-            }
-            Expression::After(tb) => {
-                let a = self.eval_expr_opt(tb.operand.first())?;
-                let b = self.eval_expr_opt(tb.operand.get(1))?;
-                if matches!(a, Value::Interval { .. }) || matches!(b, Value::Interval { .. }) {
-                    super::intervals::after(&a, &b)
-                } else {
-                    super::operators::after(&a, &b, tb.precision.as_deref())
-                }
-            }
+            Expression::SameOrBefore(tb) => self.eval_temporal_relation(
+                tb,
+                super::operators::same_or_before,
+                super::intervals::same_or_before,
+            ),
+            Expression::SameOrAfter(tb) => self.eval_temporal_relation(
+                tb,
+                super::operators::same_or_after,
+                super::intervals::same_or_after,
+            ),
+            Expression::Before(tb) => self.eval_temporal_relation(
+                tb,
+                super::operators::before,
+                super::intervals::before_at_precision,
+            ),
+            Expression::After(tb) => self.eval_temporal_relation(
+                tb,
+                super::operators::after,
+                super::intervals::after_at_precision,
+            ),
             Expression::DurationBetween(tb) => {
                 let a = self.eval_expr_opt(tb.operand.first())?;
                 let b = self.eval_expr_opt(tb.operand.get(1))?;
@@ -2543,6 +2538,23 @@ impl<'lib, 'ctx> Engine<'lib, 'ctx> {
             .map(|e| self.eval_expr(e))
             .unwrap_or(Ok(Value::Null))?;
         Ok((a, b))
+    }
+
+    fn eval_temporal_relation(
+        &mut self,
+        expression: &TimeBinaryExpression,
+        scalar: TemporalRelationEvaluator,
+        interval: TemporalRelationEvaluator,
+    ) -> Result<Value, EvalError> {
+        let left = self.eval_expr_opt(expression.operand.first())?;
+        let right = self.eval_expr_opt(expression.operand.get(1))?;
+        let evaluator =
+            if matches!(left, Value::Interval { .. }) || matches!(right, Value::Interval { .. }) {
+                interval
+            } else {
+                scalar
+            };
+        evaluator(&left, &right, expression.precision.as_deref())
     }
 
     fn eval_unary_arg(&mut self, unary: &UnaryExpression) -> Result<Value, EvalError> {

--- a/crates/rh-cql/src/eval/intervals.rs
+++ b/crates/rh-cql/src/eval/intervals.rs
@@ -162,24 +162,40 @@ pub fn in_interval(point: &Value, interval: &Value) -> Result<Value, EvalError> 
 
 /// `Before` for interval and interval/point combinations.
 pub fn before(a: &Value, b: &Value) -> Result<Value, EvalError> {
-    if matches!(a, Value::Null) || matches!(b, Value::Null) {
-        return Ok(Value::Null);
-    }
+    before_at_precision(a, b, None)
+}
 
-    let left = before_left_boundary(a)?;
-    let right = before_right_boundary(b)?;
-    match (left, right) {
-        (Some(left), Some(right)) => match cql_compare(left, right) {
-            Some(ord) => Ok(Value::Boolean(ord == Ordering::Less)),
-            None => Ok(Value::Null),
-        },
-        _ => Ok(Value::Null),
-    }
+/// `Before` for interval and interval/point combinations at an optional precision.
+pub fn before_at_precision(
+    a: &Value,
+    b: &Value,
+    precision: Option<&str>,
+) -> Result<Value, EvalError> {
+    compare_before_boundaries(a, b, precision, Ordering::is_lt)
 }
 
 /// `After` for interval and interval/point combinations.
 pub fn after(a: &Value, b: &Value) -> Result<Value, EvalError> {
-    before(b, a)
+    after_at_precision(a, b, None)
+}
+
+/// `After` for interval and interval/point combinations at an optional precision.
+pub fn after_at_precision(
+    a: &Value,
+    b: &Value,
+    precision: Option<&str>,
+) -> Result<Value, EvalError> {
+    before_at_precision(b, a, precision)
+}
+
+/// `SameOrBefore` for interval and interval/point combinations.
+pub fn same_or_before(a: &Value, b: &Value, precision: Option<&str>) -> Result<Value, EvalError> {
+    compare_before_boundaries(a, b, precision, Ordering::is_le)
+}
+
+/// `SameOrAfter` for interval and interval/point combinations.
+pub fn same_or_after(a: &Value, b: &Value, precision: Option<&str>) -> Result<Value, EvalError> {
+    same_or_before(b, a, precision)
 }
 
 fn before_left_boundary(value: &Value) -> Result<Option<&Value>, EvalError> {
@@ -199,6 +215,45 @@ fn before_right_boundary(value: &Value) -> Result<Option<&Value>, EvalError> {
             Ok(low)
         }
         _ => Ok(Some(value)),
+    }
+}
+
+fn compare_before_boundaries(
+    left: &Value,
+    right: &Value,
+    precision: Option<&str>,
+    predicate: impl FnOnce(Ordering) -> bool,
+) -> Result<Value, EvalError> {
+    if matches!(left, Value::Null) || matches!(right, Value::Null) {
+        return Ok(Value::Null);
+    }
+
+    compare_timing_boundaries(
+        before_left_boundary(left)?,
+        before_right_boundary(right)?,
+        precision,
+        predicate,
+    )
+}
+
+fn compare_timing_boundaries(
+    left: Option<&Value>,
+    right: Option<&Value>,
+    precision: Option<&str>,
+    predicate: impl FnOnce(Ordering) -> bool,
+) -> Result<Value, EvalError> {
+    let (Some(left), Some(right)) = (left, right) else {
+        return Ok(Value::Null);
+    };
+    let left = precision
+        .map(|precision| truncate_temporal_value(left, precision))
+        .unwrap_or_else(|| left.clone());
+    let right = precision
+        .map(|precision| truncate_temporal_value(right, precision))
+        .unwrap_or_else(|| right.clone());
+    match cql_compare(&left, &right) {
+        Some(ord) => Ok(Value::Boolean(predicate(ord))),
+        None => Ok(Value::Null),
     }
 }
 

--- a/crates/rh-cql/src/parser/expression/mod.rs
+++ b/crates/rh-cql/src/parser/expression/mod.rs
@@ -5,9 +5,9 @@
 //!
 //! ## Operator Precedence (lowest to highest)
 //!
-//! 1. `or`, `xor`
-//! 2. `and`
-//! 3. `implies`
+//! 1. `implies`
+//! 2. `or`, `xor`
+//! 3. `and`
 //! 4. `=`, `!=`, `~`, `!~`, `in`, `contains`
 //! 5. `<`, `>`, `<=`, `>=`
 //! 6. `|` (union)
@@ -30,7 +30,7 @@ mod selectors;
 ///
 /// Entry point for the full CQL expression grammar.
 pub fn expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    precedence::parse_or_expression(input)
+    precedence::parse_implies_expression(input)
 }
 
 /// Parse a type specifier (used by the statement parser for type annotations
@@ -47,6 +47,93 @@ mod tests {
 
     fn parse_expr(s: &str) -> Expression {
         expression(span(s)).unwrap().1
+    }
+
+    fn parse_complete_expr(s: &str) -> Expression {
+        crate::parser::CqlParser::new().parse_expression(s).unwrap()
+    }
+
+    fn medication_request_body(library: &Library) -> &Expression {
+        match library.statements.as_slice() {
+            [Statement::FunctionDef(FunctionDef {
+                name,
+                body: Some(body),
+                ..
+            })] if name == "Is Current Medication Request" => body,
+            other => panic!("expected medication function, got {other:?}"),
+        }
+    }
+
+    fn ast_without_locations(expression: &Expression) -> serde_json::Value {
+        fn remove_locations(value: &mut serde_json::Value) {
+            match value {
+                serde_json::Value::Object(object) => {
+                    object.remove("location");
+                    for child in object.values_mut() {
+                        remove_locations(child);
+                    }
+                }
+                serde_json::Value::Array(items) => {
+                    for child in items {
+                        remove_locations(child);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let mut value = serde_json::to_value(expression).expect("AST should serialize");
+        remove_locations(&mut value);
+        value
+    }
+
+    #[derive(Clone, Copy)]
+    enum NestedSide {
+        Left,
+        Right,
+    }
+
+    fn assert_binary_shape(
+        expression: &Expression,
+        description: &str,
+        root_operator: BinaryOperator,
+        nested_operator: BinaryOperator,
+        nested_side: NestedSide,
+    ) {
+        let Expression::BinaryExpression(root) = expression else {
+            panic!("expected binary root for {description}, got {expression:?}");
+        };
+        assert_eq!(
+            root.operator, root_operator,
+            "unexpected root for {description}"
+        );
+        let nested = match nested_side {
+            NestedSide::Left => &root.left,
+            NestedSide::Right => &root.right,
+        };
+        assert!(
+            matches!(
+                nested.as_ref(),
+                Expression::BinaryExpression(BinaryExpression { operator, .. })
+                    if *operator == nested_operator
+            ),
+            "unexpected nested grouping for {description}: {nested:?}"
+        );
+    }
+
+    fn assert_mixed_logical_shape(
+        source: &str,
+        root_operator: BinaryOperator,
+        nested_operator: BinaryOperator,
+        nested_side: NestedSide,
+    ) {
+        assert_binary_shape(
+            &parse_complete_expr(source),
+            source,
+            root_operator,
+            nested_operator,
+            nested_side,
+        );
     }
 
     // ========================================================================
@@ -186,6 +273,101 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_all_mixed_logical_operator_pairings() {
+        use BinaryOperator::{And, Implies, Or, Xor};
+        use NestedSide::{Left, Right};
+
+        for (source, root, nested, nested_side) in [
+            ("false and false or true", Or, And, Left),
+            ("true or false and false", Or, And, Right),
+            ("false and false xor true", Xor, And, Left),
+            ("true xor true and false", Xor, And, Right),
+            ("true or false xor true", Xor, Or, Left),
+            ("true xor false or true", Or, Xor, Left),
+            ("false and true implies false", Implies, And, Left),
+            ("false implies true and false", Implies, And, Right),
+            ("true or false implies false", Implies, Or, Left),
+            ("false implies false or false", Implies, Or, Right),
+            ("true xor false implies true", Implies, Xor, Left),
+            ("false implies false xor true", Implies, Xor, Right),
+        ] {
+            assert_mixed_logical_shape(source, root, nested, nested_side);
+        }
+    }
+
+    #[test]
+    fn test_logical_operator_associativity() {
+        use BinaryOperator::{And, Implies, Or, Xor};
+
+        for (source, operator) in [
+            ("true and false and true", And),
+            ("true or false or true", Or),
+            ("true xor false xor true", Xor),
+            // CQL 1.5.3's direct-left-recursive grammar declares no
+            // right-associative override, matching the reference translator.
+            ("false implies true implies false", Implies),
+        ] {
+            assert_mixed_logical_shape(source, operator, operator, NestedSide::Left);
+        }
+    }
+
+    #[test]
+    fn test_parenthesized_function_and_query_logical_grouping() {
+        let parenthesized = parse_complete_expr("(false implies true) and false");
+        assert!(matches!(
+            parenthesized,
+            Expression::BinaryExpression(BinaryExpression {
+                operator: BinaryOperator::And,
+                left,
+                ..
+            }) if matches!(
+                left.as_ref(),
+                Expression::Parenthesized(inner) if matches!(
+                    inner.as_ref(),
+                    Expression::BinaryExpression(BinaryExpression {
+                        operator: BinaryOperator::Implies,
+                        ..
+                    })
+                )
+            )
+        ));
+
+        let parser = crate::parser::CqlParser::new();
+        let library = parser
+            .parse("library T define function F(): false implies true and false")
+            .expect("function should parse");
+        let function_body = match library.statements.as_slice() {
+            [Statement::FunctionDef(FunctionDef {
+                body: Some(body), ..
+            })] => body,
+            other => panic!("expected one function definition, got {other:?}"),
+        };
+        assert_binary_shape(
+            function_body,
+            "function body",
+            BinaryOperator::Implies,
+            BinaryOperator::And,
+            NestedSide::Right,
+        );
+
+        let query = parse_complete_expr("from { 1 } N where false implies true and false return N");
+        let Expression::Query(Query {
+            where_clause: Some(where_clause),
+            ..
+        }) = query
+        else {
+            panic!("expected query with where clause, got {query:?}");
+        };
+        assert_binary_shape(
+            &where_clause,
+            "query where clause",
+            BinaryOperator::Implies,
+            BinaryOperator::And,
+            NestedSide::Right,
+        );
+    }
+
     // ========================================================================
     // Unary Expression Tests
     // ========================================================================
@@ -286,6 +468,297 @@ mod tests {
                 operator: TypeOperator::Is,
                 ..
             })
+        ));
+    }
+
+    #[test]
+    fn test_literal_is_expressions_use_canonical_unary_operators() {
+        for (source, expected) in [
+            ("x is null", UnaryOperator::IsNull),
+            ("x is true", UnaryOperator::IsTrue),
+            ("x is false", UnaryOperator::IsFalse),
+        ] {
+            let expr = parse_complete_expr(source);
+            assert!(
+                matches!(
+                    expr,
+                    Expression::UnaryExpression(UnaryExpression { operator, .. })
+                        if operator == expected
+                ),
+                "unexpected AST for {source}: {expr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_negated_literal_is_expressions_wrap_canonical_operator() {
+        for (source, expected) in [
+            ("x is not null", UnaryOperator::IsNull),
+            ("x is not true", UnaryOperator::IsTrue),
+            ("x is not false", UnaryOperator::IsFalse),
+        ] {
+            let expr = parse_complete_expr(source);
+            assert!(
+                matches!(
+                    &expr,
+                    Expression::UnaryExpression(UnaryExpression {
+                        operator: UnaryOperator::Not,
+                        operand,
+                        ..
+                    }) if matches!(
+                        operand.as_ref(),
+                        Expression::UnaryExpression(UnaryExpression { operator, .. })
+                            if *operator == expected
+                    )
+                ),
+                "unexpected AST for {source}: {expr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_literal_is_keywords_do_not_shadow_qualified_type_tests() {
+        for source in ["value is FHIR.Quantity", "value is not FHIR.Quantity"] {
+            let expr = parse_complete_expr(source);
+            let type_expression = match expr {
+                Expression::TypeExpression(type_expression) => type_expression,
+                Expression::UnaryExpression(UnaryExpression {
+                    operator: UnaryOperator::Not,
+                    operand,
+                    ..
+                }) => match *operand {
+                    Expression::TypeExpression(type_expression) => type_expression,
+                    other => panic!("expected type expression for {source}, got {other:?}"),
+                },
+                other => panic!("expected type test for {source}, got {other:?}"),
+            };
+
+            assert_eq!(type_expression.operator, TypeOperator::Is);
+            assert!(matches!(
+                type_expression.type_specifier,
+                TypeSpecifier::Named(NamedTypeSpecifier {
+                    namespace: Some(ref namespace),
+                    ref name,
+                }) if namespace == "FHIR" && name == "Quantity"
+            ));
+        }
+    }
+
+    #[test]
+    fn test_nested_medication_request_null_test_preserves_member_operand() {
+        let expr = parse_complete_expr("medicationRequest.dispenseRequest.validityPeriod is null");
+        let operand = match expr {
+            Expression::UnaryExpression(UnaryExpression {
+                operator: UnaryOperator::IsNull,
+                operand,
+                ..
+            }) => operand,
+            other => panic!("expected IsNull expression, got {other:?}"),
+        };
+
+        let validity_period = match *operand {
+            Expression::MemberInvocation(member) => member,
+            other => panic!("expected validityPeriod member access, got {other:?}"),
+        };
+        assert_eq!(validity_period.name, "validityPeriod");
+
+        let dispense_request = match *validity_period.source {
+            Expression::MemberInvocation(member) => member,
+            other => panic!("expected dispenseRequest member access, got {other:?}"),
+        };
+        assert_eq!(dispense_request.name, "dispenseRequest");
+        assert!(matches!(
+            dispense_request.source.as_ref(),
+            Expression::IdentifierRef(IdentifierRef { name, .. })
+                if name == "medicationRequest"
+        ));
+    }
+
+    #[test]
+    fn test_medication_request_neighboring_expression_controls() {
+        let repeated = parse_complete_expr("A and B and C");
+        assert!(matches!(
+            repeated,
+            Expression::BinaryExpression(BinaryExpression {
+                operator: BinaryOperator::And,
+                left,
+                ..
+            }) if matches!(
+                left.as_ref(),
+                Expression::BinaryExpression(BinaryExpression {
+                    operator: BinaryOperator::And,
+                    ..
+                })
+            )
+        ));
+
+        let parenthesized = parse_complete_expr("A and (B or C)");
+        assert!(matches!(
+            parenthesized,
+            Expression::BinaryExpression(BinaryExpression {
+                operator: BinaryOperator::And,
+                right,
+                ..
+            }) if matches!(
+                right.as_ref(),
+                Expression::Parenthesized(inner) if matches!(
+                    inner.as_ref(),
+                    Expression::BinaryExpression(BinaryExpression {
+                        operator: BinaryOperator::Or,
+                        ..
+                    })
+                )
+            )
+        ));
+
+        let qualified = parse_complete_expr(
+            "end of FHIRHelpers.ToInterval(request.dispenseRequest.validityPeriod)",
+        );
+        assert!(matches!(
+            qualified,
+            Expression::UnaryExpression(UnaryExpression {
+                operator: UnaryOperator::End,
+                operand,
+                ..
+            }) if matches!(
+                operand.as_ref(),
+                Expression::FunctionInvocation(FunctionInvocation {
+                    library: Some(library),
+                    name,
+                    arguments,
+                    ..
+                }) if library == "FHIRHelpers" && name == "ToInterval" && arguments.len() == 1
+            )
+        ));
+    }
+
+    #[test]
+    fn test_zero_offset_temporal_relationship_spellings() {
+        let cases = [
+            (
+                "@2024-01-01 on before @2024-02-01",
+                TimingDirection::Before,
+                None,
+            ),
+            (
+                "Interval[@2024-01-01, @2024-02-01] on or before month of @2024-03-01",
+                TimingDirection::OnOrBefore,
+                Some(DateTimePrecision::Month),
+            ),
+            (
+                "@T10:00 on after hour of Interval[@T08:00, @T09:00]",
+                TimingDirection::After,
+                Some(DateTimePrecision::Hour),
+            ),
+            (
+                "Interval[1, 5] on or after Interval[1, 3]",
+                TimingDirection::OnOrAfter,
+                None,
+            ),
+            (
+                "@2024-01-01 before @2024-02-01",
+                TimingDirection::Before,
+                None,
+            ),
+            (
+                "Interval[@2024-01-01, @2024-02-01] before or on month of @2024-03-01",
+                TimingDirection::BeforeOrOn,
+                Some(DateTimePrecision::Month),
+            ),
+            (
+                "@T10:00 after hour of Interval[@T08:00, @T09:00]",
+                TimingDirection::After,
+                Some(DateTimePrecision::Hour),
+            ),
+            (
+                "Interval[1, 5] after or on Interval[1, 3]",
+                TimingDirection::AfterOrOn,
+                None,
+            ),
+        ];
+
+        for (source, expected_direction, expected_precision) in cases {
+            let expr = parse_complete_expr(source);
+            assert!(
+                matches!(
+                    expr,
+                    Expression::TimingExpression(TimingExpression {
+                        timing: TimingPhrase::RelativeTiming {
+                            offset: None,
+                            direction,
+                            precision,
+                            ..
+                        },
+                        ..
+                    }) if direction == expected_direction && precision == expected_precision
+                ),
+                "unexpected timing AST for {source}: {expr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_current_medication_request_multiline_and_single_line_ast_match() {
+        const MULTILINE: &str = r#"
+library MedicationTest version '1.0.0'
+using FHIR version '4.0.1'
+include FHIRHelpers version '4.0.1' called FHIRHelpers
+
+define function "Is Current Medication Request"(
+  medicationRequest FHIR.MedicationRequest
+):
+  medicationRequest.status in { 'active', 'on-hold' }
+    and medicationRequest.intent in { 'order', 'plan' }
+    and (
+      medicationRequest.dispenseRequest.validityPeriod is null
+        or end of FHIRHelpers.ToInterval(
+          medicationRequest.dispenseRequest.validityPeriod
+        ) on or after Today()
+    )
+"#;
+        const SINGLE_LINE: &str = "library MedicationTest version '1.0.0' using FHIR version \
+'4.0.1' include FHIRHelpers version '4.0.1' called FHIRHelpers define function \
+\"Is Current Medication Request\"(medicationRequest FHIR.MedicationRequest): \
+medicationRequest.status in { 'active', 'on-hold' } and medicationRequest.intent in \
+{ 'order', 'plan' } and (medicationRequest.dispenseRequest.validityPeriod is null or end of \
+FHIRHelpers.ToInterval(medicationRequest.dispenseRequest.validityPeriod) on or after Today())";
+
+        let parser = crate::parser::CqlParser::new();
+        let multiline = parser
+            .parse(MULTILINE)
+            .expect("multiline function should parse");
+        let single_line = parser
+            .parse(SINGLE_LINE)
+            .expect("single-line function should parse");
+        assert_eq!(
+            ast_without_locations(medication_request_body(&multiline)),
+            ast_without_locations(medication_request_body(&single_line))
+        );
+        let outer = medication_request_body(&multiline);
+        assert!(matches!(
+            outer,
+            Expression::BinaryExpression(BinaryExpression {
+                operator: BinaryOperator::And,
+                left,
+                right,
+                ..
+            }) if matches!(
+                left.as_ref(),
+                Expression::BinaryExpression(BinaryExpression {
+                    operator: BinaryOperator::And,
+                    ..
+                })
+            ) && matches!(
+                right.as_ref(),
+                Expression::Parenthesized(inner) if matches!(
+                    inner.as_ref(),
+                    Expression::BinaryExpression(BinaryExpression {
+                        operator: BinaryOperator::Or,
+                        right,
+                        ..
+                    }) if matches!(right.as_ref(), Expression::TimingExpression(_))
+                )
+            )
         ));
     }
 

--- a/crates/rh-cql/src/parser/expression/precedence.rs
+++ b/crates/rh-cql/src/parser/expression/precedence.rs
@@ -5,9 +5,9 @@
 //!
 //! ## Operator Precedence (lowest to highest)
 //!
-//! 1. `or`, `xor`
-//! 2. `and`
-//! 3. `implies`
+//! 1. `implies`
+//! 2. `or`, `xor`
+//! 3. `and`
 //! 4. `=`, `!=`, `~`, `!~`, `in`, `contains`
 //! 5. `<`, `>`, `<=`, `>=`
 //! 6. `|` (union)
@@ -37,9 +37,9 @@ use nom::{
     branch::alt,
     bytes::complete::tag_no_case,
     character::complete::char,
-    combinator::{map, not, opt, peek, value},
+    combinator::{cut, map, not, opt, peek, value},
     multi::{many0, separated_list0},
-    sequence::{delimited, preceded, tuple},
+    sequence::{delimited, pair, preceded, tuple},
     IResult,
 };
 
@@ -57,57 +57,69 @@ fn binary_expr(op: BinaryOperator, left: Expression, right: Expression) -> Expre
     })
 }
 
-/// Fold a sequence of `(operator, rhs)` pairs into a left-associative binary
-/// expression tree.  All parsers that respect left-to-right associativity use
-/// this helper so the folding logic lives in exactly one place.
+fn unary_expr(operator: UnaryOperator, operand: Expression) -> Expression {
+    Expression::UnaryExpression(UnaryExpression {
+        operator,
+        operand: Box::new(operand),
+        location: None,
+    })
+}
+
 fn fold_left_assoc(first: Expression, rest: Vec<(BinaryOperator, Expression)>) -> Expression {
     rest.into_iter()
         .fold(first, |acc, (op, rhs)| binary_expr(op, acc, rhs))
 }
 
-// ============================================================================
-// Precedence Level 1: OR / XOR (lowest precedence)
-// ============================================================================
-
-pub(crate) fn parse_or_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_and_expression(input)?;
-    let (input, rest) = many0(tuple((
-        ws(alt((
-            value(BinaryOperator::Or, keyword("or")),
-            value(BinaryOperator::Xor, keyword("xor")),
-        ))),
-        parse_and_expression,
-    )))(input)?;
+fn parse_left_assoc<'a, P>(
+    input: Span<'a>,
+    operand: fn(Span<'a>) -> IResult<Span<'a>, Expression>,
+    operator: P,
+) -> IResult<Span<'a>, Expression>
+where
+    P: FnMut(Span<'a>) -> IResult<Span<'a>, BinaryOperator>,
+{
+    let (input, first) = operand(input)?;
+    let (input, rest) = many0(pair(ws(operator), cut(operand)))(input)?;
     Ok((input, fold_left_assoc(first, rest)))
 }
 
 // ============================================================================
-// Precedence Level 2: AND
+// Precedence Level 1: IMPLIES (lowest precedence)
 // ============================================================================
 
-fn parse_and_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_implies_expression(input)?;
-    let (input, rest) = many0(preceded(ws(keyword("and")), parse_implies_expression))(input)?;
-    Ok((
+pub(crate) fn parse_implies_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
+    parse_left_assoc(
         input,
-        rest.into_iter()
-            .fold(first, |acc, rhs| binary_expr(BinaryOperator::And, acc, rhs)),
-    ))
+        parse_or_expression,
+        value(BinaryOperator::Implies, keyword("implies")),
+    )
 }
 
 // ============================================================================
-// Precedence Level 3: IMPLIES
+// Precedence Level 2: OR / XOR
 // ============================================================================
 
-fn parse_implies_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_equality_expression(input)?;
-    let (input, rest) = many0(preceded(ws(keyword("implies")), parse_equality_expression))(input)?;
-    Ok((
+fn parse_or_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
+    parse_left_assoc(
         input,
-        rest.into_iter().fold(first, |acc, rhs| {
-            binary_expr(BinaryOperator::Implies, acc, rhs)
-        }),
-    ))
+        parse_and_expression,
+        alt((
+            value(BinaryOperator::Or, keyword("or")),
+            value(BinaryOperator::Xor, keyword("xor")),
+        )),
+    )
+}
+
+// ============================================================================
+// Precedence Level 3: AND
+// ============================================================================
+
+fn parse_and_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
+    parse_left_assoc(
+        input,
+        parse_equality_expression,
+        value(BinaryOperator::And, keyword("and")),
+    )
 }
 
 // ============================================================================
@@ -115,9 +127,10 @@ fn parse_implies_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
 // ============================================================================
 
 fn parse_equality_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_comparison_expression(input)?;
-    let (input, rest) = many0(tuple((
-        ws(alt((
+    parse_left_assoc(
+        input,
+        parse_comparison_expression,
+        alt((
             // Multi-char operators first
             value(BinaryOperator::NotEqual, tag_no_case("!=")),
             value(BinaryOperator::NotEquivalent, tag_no_case("!~")),
@@ -127,10 +140,8 @@ fn parse_equality_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
             // Keyword operators
             value(BinaryOperator::In, keyword("in")),
             value(BinaryOperator::Contains, keyword("contains")),
-        ))),
-        parse_comparison_expression,
-    )))(input)?;
-    Ok((input, fold_left_assoc(first, rest)))
+        )),
+    )
 }
 
 // ============================================================================
@@ -138,19 +149,18 @@ fn parse_equality_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
 // ============================================================================
 
 fn parse_comparison_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_between_expression(input)?;
-    let (input, rest) = many0(tuple((
-        ws(alt((
+    parse_left_assoc(
+        input,
+        parse_between_expression,
+        alt((
             // Multi-char operators first
             value(BinaryOperator::LessOrEqual, tag_no_case("<=")),
             value(BinaryOperator::GreaterOrEqual, tag_no_case(">=")),
             // Single-char operators
             value(BinaryOperator::Less, char('<')),
             value(BinaryOperator::Greater, char('>')),
-        ))),
-        parse_between_expression,
-    )))(input)?;
-    Ok((input, fold_left_assoc(first, rest)))
+        )),
+    )
 }
 
 // ============================================================================
@@ -169,9 +179,9 @@ fn parse_between_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
     // Try to parse "between X and Y"
     let result = opt(tuple((
         ws(keyword("between")),
-        parse_interval_operator_expression,
-        ws(keyword("and")),
-        parse_interval_operator_expression,
+        cut(parse_interval_operator_expression),
+        cut(ws(keyword("and"))),
+        cut(parse_interval_operator_expression),
     )))(input)?;
 
     match result {
@@ -396,8 +406,12 @@ fn parse_interval_operator_expression(input: Span<'_>) -> IResult<Span<'_>, Expr
 /// Parse a single interval operator followed by its operand
 fn parse_interval_op_with_operand(input: Span<'_>) -> IResult<Span<'_>, (IntervalOp, Expression)> {
     // Try timing phrases first (most complex)
-    if let Ok((remaining, (timing, expr))) = parse_timing_phrase_with_operand(input) {
-        return Ok((remaining, (IntervalOp::Timing(timing), expr)));
+    match parse_timing_phrase_with_operand(input) {
+        Ok((remaining, (timing, expr))) => {
+            return Ok((remaining, (IntervalOp::Timing(timing), expr)));
+        }
+        Err(nom::Err::Error(_)) => {}
+        Err(error) => return Err(error),
     }
 
     // First, try to parse compound operators: "starts/ends during/before/after [precision of]"
@@ -416,7 +430,7 @@ fn parse_interval_op_with_operand(input: Span<'_>) -> IResult<Span<'_>, (Interva
 
     match compound_result {
         (remaining, Some((boundary, op, precision))) => {
-            let (remaining, expr) = parse_union_expression(remaining)?;
+            let (remaining, expr) = cut(parse_union_expression)(remaining)?;
             Ok((
                 remaining,
                 (
@@ -450,7 +464,7 @@ fn parse_interval_op_with_operand(input: Span<'_>) -> IResult<Span<'_>, (Interva
                 let precision = precision_opt.map(|(p, _)| p);
                 // Only use this variant if we have precision or boundary
                 if precision.is_some() || boundary.is_some() {
-                    let (remaining, expr) = parse_union_expression(remaining)?;
+                    let (remaining, expr) = cut(parse_union_expression)(remaining)?;
                     return Ok((
                         remaining,
                         (
@@ -488,19 +502,19 @@ fn parse_interval_op_with_operand(input: Span<'_>) -> IResult<Span<'_>, (Interva
                     value(BinaryOperator::After, keyword("after")),
                 ))),
                 parse_precision,
-                ws(keyword("of")),
+                cut(ws(keyword("of"))),
             )))(input)?;
 
             match temporal_with_precision {
                 (remaining, Some((op, precision, _))) => {
-                    let (remaining, expr) = parse_union_expression(remaining)?;
+                    let (remaining, expr) = cut(parse_union_expression)(remaining)?;
                     Ok((remaining, (IntervalOp::WithPrecision(op, precision), expr)))
                 }
                 (_, None) => {
                     // Fall back to simple operators
                     let (remaining, op) = parse_simple_interval_operator(input)?;
 
-                    let (remaining, expr) = parse_union_expression(remaining)?;
+                    let (remaining, expr) = cut(parse_union_expression)(remaining)?;
                     Ok((remaining, (IntervalOp::Simple(op), expr)))
                 }
             }
@@ -576,18 +590,11 @@ fn parse_simple_interval_operator(input: Span<'_>) -> IResult<Span<'_>, BinaryOp
 fn parse_timing_phrase_with_operand(
     input: Span<'_>,
 ) -> IResult<Span<'_>, (TimingPhrase, Expression)> {
-    // Try "same" timing first
-    if let Ok(result) = parse_same_timing(input) {
-        return Ok(result);
-    }
-
-    // Try "within" timing
-    if let Ok(result) = parse_within_timing(input) {
-        return Ok(result);
-    }
-
-    // Try relative timing (before/after variants)
-    parse_relative_timing(input)
+    alt((
+        parse_same_timing,
+        parse_within_timing,
+        parse_relative_timing,
+    ))(input)
 }
 
 /// Parse "same" timing phrase
@@ -607,7 +614,7 @@ fn parse_same_timing(input: Span<'_>) -> IResult<Span<'_>, (TimingPhrase, Expres
     let (input, precision) = opt(ws(parse_precision))(input)?;
 
     // Direction: "as", "or before", "or after"
-    let (input, direction) = ws(alt((
+    let (input, direction) = cut(ws(alt((
         value(
             SameDirection::OrBefore,
             tuple((keyword("or"), ws(keyword("before")))),
@@ -617,7 +624,7 @@ fn parse_same_timing(input: Span<'_>) -> IResult<Span<'_>, (TimingPhrase, Expres
             tuple((keyword("or"), ws(keyword("after")))),
         ),
         value(SameDirection::As, keyword("as")),
-    )))(input)?;
+    ))))(input)?;
 
     // Optional right boundary: start/end
     let (input, right_boundary) = opt(ws(alt((
@@ -625,7 +632,7 @@ fn parse_same_timing(input: Span<'_>) -> IResult<Span<'_>, (TimingPhrase, Expres
         value(IntervalBoundary::End, keyword("end")),
     ))))(input)?;
 
-    let (input, expr) = parse_union_expression(input)?;
+    let (input, expr) = cut(parse_union_expression)(input)?;
 
     Ok((
         input,
@@ -651,15 +658,15 @@ fn parse_within_timing(input: Span<'_>) -> IResult<Span<'_>, (TimingPhrase, Expr
 
     let (input, properly) = opt(ws(keyword("properly")))(input)?;
     let (input, _) = ws(keyword("within"))(input)?;
-    let (input, quantity) = ws(parse_duration_quantity)(input)?;
-    let (input, _) = ws(keyword("of"))(input)?;
+    let (input, quantity) = cut(ws(parse_duration_quantity))(input)?;
+    let (input, _) = cut(ws(keyword("of")))(input)?;
 
     let (input, right_boundary) = opt(ws(alt((
         value(IntervalBoundary::Start, keyword("start")),
         value(IntervalBoundary::End, keyword("end")),
     ))))(input)?;
 
-    let (input, expr) = parse_union_expression(input)?;
+    let (input, expr) = cut(parse_union_expression)(input)?;
 
     let offset = TimingOffset {
         quantity: QuantityValue {
@@ -699,26 +706,6 @@ fn parse_relative_timing(input: Span<'_>) -> IResult<Span<'_>, (TimingPhrase, Ex
     // - more than <quantity> before/after
     let (input, offset) = parse_timing_offset(input)?;
 
-    // Parse direction - must have at least offset or boundary to trigger timing phrase parsing
-    // If we have neither, this isn't a timing phrase
-    if offset.is_none() && left_boundary.is_none() {
-        return Err(nom::Err::Error(nom::error::Error::new(
-            input,
-            nom::error::ErrorKind::Tag,
-        )));
-    }
-
-    // We need an offset for timing phrases (simple before/after without offset is handled elsewhere)
-    let offset = match offset {
-        Some(o) => o,
-        None => {
-            return Err(nom::Err::Error(nom::error::Error::new(
-                input,
-                nom::error::ErrorKind::Tag,
-            )))
-        }
-    };
-
     let (input, direction) = ws(parse_timing_direction)(input)?;
 
     // Optional precision: day of, hour of, etc.
@@ -730,14 +717,14 @@ fn parse_relative_timing(input: Span<'_>) -> IResult<Span<'_>, (TimingPhrase, Ex
         value(IntervalBoundary::End, keyword("end")),
     ))))(input)?;
 
-    let (input, expr) = parse_union_expression(input)?;
+    let (input, expr) = cut(parse_union_expression)(input)?;
 
     Ok((
         input,
         (
             TimingPhrase::RelativeTiming {
                 left_boundary,
-                offset: Some(offset),
+                offset,
                 direction,
                 precision,
                 right_boundary,
@@ -862,28 +849,31 @@ fn parse_duration_unit(input: Span<'_>) -> IResult<Span<'_>, String> {
 
 /// Parse timing direction keyword
 fn parse_timing_direction(input: Span<'_>) -> IResult<Span<'_>, TimingDirection> {
-    alt((
-        // Multi-word variants first (longer match)
-        value(
-            TimingDirection::OnOrBefore,
-            tuple((keyword("on"), ws(keyword("or")), ws(keyword("before")))),
-        ),
-        value(
-            TimingDirection::OnOrAfter,
-            tuple((keyword("on"), ws(keyword("or")), ws(keyword("after")))),
-        ),
-        value(
-            TimingDirection::BeforeOrOn,
-            tuple((keyword("before"), ws(keyword("or")), ws(keyword("on")))),
-        ),
-        value(
-            TimingDirection::AfterOrOn,
-            tuple((keyword("after"), ws(keyword("or")), ws(keyword("on")))),
-        ),
-        // Simple variants
+    if let Ok((input, _)) = keyword("on")(input) {
+        let (input, or) = opt(ws(keyword("or")))(input)?;
+        let (input, direction) = cut(ws(alt((
+            value(TimingDirection::Before, keyword("before")),
+            value(TimingDirection::After, keyword("after")),
+        ))))(input)?;
+        let direction = match direction {
+            TimingDirection::Before if or.is_some() => TimingDirection::OnOrBefore,
+            TimingDirection::After if or.is_some() => TimingDirection::OnOrAfter,
+            direction => direction,
+        };
+        return Ok((input, direction));
+    }
+
+    let (input, direction) = alt((
         value(TimingDirection::Before, keyword("before")),
         value(TimingDirection::After, keyword("after")),
-    ))(input)
+    ))(input)?;
+    let (input, or_on) = opt(preceded(ws(keyword("or")), cut(ws(keyword("on")))))(input)?;
+    let direction = match direction {
+        TimingDirection::Before if or_on.is_some() => TimingDirection::BeforeOrOn,
+        TimingDirection::After if or_on.is_some() => TimingDirection::AfterOrOn,
+        direction => direction,
+    };
+    Ok((input, direction))
 }
 
 // ============================================================================
@@ -891,17 +881,16 @@ fn parse_timing_direction(input: Span<'_>) -> IResult<Span<'_>, TimingDirection>
 // ============================================================================
 
 fn parse_union_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_additive_expression(input)?;
-    let (input, rest) = many0(tuple((
-        ws(alt((
+    parse_left_assoc(
+        input,
+        parse_additive_expression,
+        alt((
             value(BinaryOperator::Union, char('|')),
             value(BinaryOperator::Union, keyword("union")),
             value(BinaryOperator::Except, keyword("except")),
             value(BinaryOperator::Intersect, keyword("intersect")),
-        ))),
-        parse_additive_expression,
-    )))(input)?;
-    Ok((input, fold_left_assoc(first, rest)))
+        )),
+    )
 }
 
 // ============================================================================
@@ -909,16 +898,15 @@ fn parse_union_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
 // ============================================================================
 
 fn parse_additive_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_multiplicative_expression(input)?;
-    let (input, rest) = many0(tuple((
-        ws(alt((
+    parse_left_assoc(
+        input,
+        parse_multiplicative_expression,
+        alt((
             value(BinaryOperator::Add, char('+')),
             value(BinaryOperator::Subtract, char('-')),
             value(BinaryOperator::Concatenate, char('&')),
-        ))),
-        parse_multiplicative_expression,
-    )))(input)?;
-    Ok((input, fold_left_assoc(first, rest)))
+        )),
+    )
 }
 
 // ============================================================================
@@ -926,17 +914,16 @@ fn parse_additive_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
 // ============================================================================
 
 fn parse_multiplicative_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_power_expression(input)?;
-    let (input, rest) = many0(tuple((
-        ws(alt((
+    parse_left_assoc(
+        input,
+        parse_power_expression,
+        alt((
             value(BinaryOperator::Multiply, char('*')),
             value(BinaryOperator::Divide, char('/')),
             value(BinaryOperator::TruncatedDivide, keyword("div")),
             value(BinaryOperator::Modulo, keyword("mod")),
-        ))),
-        parse_power_expression,
-    )))(input)?;
-    Ok((input, fold_left_assoc(first, rest)))
+        )),
+    )
 }
 
 // ============================================================================
@@ -944,14 +931,11 @@ fn parse_multiplicative_expression(input: Span<'_>) -> IResult<Span<'_>, Express
 // ============================================================================
 
 fn parse_power_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
-    let (input, first) = parse_unary_expression(input)?;
-    let (input, rest) = many0(preceded(ws(char('^')), parse_unary_expression))(input)?;
-    Ok((
+    parse_left_assoc(
         input,
-        rest.into_iter().fold(first, |acc, rhs| {
-            binary_expr(BinaryOperator::Power, acc, rhs)
-        }),
-    ))
+        parse_unary_expression,
+        value(BinaryOperator::Power, char('^')),
+    )
 }
 
 // ============================================================================
@@ -1234,24 +1218,44 @@ fn parse_convert_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
     ))
 }
 
+fn parse_literal_test_operator(input: Span<'_>) -> IResult<Span<'_>, (UnaryOperator, bool)> {
+    let (input, _) = ws(keyword("is"))(input)?;
+    let (input, negated) = opt(ws(keyword("not")))(input)?;
+    let (input, operator) = ws(alt((
+        value(UnaryOperator::IsNull, keyword("null")),
+        value(UnaryOperator::IsTrue, keyword("true")),
+        value(UnaryOperator::IsFalse, keyword("false")),
+    )))(input)?;
+    Ok((input, (operator, negated.is_some())))
+}
+
 fn parse_type_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
     let (input, first) = parse_invocation_expression(input)?;
 
+    if let Ok((remaining, (operator, negated))) = parse_literal_test_operator(input) {
+        let test = unary_expr(operator, first);
+        let expression = if negated {
+            unary_expr(UnaryOperator::Not, test)
+        } else {
+            test
+        };
+        return Ok((remaining, expression));
+    }
+
     // Check for 'is not' (negated type check)
     if let Ok((input2, _)) = tuple((ws(keyword("is")), ws(keyword("not"))))(input) {
-        let (input, type_spec) = parse_type_specifier(input2)?;
+        let (input, type_spec) = cut(parse_type_specifier)(input2)?;
         return Ok((
             input,
-            Expression::UnaryExpression(UnaryExpression {
-                operator: UnaryOperator::Not,
-                operand: Box::new(Expression::TypeExpression(TypeExpression {
+            unary_expr(
+                UnaryOperator::Not,
+                Expression::TypeExpression(TypeExpression {
                     operator: TypeOperator::Is,
                     operand: Box::new(first),
                     type_specifier: type_spec,
                     location: None,
-                })),
-                location: None,
-            }),
+                }),
+            ),
         ));
     }
 
@@ -1261,7 +1265,7 @@ fn parse_type_expression(input: Span<'_>) -> IResult<Span<'_>, Expression> {
             value(TypeOperator::Is, keyword("is")),
             value(TypeOperator::As, keyword("as")),
         ))),
-        parse_type_specifier,
+        cut(parse_type_specifier),
     )))(input)?;
 
     match type_op {

--- a/crates/rh-cql/src/parser/mod.rs
+++ b/crates/rh-cql/src/parser/mod.rs
@@ -13,6 +13,12 @@
 //! - [`expression`]: Expression parsing with operator precedence
 //! - [`statement`]: Library header and definition parsing
 //!
+//! [`CqlParser::parse`] and [`statement::parse_library`] are complete-library
+//! entry points and require the input to end after permitted trailing trivia.
+//! [`CqlParser::parse_expression`] similarly requires a complete expression.
+//! Internal expression and declaration parsers return their unconsumed
+//! [`Span`] so callers can compose them into larger grammar productions.
+//!
 //! ## CQL Grammar Reference
 //!
 //! Based on CQL version 1.5.3 specification. The grammar is translated from
@@ -100,29 +106,7 @@ impl CqlParser {
 
     /// Parse a library from a span
     fn parse_library(&self, span: Span<'_>) -> Result<ast::Library> {
-        match statement::parse_library(span) {
-            Ok((remaining, library)) => {
-                let remaining_str = remaining.fragment().trim();
-                if remaining_str.is_empty() {
-                    Ok(library)
-                } else {
-                    let loc = remaining.location();
-                    Err(CqlError::ParseError {
-                        message: format!(
-                            "Unexpected content after library: {}",
-                            &remaining_str[..remaining_str.len().min(50)]
-                        ),
-                        line: loc.line,
-                        column: loc.column,
-                    })
-                }
-            }
-            Err(e) => Err(CqlError::ParseError {
-                message: format!("Parse error: {e:?}"),
-                line: 1,
-                column: 1,
-            }),
-        }
+        parse_complete(span, "library", statement::parse_library)
     }
 
     /// Parse a single expression (useful for testing)
@@ -144,29 +128,48 @@ impl CqlParser {
 
     /// Parse an expression from a span
     fn parse_expr(&self, span: Span<'_>) -> Result<ast::Expression> {
-        match expression::expression(span) {
-            Ok((remaining, expr)) => {
-                let remaining_str = remaining.fragment().trim();
-                if remaining_str.is_empty() {
-                    Ok(expr)
-                } else {
-                    let loc = remaining.location();
-                    Err(CqlError::ParseError {
-                        message: format!(
-                            "Unexpected content after expression: {}",
-                            &remaining_str[..remaining_str.len().min(50)]
-                        ),
-                        line: loc.line,
-                        column: loc.column,
-                    })
-                }
+        parse_complete(span, "expression", expression::expression)
+    }
+}
+
+fn parse_complete<'a, T>(
+    span: Span<'a>,
+    production: &str,
+    parser: impl FnOnce(Span<'a>) -> nom::IResult<Span<'a>, T>,
+) -> Result<T> {
+    let fallback = span.location();
+    match parser(span) {
+        Ok((remaining, parsed)) => {
+            let trailing = remaining.fragment().trim();
+            if trailing.is_empty() {
+                Ok(parsed)
+            } else {
+                let location = remaining.location();
+                let excerpt: String = trailing.chars().take(50).collect();
+                Err(CqlError::ParseError {
+                    message: format!("Unexpected content after {production}: {excerpt}"),
+                    line: location.line,
+                    column: location.column,
+                })
             }
-            Err(e) => Err(CqlError::ParseError {
-                message: format!("Parse error: {e:?}"),
-                line: 1,
-                column: 1,
-            }),
         }
+        Err(error) => Err(located_parse_error(error, fallback)),
+    }
+}
+
+fn located_parse_error(
+    error: nom::Err<nom::error::Error<Span<'_>>>,
+    fallback: span::SourceLocation,
+) -> CqlError {
+    let message = format!("Parse error: {error:?}");
+    let location = match &error {
+        nom::Err::Error(error) | nom::Err::Failure(error) => error.input.location(),
+        nom::Err::Incomplete(_) => fallback,
+    };
+    CqlError::ParseError {
+        message,
+        line: location.line,
+        column: location.column,
     }
 }
 
@@ -275,6 +278,79 @@ mod tests {
         let parser = CqlParser::new();
         let result = parser.parse_expression("42 garbage");
         assert!(result.is_err());
+    }
+
+    fn assert_parse_error_location(source: &str, expected_line: usize, expected_column: usize) {
+        match CqlParser::new().parse(source) {
+            Err(CqlError::ParseError { line, column, .. }) => {
+                assert_eq!((line, column), (expected_line, expected_column));
+            }
+            other => panic!("expected located parse error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_malformed_temporal_direction_reports_phrase_location() {
+        assert_parse_error_location(
+            "library Bad\ndefine X: @2024-01-01 on or sideways @2024-02-01",
+            2,
+            29,
+        );
+    }
+
+    #[test]
+    fn test_nested_right_operand_reports_deepest_location() {
+        assert_parse_error_location("library Bad\ndefine X: true and (false or )", 2, 30);
+    }
+
+    #[test]
+    fn test_invalid_declaration_reports_after_starter() {
+        assert_parse_error_location("library Bad\ndefine X 1 + 2", 2, 10);
+    }
+
+    #[test]
+    fn test_unexpected_trailing_construct_reports_its_location() {
+        assert_parse_error_location("library Bad\ndefine X: 1\nbogus", 3, 1);
+    }
+
+    #[test]
+    fn test_delimiter_sensitive_expressions_remain_valid() {
+        let parser = CqlParser::new();
+
+        assert!(matches!(
+            parser.parse_expression("3 between 1 and 5").unwrap(),
+            Expression::TernaryExpression(_)
+        ));
+        assert!(matches!(
+            parser
+                .parse_expression("from { 1, 2 } N where N > 1 return N")
+                .unwrap(),
+            Expression::Query(_)
+        ));
+        assert!(matches!(
+            parser.parse_expression("{ 1, 2, 3 }").unwrap(),
+            Expression::ListExpression(ref list) if list.elements.len() == 3
+        ));
+        assert!(matches!(
+            parser
+                .parse_expression("Tuple { first: 1, second: 2 }")
+                .unwrap(),
+            Expression::TupleExpression(ref tuple) if tuple.elements.len() == 2
+        ));
+    }
+
+    #[test]
+    fn test_alternate_statement_productions_remain_valid() {
+        let library = CqlParser::new()
+            .parse(
+                "library Controls\n\
+                 define Value: 1\n\
+                 define function Identity(value Integer): value",
+            )
+            .unwrap();
+
+        assert!(matches!(library.statements[0], Statement::ExpressionDef(_)));
+        assert!(matches!(library.statements[1], Statement::FunctionDef(_)));
     }
 
     #[test]

--- a/crates/rh-cql/src/parser/statement.rs
+++ b/crates/rh-cql/src/parser/statement.rs
@@ -15,7 +15,7 @@ use super::span::Span;
 use nom::{
     branch::alt,
     character::complete::char,
-    combinator::{map, opt, value},
+    combinator::{cut, eof, map, opt, peek, value},
     multi::many0,
     sequence::{delimited, pair, preceded},
     IResult,
@@ -385,26 +385,11 @@ fn parse_function_parameter(input: Span<'_>) -> IResult<Span<'_>, FunctionParame
 /// Parse a statement (expression or function definition)
 pub fn parse_statement(input: Span<'_>) -> IResult<Span<'_>, Statement> {
     let (input, _) = skip_ws_and_comments(input)?;
-
-    // Peek ahead to determine if this is a function or expression definition
-    // Function definitions have: [access] [fluent] define function
-    // Expression definitions have: [access] define Name:
-
-    // Try function first (since it's more specific)
-    if let Ok((remaining, func_def)) = parse_function_def(input) {
-        return Ok((remaining, Statement::FunctionDef(func_def)));
-    }
-
-    // Try expression definition
-    if let Ok((remaining, expr_def)) = parse_expression_def(input) {
-        return Ok((remaining, Statement::ExpressionDef(expr_def)));
-    }
-
-    // Fallback error
-    Err(nom::Err::Error(nom::error::Error::new(
-        input,
-        nom::error::ErrorKind::Alt,
-    )))
+    let (_, _) = starter_with_optional_access("define")(input)?;
+    cut(alt((
+        map(parse_function_def, Statement::FunctionDef),
+        map(parse_expression_def, Statement::ExpressionDef),
+    )))(input)
 }
 
 // ============================================================================
@@ -426,6 +411,51 @@ fn parse_optional_access_modifier(input: Span<'_>) -> IResult<Span<'_>, Option<A
     let (input, _) = skip_ws_and_comments(input)?;
 
     Ok((input, modifier))
+}
+
+fn starter_with_optional_access<'a>(
+    starter: &'static str,
+) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, ()> {
+    move |input| {
+        let (input, _) = parse_optional_access_modifier(input)?;
+        let (input, _) = keyword(starter)(input)?;
+        Ok((input, ()))
+    }
+}
+
+fn keyword_starter<'a>(
+    keyword_value: &'static str,
+) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, ()> {
+    move |input| {
+        let (input, _) = skip_ws_and_comments(input)?;
+        let (input, _) = keyword(keyword_value)(input)?;
+        Ok((input, ()))
+    }
+}
+
+fn terminology_starter(input: Span<'_>) -> IResult<Span<'_>, ()> {
+    let (input, _) = parse_optional_access_modifier(input)?;
+    let (input, _) = alt((
+        keyword("codesystem"),
+        keyword("valueset"),
+        keyword("code"),
+        keyword("concept"),
+    ))(input)?;
+    Ok((input, ()))
+}
+
+fn committed_after<'a, O, S, P>(
+    mut starter: S,
+    mut parser: P,
+) -> impl FnMut(Span<'a>) -> IResult<Span<'a>, O>
+where
+    S: FnMut(Span<'a>) -> IResult<Span<'a>, ()>,
+    P: FnMut(Span<'a>) -> IResult<Span<'a>, O>,
+{
+    move |input| {
+        let (_, _) = peek(&mut starter)(input)?;
+        cut(&mut parser)(input)
+    }
 }
 
 // ============================================================================
@@ -456,16 +486,23 @@ pub fn parse_library(input: Span<'_>) -> IResult<Span<'_>, Library> {
     let (input, _) = skip_ws_and_comments(input)?;
 
     // Parse library identifier (optional)
-    let (input, identifier) = opt(parse_library_identifier)(input)?;
+    let (input, identifier) = opt(committed_after(
+        keyword_starter("library"),
+        parse_library_identifier,
+    ))(input)?;
 
     // Parse using definitions
-    let (input, usings) = many0(parse_using_def)(input)?;
+    let (input, usings) = many0(committed_after(keyword_starter("using"), parse_using_def))(input)?;
 
     // Parse include definitions
-    let (input, includes) = many0(parse_include_def)(input)?;
+    let (input, includes) = many0(committed_after(
+        keyword_starter("include"),
+        parse_include_def,
+    ))(input)?;
 
     // Parse terminology definitions in any order (codesystem, valueset, code, concept)
-    let (input, terminology_defs) = many0(parse_terminology_def)(input)?;
+    let (input, terminology_defs) =
+        many0(committed_after(terminology_starter, parse_terminology_def))(input)?;
 
     // Separate terminology definitions by type
     let mut codesystems = Vec::new();
@@ -483,15 +520,22 @@ pub fn parse_library(input: Span<'_>) -> IResult<Span<'_>, Library> {
     }
 
     // Parse parameter definitions
-    let (input, parameters) = many0(parse_parameter_def)(input)?;
+    let (input, parameters) = many0(committed_after(
+        starter_with_optional_access("parameter"),
+        parse_parameter_def,
+    ))(input)?;
 
     // Parse context definitions
-    let (input, contexts) = many0(parse_context_def)(input)?;
+    let (input, contexts) = many0(committed_after(
+        keyword_starter("context"),
+        parse_context_def,
+    ))(input)?;
 
     // Parse statements (expression and function definitions)
     let (input, statements) = many0(parse_statement)(input)?;
 
     let (input, _) = skip_ws_and_comments(input)?;
+    let (input, _) = eof(input)?;
 
     Ok((
         input,

--- a/crates/rh-cql/tests/emit_conformance_tests.rs
+++ b/crates/rh-cql/tests/emit_conformance_tests.rs
@@ -57,6 +57,32 @@ fn emitter_with_result_types() -> ElmEmitter {
     ElmEmitter::new(CompilerOptions::new().with_option(CompilerOption::EnableResultTypes))
 }
 
+fn emit_source_expression(source: &str) -> elm::Expression {
+    let cql = format!("library Test version '1.0'\ndefine Expr: {source}\n");
+    let (typed_lib, diags) = analyze(&cql);
+    assert!(diags.is_empty(), "unexpected diagnostics: {diags:?}");
+    let body = first_expr_body(&typed_lib);
+    emitter_with_result_types().emit_expression(body)
+}
+
+#[derive(Clone, Copy)]
+enum LiteralTest {
+    Null,
+    True,
+    False,
+}
+
+impl LiteralTest {
+    fn matches(self, expression: &elm::Expression) -> bool {
+        matches!(
+            (self, expression),
+            (Self::Null, elm::Expression::IsNull(_))
+                | (Self::True, elm::Expression::IsTrue(_))
+                | (Self::False, elm::Expression::IsFalse(_))
+        )
+    }
+}
+
 /// Extract the typed expression body of the first `ExpressionDef` statement.
 fn first_expr_body(
     lib: &rh_cql::semantics::typed_ast::TypedLibrary,
@@ -116,6 +142,83 @@ fn test_conformance_boolean_and() {
         matches!(expr, elm::Expression::And(_)),
         "Expected And, got {expr:?}"
     );
+}
+
+#[test]
+fn test_literal_is_expressions_emit_canonical_elm() {
+    for (source, expected) in [
+        ("null is null", LiteralTest::Null),
+        ("true is true", LiteralTest::True),
+        ("false is false", LiteralTest::False),
+    ] {
+        let expression = emit_source_expression(source);
+        assert!(
+            expected.matches(&expression),
+            "unexpected ELM for {source}: {expression:?}"
+        );
+    }
+}
+
+#[test]
+fn test_negated_literal_is_expressions_wrap_canonical_elm() {
+    for (source, expected) in [
+        ("null is not null", LiteralTest::Null),
+        ("true is not true", LiteralTest::True),
+        ("false is not false", LiteralTest::False),
+    ] {
+        let expression = emit_source_expression(source);
+        let operand = match expression {
+            elm::Expression::Not(unary) => unary.operand,
+            other => panic!("expected Not for {source}, got {other:?}"),
+        };
+        assert!(
+            operand
+                .as_deref()
+                .is_some_and(|operand| expected.matches(operand)),
+            "unexpected ELM for {source}: {operand:?}"
+        );
+    }
+}
+
+#[test]
+fn test_named_is_expression_remains_generic_elm() {
+    assert!(matches!(
+        emit_source_expression("1 is Integer"),
+        elm::Expression::Is(_)
+    ));
+}
+
+#[test]
+fn test_zero_offset_temporal_relationships_emit_canonical_elm() {
+    let before = emit_source_expression("@2024-01-01 before @2024-02-01");
+    assert!(matches!(before, elm::Expression::Before(_)));
+
+    let after = emit_source_expression("@2024-02-01 after @2024-01-01");
+    assert!(matches!(after, elm::Expression::After(_)));
+
+    for source in [
+        "@2024-01-01 on or before month of @2024-02-01",
+        "@2024-01-01 before or on month of @2024-02-01",
+    ] {
+        let expression = emit_source_expression(source);
+        assert!(matches!(
+            expression,
+            elm::Expression::SameOrBefore(ref timing)
+                if timing.precision.as_deref() == Some("month")
+        ));
+    }
+
+    for source in [
+        "@T10:00 on or after hour of @T09:00",
+        "@T10:00 after or on hour of @T09:00",
+    ] {
+        let expression = emit_source_expression(source);
+        assert!(matches!(
+            expression,
+            elm::Expression::SameOrAfter(ref timing)
+                if timing.precision.as_deref() == Some("hour")
+        ));
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/rh-cql/tests/eval_integration_tests.rs
+++ b/crates/rh-cql/tests/eval_integration_tests.rs
@@ -41,6 +41,10 @@ fn eval_expr(cql: &str, expr_name: &str) -> Value {
     evaluate_elm(&result.library, expr_name, &ctx).expect("evaluation failed")
 }
 
+fn eval_source_expression(source: &str) -> Value {
+    eval_expr(&format!("library T define X: {source}"), "X")
+}
+
 fn compile_or_eval_fails(cql: &str, expr_name: &str) -> bool {
     let Ok(result) = compile_with_model(cql, None, None) else {
         return true;
@@ -173,6 +177,57 @@ fn eval_boolean_or() {
 fn eval_boolean_not() {
     let cql = "library T define X: not true";
     assert_eq!(eval_expr(cql, "X"), Value::Boolean(false));
+}
+
+#[test]
+fn eval_mixed_logical_precedence_and_associativity() {
+    for (source, expected) in [
+        ("false implies true and false", true),
+        ("false and false or true", true),
+        ("true or false and false", true),
+        ("false and false xor true", true),
+        ("true xor true and false", true),
+        ("true or false xor true", false),
+        ("true xor false or true", true),
+        ("false and true implies false", true),
+        ("true or false implies false", false),
+        ("false implies false or false", true),
+        ("true xor false implies true", true),
+        ("false implies false xor true", true),
+        ("true and false and true", false),
+        ("false or false or true", true),
+        ("true xor false xor true", false),
+        ("false implies true implies false", false),
+        ("(false implies true) and false", false),
+    ] {
+        assert_eq!(
+            eval_source_expression(source),
+            Value::Boolean(expected),
+            "unexpected result for {source}"
+        );
+    }
+}
+
+#[test]
+fn eval_corrected_logical_precedence_in_function_and_query() {
+    let function = compile_with_model(
+        "library T define function F(): false implies true and false",
+        None,
+        None,
+    )
+    .expect("function should compile");
+    assert!(
+        function.errors.is_empty(),
+        "function compilation errors: {:?}",
+        function.errors
+    );
+    assert_eq!(
+        eval_expr(
+            "library T define X: from { 1 } N where false implies true and false return N",
+            "X",
+        ),
+        Value::List(vec![Value::Integer(1)])
+    );
 }
 
 #[test]
@@ -337,6 +392,76 @@ fn eval_to_integer_cast() {
 fn eval_is_type_check() {
     let cql = "library T define X: 42 is Integer";
     assert_eq!(eval_expr(cql, "X"), Value::Boolean(true));
+}
+
+#[test]
+fn eval_literal_is_expressions() {
+    for (source, expected) in [
+        ("true is true", true),
+        ("false is false", true),
+        ("null is null", true),
+        ("true is false", false),
+        ("false is true", false),
+        ("null is true", false),
+        ("null is false", false),
+        ("true is null", false),
+    ] {
+        assert_eq!(
+            eval_source_expression(source),
+            Value::Boolean(expected),
+            "unexpected result for {source}"
+        );
+    }
+}
+
+#[test]
+fn eval_negated_literal_is_expressions_match_explicit_not() {
+    for (operand, target) in [
+        ("true", "null"),
+        ("false", "null"),
+        ("null", "null"),
+        ("true", "true"),
+        ("false", "true"),
+        ("null", "true"),
+        ("true", "false"),
+        ("false", "false"),
+        ("null", "false"),
+    ] {
+        let negated = format!("{operand} is not {target}");
+        let explicit = format!("not ({operand} is {target})");
+        assert_eq!(
+            eval_source_expression(&negated),
+            eval_source_expression(&explicit),
+            "negated form differs for {operand} is not {target}"
+        );
+    }
+}
+
+#[test]
+fn eval_legacy_generic_is_null_elm() {
+    use rh_cql::elm::{Expression, StatementDef};
+
+    let mut result = compile_with_model("library T define X: null is Integer", None, None)
+        .expect("compile failed");
+    let statements = result
+        .library
+        .statements
+        .as_mut()
+        .expect("missing statements");
+    let definition = match statements.defs.first_mut() {
+        Some(StatementDef::Expression(definition)) => definition,
+        other => panic!("expected expression definition, got {other:?}"),
+    };
+    let is_expression = match definition.expression.as_deref_mut() {
+        Some(Expression::Is(is_expression)) => is_expression,
+        other => panic!("expected generic Is expression, got {other:?}"),
+    };
+    is_expression.is_type = Some("{urn:hl7-org:elm-types:r1}null".into());
+
+    assert_eq!(
+        evaluate_elm(&result.library, "X", &default_ctx()).expect("evaluation failed"),
+        Value::Boolean(true)
+    );
 }
 
 #[test]
@@ -870,6 +995,48 @@ fn eval_interval_before_after_point_and_interval() {
         eval_expr("library T define X: Interval[11, 20] after 12", "X"),
         Value::Boolean(false)
     );
+}
+
+#[test]
+fn eval_zero_offset_inclusive_temporal_relationships() {
+    for (source, expected) in [
+        ("@2024-01-01 on or before @2024-01-01", true),
+        ("@2024-01-01 before or on @2024-01-01", true),
+        ("@2024-01-01 on or after @2024-01-01", true),
+        ("@2024-01-01 after or on @2024-01-01", true),
+        ("@2024-02-01 on or before month of @2024-01-01", false),
+        ("@T10:00 on or after hour of @T09:00", true),
+        (
+            "Interval[@2012-12-01, @2013-12-01] on or after month of @2012-11-15",
+            true,
+        ),
+        (
+            "@2012-11-15 on or after month of Interval[@2012-12-01, @2013-12-01]",
+            false,
+        ),
+        (
+            "Interval[@T10:00:00.000, @T19:59:59.999] on or after hour of Interval[@T08:00:00.000, @T09:59:59.999]",
+            true,
+        ),
+        ("Interval[6, 10] on or after 6", true),
+        ("2.5 on or after Interval[1.666, 2.50000001]", false),
+        (
+            "Interval[@2012-10-01, @2012-11-01] on or before month of @2012-11-15",
+            true,
+        ),
+        (
+            "@2012-11-15 on or before month of Interval[@2012-10-01, @2013-12-01]",
+            false,
+        ),
+        ("Interval[4, 6] on or before 6", true),
+        ("1.6667 on or before Interval[1.666, 2.50000001]", false),
+    ] {
+        assert_eq!(
+            eval_source_expression(source),
+            Value::Boolean(expected),
+            "unexpected result for {source}"
+        );
+    }
 }
 
 #[test]

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/.openspec.yaml
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/design.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/design.md
@@ -1,0 +1,72 @@
+## Context
+
+The comparison parser currently routes `is null`, `is true`, and `is false` through generic type
+testing. The evaluator compensates for a type literally named `null`, but this produces
+noncanonical ELM and cannot make Boolean identity tests correct. Native unary operators and ELM
+forms already exist, so the parser must select them before generic type-specifier parsing.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Produce canonical AST and ELM for positive and negated null/Boolean tests.
+- Evaluate the forms with CQL null semantics.
+- Preserve named-type tests and compatibility with previously generated ELM.
+- Protect behavior with AST, golden ELM, and evaluator tests.
+
+**Non-Goals:**
+
+- Remove generic `Is` or `As` type operations.
+- Change public compile/evaluate APIs.
+- Redesign the full comparison precedence level.
+
+## Decisions
+
+### Parse literal test targets before type specifiers
+
+A dedicated branch for `is not? (null | true | false)` will precede generic `is`/`as` parsing.
+Keyword boundaries will ensure identifiers or qualified types are not captured as literals.
+
+The alternative—repairing only evaluator handling of generic `Is`—would leave emitted ELM
+noncanonical and conflate values with type names.
+
+### Lower negation through `Not`
+
+Positive tests will lower to `UnaryOperator::IsNull`, `IsTrue`, or `IsFalse`. Unless the ELM model
+requires a dedicated negated node, `is not` will lower to `Not` around the corresponding positive
+test, making negation explicit and reusable across the pipeline.
+
+### Retain legacy ELM compatibility
+
+The evaluator's generic `Is`-type-`null` path may remain for external or previously emitted ELM,
+but the compiler will no longer produce that representation. Tests will distinguish compatibility
+from the canonical compiler output.
+
+### Require compile-to-ELM evidence
+
+AST tests alone can pass while semantic analysis or emission reconstructs a generic type test.
+Golden or structural ELM assertions will therefore be part of the acceptance gate.
+
+## Risks / Trade-offs
+
+- [Dedicated syntax shadows named types] → Require exact literal-keyword boundaries and retain
+  named and qualified type regressions.
+- [Double negation or incorrect null propagation] → Assert positive and negative forms for true,
+  false, and null operands at evaluator level.
+- [Legacy compatibility masks compiler regressions] → Assert the exact compiled ELM node shape.
+- [Motivating function also depends on temporal parsing] → Keep focused null-test cases
+  independent and run the full-function regression once both changes are present.
+
+## Migration Plan
+
+1. Capture current AST, ELM, and evaluator failures.
+2. Add dedicated parsing and canonical lowering.
+3. Wire semantic/emitter/evaluator handling while retaining legacy input compatibility.
+4. Run focused, crate-wide, and HL7 checks before refreshing coverage claims.
+
+Rollback requires only reverting source and tests; no serialized format migration is required.
+
+## Open Questions
+
+- Confirm the canonical ELM representation of each negated form against the reference translator
+  before finalizing golden output.

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/proposal.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/proposal.md
@@ -1,0 +1,44 @@
+## Why
+
+`is null`, `is true`, and `is false` currently parse as generic type tests, causing noncanonical
+ELM and incorrect Boolean evaluation. Dedicated syntax lowering is needed so valid CQL produces
+the standard nullological nodes while preserving generic named-type checks.
+
+## What Changes
+
+- Parse positive and negated null/Boolean test syntax before generic `is`/`as` type-specifier
+  parsing.
+- Lower positive forms to `IsNull`, `IsTrue`, and `IsFalse`, and lower negative forms to their
+  canonical negated representation.
+- Emit native ELM nullological nodes and evaluate them with CQL three-valued logic.
+- Preserve generic checks such as `value is FHIR.Quantity` and retain legacy ELM compatibility
+  where needed.
+- Add parser, golden ELM, evaluator, and motivating-function regressions, then update only the
+  conformance claims supported by those tests.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cql-parser-conformance`: Require canonical AST lowering for positive and negated null/Boolean
+  tests without regressing named-type tests.
+- `cql-elm-emitter`: Require source null/Boolean tests to emit native `IsNull`, `IsTrue`, and
+  `IsFalse` ELM nodes.
+- `cql-eval-engine`: Require correct three-valued evaluation of positive and negated
+  null/Boolean tests.
+- `cql-spec-coverage`: Require nullological coverage claims to cite parser, emitter, and evaluator
+  evidence.
+
+## Impact
+
+- Affected crate: `crates/rh-cql`
+- Primary code: parser precedence, AST/semantic handling if required, ELM operator emission, and
+  evaluator dispatch
+- Tests: parser AST tests, compile-to-ELM golden assertions, and evaluation integration tests
+- Documentation: `crates/rh-cql/SPEC_COVERAGE.md` and `crates/rh-cql/CONFORMANCE.md`
+- No public API changes; compatibility with previously generated generic `Is(null)` ELM may be
+  retained internally

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-elm-emitter/spec.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-elm-emitter/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Source null and Boolean tests emit canonical ELM
+
+The compiler SHALL emit native `IsNull`, `IsTrue`, and `IsFalse` ELM nodes for the corresponding
+source syntax and SHALL NOT emit those forms as generic `Is` type tests.
+
+#### Scenario: Positive nullological forms use native nodes
+
+- **WHEN** source expressions using `is null`, `is true`, and `is false` are compiled
+- **THEN** structural or golden ELM assertions find `IsNull`, `IsTrue`, and `IsFalse` nodes
+
+#### Scenario: Negative forms wrap canonical positive nodes
+
+- **WHEN** source expressions using each `is not` literal form are compiled
+- **THEN** the ELM uses the reference-compatible negated representation around the corresponding
+  native positive node
+
+#### Scenario: Named type checks retain generic ELM
+
+- **WHEN** a named or qualified `is` type test is compiled
+- **THEN** its ELM remains a generic `Is` expression with the requested type specifier

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-eval-engine/spec.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-eval-engine/spec.md
@@ -1,0 +1,35 @@
+## ADDED Requirements
+
+### Requirement: Source null and Boolean tests evaluate with CQL semantics
+
+Positive and negated null/Boolean tests compiled from source SHALL evaluate through dedicated
+nullological ELM dispatch and SHALL return the CQL-defined Boolean result for true, false, and null
+operands.
+
+#### Scenario: Positive identity tests are true
+
+- **WHEN** `true is true`, `false is false`, and `null is null` are compiled and evaluated
+- **THEN** each result is `Value::Boolean(true)`
+
+#### Scenario: Mismatched positive tests are false
+
+- **WHEN** supported nonmatching true, false, and null test combinations are evaluated
+- **THEN** each result is the CQL-defined Boolean false rather than an unsupported or generic-type
+  result
+
+#### Scenario: Negated forms invert their canonical tests
+
+- **WHEN** `is not null`, `is not true`, and `is not false` expressions are evaluated across true,
+  false, and null operands
+- **THEN** each result matches explicit `not` applied to the corresponding canonical positive test
+
+### Requirement: Legacy generic null-test ELM remains consumable
+
+The evaluator SHALL continue to accept previously generated or external generic `Is` ELM whose
+type name is `null` while the compiler stops emitting that shape.
+
+#### Scenario: Legacy ELM compatibility path remains isolated
+
+- **WHEN** legacy generic `Is(null)` ELM is evaluated
+- **THEN** it retains its compatible result
+- **THEN** compiling equivalent source produces native `IsNull` ELM instead

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-parser-conformance/spec.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-parser-conformance/spec.md
@@ -1,0 +1,32 @@
+## ADDED Requirements
+
+### Requirement: Parser lowers null and Boolean tests canonically
+
+The parser SHALL lower `is null`, `is true`, and `is false` to `IsNull`, `IsTrue`, and `IsFalse`
+unary AST operations instead of generic named-type tests.
+
+#### Scenario: Positive forms produce dedicated operations
+
+- **WHEN** `A is null`, `A is true`, and `A is false` are parsed
+- **THEN** their AST nodes use `IsNull`, `IsTrue`, and `IsFalse`, respectively
+
+#### Scenario: Negative forms produce explicit negation
+
+- **WHEN** `A is not null`, `A is not true`, and `A is not false` are parsed
+- **THEN** each AST is the canonical negated form of its corresponding dedicated positive test
+
+### Requirement: Literal tests do not replace generic type tests
+
+The dedicated null and Boolean syntax SHALL preserve generic `is` and `is not` type-specifier
+parsing for named and qualified types.
+
+#### Scenario: Qualified type checks remain generic
+
+- **WHEN** `value is FHIR.Quantity` and `value is not FHIR.Quantity` are parsed
+- **THEN** they remain generic type tests with the complete qualified type specifier
+
+#### Scenario: Medication-request null test is canonical
+
+- **WHEN** the motivating medication-request function is parsed
+- **THEN** `medicationRequest.dispenseRequest.validityPeriod is null` produces an `IsNull` AST
+  node over the complete nested member expression

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-spec-coverage/spec.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/specs/cql-spec-coverage/spec.md
@@ -1,0 +1,21 @@
+## ADDED Requirements
+
+### Requirement: Nullological coverage reflects canonical end-to-end support
+
+Coverage documents SHALL distinguish parser acceptance from canonical AST, ELM, and evaluator
+support for `IsNull`, `IsTrue`, and `IsFalse` source forms.
+
+#### Scenario: Implemented rows cite all pipeline evidence
+
+- **WHEN** a nullological source form is marked implemented
+- **THEN** its notes cite parser AST, canonical ELM, and evaluator tests
+
+#### Scenario: Partial stages remain visible
+
+- **WHEN** any positive or negated form lacks canonical emission or evaluation evidence
+- **THEN** the relevant stage remains marked partial or unsupported
+
+#### Scenario: Conformance totals preserve the zero-wrong-answer invariant
+
+- **WHEN** documentation is refreshed after the change
+- **THEN** it records the test command and run date and reports a `fail` count of `0`

--- a/openspec/changes/canonicalize-cql-boolean-null-tests/tasks.md
+++ b/openspec/changes/canonicalize-cql-boolean-null-tests/tasks.md
@@ -1,0 +1,38 @@
+## 1. Add Canonical-Shape Regressions
+
+- [x] 1.1 Add parser AST tests for `is null`, `is true`, `is false`, and each corresponding
+  `is not` form
+- [x] 1.2 Add named and qualified type controls for `value is FHIR.Quantity` and
+  `value is not FHIR.Quantity`
+- [x] 1.3 Add the medication-request nested `validityPeriod is null` expression and assert an
+  `IsNull` node over the complete member-access operand
+- [x] 1.4 Add compile-to-ELM golden or structural assertions for all positive and negated forms
+
+## 2. Implement Parser and Compiler Lowering
+
+- [x] 2.1 Add a dedicated `expression is not? (null | true | false)` parser branch before generic
+  `is`/`as` type-specifier handling with exact keyword boundaries
+- [x] 2.2 Lower positive forms to `IsNull`, `IsTrue`, and `IsFalse` AST operations and negative
+  forms to the reference-compatible explicit negation
+- [x] 2.3 Update semantic analysis and ELM emission as needed so compiled source retains the
+  canonical native node shape
+- [x] 2.4 Preserve generic named-type parsing and emission without public API changes
+
+## 3. Implement and Verify Evaluation
+
+- [x] 3.1 Add evaluator assertions for matching and nonmatching true, false, and null operands
+  across positive forms
+- [x] 3.2 Add evaluator assertions for all `is not` forms and verify they match explicit negation
+  of the canonical positive operations
+- [x] 3.3 Wire or correct native nullological dispatch and three-valued behavior exposed by the
+  focused tests
+- [x] 3.4 Retain and isolate the legacy generic `Is(null)` compatibility path while asserting the
+  compiler no longer emits it
+
+## 4. Validate and Document
+
+- [x] 4.1 Run parser, `emit_conformance_tests`, and `eval_integration_tests` focused checks
+- [x] 4.2 Run `cargo test -p rh-cql` and the full HL7 evaluation suite, confirming `fail=0`
+- [x] 4.3 Update nullological rows in `SPEC_COVERAGE.md` and conformance totals only where all
+  claimed stages have cited evidence
+- [x] 4.4 Run `cargo fmt --all`, `just docs-sync`, and `just check`

--- a/openspec/changes/correct-cql-logical-precedence/.openspec.yaml
+++ b/openspec/changes/correct-cql-logical-precedence/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/correct-cql-logical-precedence/design.md
+++ b/openspec/changes/correct-cql-logical-precedence/design.md
@@ -1,0 +1,65 @@
+## Context
+
+The logical parser entry points currently let `implies` bind more tightly than `and` and `or`.
+CQL requires `implies` to be the lowest-precedence logical operator. Because the AST is already a
+nested binary tree, the correction is confined to parser delegation and associativity.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Encode the CQL logical precedence hierarchy directly in parser entry points.
+- Make operator associativity explicit and testable.
+- Demonstrate correct grouping through both AST and evaluation results.
+- Preserve explicit parentheses and existing valid query/function parsing.
+
+**Non-Goals:**
+
+- Change logical operator runtime semantics or ELM representations.
+- Rework comparison, arithmetic, or timing precedence beyond delegation boundaries.
+- Change public APIs.
+
+## Decisions
+
+### Make `implies` the logical entry point
+
+The precedence chain will delegate from `implies` to `or`/`xor`, from `or`/`xor` to `and`, and
+from `and` to comparison expressions. This structure makes lower precedence correspond to a
+higher-level parser function.
+
+Adding an AST regrouping pass after parsing was rejected because it would obscure grammar errors
+and complicate source spans.
+
+### Preserve left folds except where the grammar says otherwise
+
+`and`, `or`, and `xor` will continue to use left folds. Repeated `implies` associativity will be
+confirmed from CQL 1.5.3 grammar/reference behavior and then encoded directly rather than inherited
+accidentally from a helper.
+
+### Use value-sensitive regression expressions
+
+Tests such as `false implies true and false` will assert both the nested AST and the evaluated
+value. A matrix of mixed logical pairs, plus parenthesized controls, will prevent a syntactically
+plausible but semantically wrong ordering.
+
+## Risks / Trade-offs
+
+- [Parser delegation becomes recursive or skips a level] → Cover every mixed operator pairing.
+- [Repeated `implies` gets an assumed associativity] → Confirm against normative/reference
+  behavior before implementing the fold.
+- [Query or function parsing regresses] → Add representative `where` and function-body cases to
+  focused tests and run the full crate suite.
+
+## Migration Plan
+
+1. Add failing grouping and value regressions for mixed logical expressions.
+2. Reorder parser entry points and encode associativity.
+3. Run parser, evaluator, crate-wide, and conformance suites.
+4. Update coverage evidence only after the test results are recorded.
+
+Rollback is a source revert; there is no API or persisted-data migration.
+
+## Open Questions
+
+- What associativity does the CQL 1.5.3 reference translator apply to an unparenthesized repeated
+  `implies` chain?

--- a/openspec/changes/correct-cql-logical-precedence/proposal.md
+++ b/openspec/changes/correct-cql-logical-precedence/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The current parser makes `implies` bind more tightly than `and` and `or`, contrary to the CQL
+grammar and capable of changing query and function results. The logical precedence ladder needs a
+focused correction with explicit associativity coverage.
+
+## What Changes
+
+- Reorder logical parsing from lowest to highest precedence as `implies`, `or`/`xor`, `and`, then
+  comparison and higher-precedence expressions.
+- Keep `and`, `or`, and `xor` left-associative and encode the specification-defined associativity
+  of repeated `implies`.
+- Add mixed-operator parser and evaluator regressions, including expressions whose values expose
+  incorrect grouping.
+- Verify parenthesized expressions, query `where` clauses, and function bodies retain their
+  explicit or expected grouping.
+- Update parser conformance documentation only when backed by the new tests.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cql-parser-conformance`: Require the CQL logical precedence hierarchy and explicit operator
+  associativity across mixed logical expressions.
+- `cql-spec-coverage`: Require logical-precedence coverage claims to be backed by grouping and
+  evaluation evidence.
+
+## Impact
+
+- Affected crate: `crates/rh-cql`
+- Primary code: `src/parser/expression/precedence.rs`
+- Tests: parser grouping cases, evaluator integration cases, queries, and function bodies
+- Documentation: `crates/rh-cql/SPEC_COVERAGE.md` and related conformance notes
+- No AST, ELM, evaluator API, or public compiler signature changes are expected

--- a/openspec/changes/correct-cql-logical-precedence/specs/cql-parser-conformance/spec.md
+++ b/openspec/changes/correct-cql-logical-precedence/specs/cql-parser-conformance/spec.md
@@ -1,0 +1,52 @@
+## ADDED Requirements
+
+### Requirement: Logical operators follow CQL precedence
+
+The parser SHALL group logical operators from lowest to highest precedence as `implies`,
+`or`/`xor`, `and`, then comparison and higher-precedence expressions.
+
+#### Scenario: And binds more tightly than implies
+
+- **WHEN** `false implies true and false` is parsed
+- **THEN** the AST groups as `false implies (true and false)`
+
+#### Scenario: And binds more tightly than or and xor
+
+- **WHEN** unparenthesized expressions mix `and` with `or` or `xor`
+- **THEN** each `and` subexpression is grouped before the surrounding `or` or `xor`
+
+#### Scenario: Or and xor bind more tightly than implies
+
+- **WHEN** unparenthesized expressions mix `implies` with `or` or `xor`
+- **THEN** each `or` or `xor` subexpression is grouped before the surrounding `implies`
+
+### Requirement: Logical associativity is explicit
+
+The parser SHALL keep `and`, `or`, and `xor` left-associative and SHALL implement repeated
+`implies` with the associativity defined by CQL 1.5.3.
+
+#### Scenario: Left-associative logical chains
+
+- **WHEN** three operands are joined by only `and`, only `or`, or only `xor`
+- **THEN** the AST groups the first two operands before the third
+
+#### Scenario: Repeated implies matches the reference grammar
+
+- **WHEN** an unparenthesized chain containing repeated `implies` is parsed
+- **THEN** its AST and evaluated value match the CQL 1.5.3 grammar and reference translator
+
+### Requirement: Explicit grouping and host expressions remain stable
+
+Parentheses SHALL override logical precedence, and the corrected hierarchy SHALL apply consistently
+inside function bodies and query `where` clauses.
+
+#### Scenario: Parentheses override default grouping
+
+- **WHEN** parentheses specify a grouping different from default logical precedence
+- **THEN** the AST preserves the parenthesized grouping
+
+#### Scenario: Functions and queries use the corrected hierarchy
+
+- **WHEN** equivalent mixed logical expressions appear in a function body and a query `where`
+  clause
+- **THEN** both contexts produce the same corrected logical grouping

--- a/openspec/changes/correct-cql-logical-precedence/specs/cql-spec-coverage/spec.md
+++ b/openspec/changes/correct-cql-logical-precedence/specs/cql-spec-coverage/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Logical precedence claims cite grouping and value evidence
+
+Coverage documentation SHALL mark mixed logical precedence and associativity supported only when
+both AST grouping and value-sensitive evaluation tests exist.
+
+#### Scenario: Coverage notes cite mixed-operator regressions
+
+- **WHEN** logical precedence support is documented
+- **THEN** the notes cite tests covering every pairing of `and`, `or`, `xor`, and `implies`
+
+#### Scenario: Associativity evidence is explicit
+
+- **WHEN** repeated logical operators are marked supported
+- **THEN** the evidence includes left-associative `and`/`or`/`xor` chains and the
+  reference-confirmed `implies` behavior
+
+#### Scenario: Conformance results report no wrong-answer regression
+
+- **WHEN** conformance documentation is refreshed after the precedence fix
+- **THEN** it records the command and run date and reports a wrong-answer `fail` count of `0`

--- a/openspec/changes/correct-cql-logical-precedence/tasks.md
+++ b/openspec/changes/correct-cql-logical-precedence/tasks.md
@@ -1,0 +1,28 @@
+## 1. Confirm Grammar and Add Regressions
+
+- [x] 1.1 Confirm repeated `implies` associativity against the CQL 1.5.3 grammar and reference
+  translator and record the expected grouping in tests
+- [x] 1.2 Add AST and value regressions for `false implies true and false` and every mixed pairing
+  of `and`, `or`, `xor`, and `implies`
+- [x] 1.3 Add left-associative chains for `and`, `or`, and `xor`, plus the confirmed repeated
+  `implies` chain
+- [x] 1.4 Add parenthesized controls and equivalent mixed expressions in a function body and query
+  `where` clause
+
+## 2. Correct Logical Parser Structure
+
+- [x] 2.1 Reorder precedence entry points so `implies` delegates to `or`/`xor`, which delegates to
+  `and`, which delegates to comparison expressions
+- [x] 2.2 Preserve left folds for `and`, `or`, and `xor` and encode the confirmed `implies`
+  associativity explicitly
+- [x] 2.3 Verify `false implies true and false` produces `false implies (true and false)` and
+  evaluates to `true`
+- [x] 2.4 Run focused parser and evaluator tests and resolve function/query regressions
+
+## 3. Validate and Document
+
+- [x] 3.1 Run `cargo test -p rh-cql parser` and `cargo test -p rh-cql --test
+  eval_integration_tests`
+- [x] 3.2 Run `cargo test -p rh-cql` and the full HL7 evaluation suite, confirming `fail=0`
+- [x] 3.3 Update logical grammar/precedence coverage notes with AST and evaluation evidence
+- [x] 3.4 Run `cargo fmt --all`, `just docs-sync`, and `just check`

--- a/openspec/changes/fix-cql-temporal-relationships/.openspec.yaml
+++ b/openspec/changes/fix-cql-temporal-relationships/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/fix-cql-temporal-relationships/design.md
+++ b/openspec/changes/fix-cql-temporal-relationships/design.md
@@ -1,0 +1,76 @@
+## Context
+
+The relative-timing parser currently parses an optional quantity offset but then returns a
+recoverable error whenever that offset is absent. Valid zero-offset phrases therefore never reach
+the timing-direction parser. The AST already stores `offset: Option<TimingOffset>`, and the emitter
+already has representations for inclusive `OnOrBefore` and `OnOrAfter`, so the fix should extend
+the parser path rather than introduce another expression model.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Recognize every zero-offset spelling in the CQL 1.5.3 `temporalRelationship` production.
+- Preserve the complete qualified right operand and optional precision.
+- Keep simple `before`/`after` ELM behavior stable while enabling inclusive forms end to end.
+- Convert the affected HL7 compile errors into supported evaluations with no wrong answers.
+
+**Non-Goals:**
+
+- Redesign the hand-written precedence parser or replace `nom`.
+- Complete nonzero offset or boundary semantics beyond behavior already supported.
+- Change imported HL7 fixtures, public compiler APIs, or whitespace semantics.
+
+## Decisions
+
+### Recognize the relationship before using the optional offset
+
+`parse_relative_timing` will keep quantity offset parsing optional through direction parsing. A
+recognized temporal relationship, rather than the presence of an offset, will distinguish this
+branch from other expressions. This matches the grammar and preserves the existing AST.
+
+The alternative—adding a separate zero-offset parser and AST variant—would duplicate relationship
+ordering and emitter logic without representing a distinct CQL concept.
+
+### Parse longer relationship spellings first
+
+The relationship parser will try `on or before`/`on or after` before their shorter prefixes and
+will support both grammar families: `on or? before|after` and `before|after (or on)?`. Table-driven
+tests will cover every spelling with and without precision.
+
+### Verify semantics at every pipeline stage
+
+Parser assertions will establish AST shape, emitter assertions will establish canonical ELM, and
+evaluator/HL7 assertions will establish supported runtime behavior. Simple `before` and `after`
+will receive emission regressions because their internal parse route may change.
+
+### Make the motivating function an integration regression
+
+The exact multiline medication-request function and a single-line equivalent will be parsed and
+compared. This change owns complete operand consumption and the outer conjunction/timing shape;
+canonical `IsNull` lowering remains owned by `canonicalize-cql-boolean-null-tests`.
+
+## Risks / Trade-offs
+
+- [Relationship prefixes consume the wrong alternative] → Order longer phrases first and test all
+  eight spellings.
+- [Simple `before`/`after` emission changes with the AST route] → Add ELM regressions before the
+  parser refactor.
+- [Parsing success exposes unsupported evaluator behavior] → Run all 17 affected HL7 cases and
+  keep documentation at partial status until end-to-end evidence exists.
+- [Cross-change motivating-function assertion depends on null-test canonicalization] → Assert the
+  temporal subtree here and the canonical nullological subtree in the Boolean/null change.
+
+## Migration Plan
+
+1. Record the current focused and HL7 conformance baseline.
+2. Add regressions for existing neighboring syntax and currently failing temporal forms.
+3. Refactor timing recognition, then close emitter/evaluator gaps exposed by the tests.
+4. Run focused, crate-wide, and HL7 conformance checks before updating coverage documents.
+
+Rollback is a normal source revert; no persisted data or public API migration is involved.
+
+## Open Questions
+
+- Confirm whether any affected HL7 case depends on partially implemented nonzero offset or
+  boundary semantics before marking it supported.

--- a/openspec/changes/fix-cql-temporal-relationships/proposal.md
+++ b/openspec/changes/fix-cql-temporal-relationships/proposal.md
@@ -1,0 +1,47 @@
+## Why
+
+`rh-cql` rejects valid zero-offset temporal relationships such as `on or after` because
+relative-timing parsing currently treats an optional quantity offset as a prerequisite. This
+blocks the motivating medication-request function and all 17 matching expressions in the bundled
+HL7 interval and date/time fixtures despite existing AST and ELM support for zero-offset forms.
+
+## What Changes
+
+- Parse every CQL 1.5.3 zero-offset `before`/`after` temporal relationship spelling, with optional
+  precision and point or interval operands.
+- Preserve optional timing offsets in the existing AST while recognizing the relationship itself
+  as the timing-phrase discriminator.
+- Emit canonical `SameOrBefore` and `SameOrAfter` ELM for inclusive relationships and preserve
+  existing semantics for simple `before` and `after`.
+- Evaluate the affected bundled HL7 temporal cases and add focused parser, emitter, evaluator, and
+  full-function regressions.
+- Refresh conformance evidence only after the supported cases pass without introducing a wrong
+  answer.
+
+## Capabilities
+
+### New Capabilities
+
+None.
+
+### Modified Capabilities
+
+- `cql-parser-conformance`: Require the complete zero-offset CQL 1.5.3 temporal-relationship
+  grammar and regression coverage for the motivating function.
+- `cql-elm-emitter`: Require canonical ELM emission and precision propagation for inclusive
+  zero-offset temporal relationships.
+- `cql-eval-engine`: Require supported zero-offset temporal relationships to evaluate against the
+  bundled HL7 expectations.
+- `cql-spec-coverage`: Require evidence-backed coverage updates for the temporal relationship
+  forms closed by this change.
+
+## Impact
+
+- Affected crate: `crates/rh-cql`
+- Primary code: `src/parser/expression/precedence.rs`, `src/emit/operators.rs`, and
+  `src/eval/operators/temporal.rs`
+- Tests: parser tests, emitter/evaluator integration tests, and the bundled HL7 interval and
+  date/time fixtures
+- Documentation: `crates/rh-cql/SPEC_COVERAGE.md` and `crates/rh-cql/CONFORMANCE.md` when metrics
+  change
+- Public compiler APIs and imported HL7 fixture inputs remain unchanged

--- a/openspec/changes/fix-cql-temporal-relationships/specs/cql-elm-emitter/spec.md
+++ b/openspec/changes/fix-cql-temporal-relationships/specs/cql-elm-emitter/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Zero-offset inclusive temporal relationships emit canonical ELM
+
+The emitter SHALL translate zero-offset inclusive temporal relationships to canonical
+`SameOrBefore` or `SameOrAfter` ELM and SHALL preserve any specified precision.
+
+#### Scenario: On-or-before emits SameOrBefore
+
+- **WHEN** an `OnOrBefore` timing expression with `offset: None` is emitted
+- **THEN** the ELM expression is `SameOrBefore` with the original operands and precision
+
+#### Scenario: On-or-after emits SameOrAfter
+
+- **WHEN** an `OnOrAfter` timing expression with `offset: None` is emitted
+- **THEN** the ELM expression is `SameOrAfter` with the original operands and precision
+
+### Requirement: Exclusive temporal emission remains stable
+
+Routing simple zero-offset `before` and `after` through timing expressions SHALL preserve their
+existing ELM meaning.
+
+#### Scenario: Before and after retain semantics
+
+- **WHEN** simple `before` and `after` expressions are emitted after the parser change
+- **THEN** their ELM operators, operand order, and precision match the pre-change behavior

--- a/openspec/changes/fix-cql-temporal-relationships/specs/cql-eval-engine/spec.md
+++ b/openspec/changes/fix-cql-temporal-relationships/specs/cql-eval-engine/spec.md
@@ -1,0 +1,28 @@
+## ADDED Requirements
+
+### Requirement: Supported zero-offset temporal relationships evaluate end to end
+
+The compiler and evaluator SHALL execute supported zero-offset inclusive temporal relationships
+without parse, emission, dispatch, or semantic errors.
+
+#### Scenario: Bundled inclusive temporal cases match expected values
+
+- **WHEN** the 17 `on or after` and `on or before` expressions in the bundled HL7 interval and
+  date/time fixtures are compiled and evaluated
+- **THEN** every supported case returns its existing HL7 expected value
+
+#### Scenario: Precision reaches temporal evaluation
+
+- **WHEN** a supported zero-offset temporal relationship includes a precision
+- **THEN** evaluation compares operands at that precision
+
+### Requirement: Temporal conformance fixes preserve correctness
+
+The temporal relationship change SHALL NOT turn any previously passing HL7 case into a wrong
+answer.
+
+#### Scenario: Conformance invariant is preserved
+
+- **WHEN** the HL7 CQL evaluation suite is run after the change
+- **THEN** the wrong-answer `fail` count remains `0`
+- **THEN** compile or evaluation error totals improve from the recorded pre-change baseline

--- a/openspec/changes/fix-cql-temporal-relationships/specs/cql-parser-conformance/spec.md
+++ b/openspec/changes/fix-cql-temporal-relationships/specs/cql-parser-conformance/spec.md
@@ -1,0 +1,51 @@
+## ADDED Requirements
+
+### Requirement: Parser supports zero-offset temporal relationships
+
+The parser SHALL recognize all CQL 1.5.3 zero-offset temporal relationship spellings and SHALL
+represent them with the existing relative-timing AST using `offset: None`.
+
+#### Scenario: Prefix relationship forms parse
+
+- **WHEN** expressions using `on before`, `on or before`, `on after`, or `on or after` are parsed
+- **THEN** each expression produces the corresponding exclusive or inclusive timing relationship
+  with no quantity offset
+
+#### Scenario: Suffix relationship forms parse
+
+- **WHEN** expressions using `before`, `before or on`, `after`, or `after or on` are parsed
+- **THEN** each expression produces the corresponding exclusive or inclusive timing relationship
+  with no quantity offset
+
+#### Scenario: Precision and operand shapes are preserved
+
+- **WHEN** zero-offset relationships are parsed with no precision, with `month of` or `hour of`
+  precision, and with point or interval operands
+- **THEN** the AST preserves the supplied precision and consumes both operands completely
+
+### Requirement: Medication-request timing function parses without rewriting
+
+The parser SHALL parse the exact `Is Current Medication Request` function from the regression
+fixture in both multiline and single-line form without source rewrites.
+
+#### Scenario: Multiline function has the expected outer AST
+
+- **WHEN** the multiline function is parsed
+- **THEN** its outer AST groups as `And(And(status-in, intent-in), Or(null-test,
+  on-or-after))`
+- **THEN** `end of FHIRHelpers.ToInterval(...)` consumes the complete qualified invocation
+
+#### Scenario: Physical line layout does not change AST structure
+
+- **WHEN** equivalent multiline and single-line forms of the function are parsed
+- **THEN** their expression AST structures are equivalent apart from source locations
+
+### Requirement: Neighboring expression syntax remains parseable
+
+The parser SHALL preserve existing support for repeated conjunctions, parenthesized logical
+operands, nested member access, qualified calls, and `end of` while adding temporal forms.
+
+#### Scenario: Existing components retain their AST forms
+
+- **WHEN** focused regressions parse each neighboring expression form
+- **THEN** parsing succeeds and produces its pre-change AST shape

--- a/openspec/changes/fix-cql-temporal-relationships/specs/cql-spec-coverage/spec.md
+++ b/openspec/changes/fix-cql-temporal-relationships/specs/cql-spec-coverage/spec.md
@@ -1,0 +1,22 @@
+## ADDED Requirements
+
+### Requirement: Temporal relationship coverage claims are evidence-backed
+
+Coverage documents SHALL mark a temporal relationship form implemented only when parser, canonical
+ELM, and supported evaluation evidence exists for that form.
+
+#### Scenario: Closed temporal rows cite implementation and tests
+
+- **WHEN** zero-offset temporal rows are updated in `SPEC_COVERAGE.md`
+- **THEN** their notes cite the parser/emitter implementation and validating focused or HL7 tests
+
+#### Scenario: Conformance delta records its baseline
+
+- **WHEN** temporal conformance totals are refreshed
+- **THEN** `CONFORMANCE.md` records the run date, command, baseline, post-change totals, and deltas
+
+#### Scenario: Partial behavior remains explicit
+
+- **WHEN** any offset, boundary, precision, or operand behavior remains unsupported
+- **THEN** the corresponding coverage stage remains partial or unsupported rather than being
+  implied complete

--- a/openspec/changes/fix-cql-temporal-relationships/tasks.md
+++ b/openspec/changes/fix-cql-temporal-relationships/tasks.md
@@ -1,0 +1,40 @@
+## 1. Establish Temporal Regression Baseline
+
+- [x] 1.1 Run `cargo test -p rh-cql --test hl7_eval_tests -- --nocapture` and record the dated
+  pass, fail, compile-error, eval-error, and skip totals before implementation
+- [x] 1.2 Add focused parser controls for repeated conjunctions, parenthesized logical operands,
+  nested member access, qualified `ToInterval`, and `end of`
+- [x] 1.3 Add the exact multiline medication-request function and a single-line equivalent,
+  asserting complete input consumption and equivalent outer AST structure
+- [x] 1.4 Add table-driven parser cases for all eight zero-offset relationship spellings, point
+  and interval operands, and absent, `month of`, and `hour of` precision
+
+## 2. Correct Relative Timing Parsing
+
+- [x] 2.1 Refactor `parse_relative_timing` so quantity offset remains optional through relationship
+  recognition and the relationship is the branch discriminator
+- [x] 2.2 Order longer multiword relationships before their shorter prefixes and implement both
+  `on or? before|after` and `before|after (or on)?` grammar families
+- [x] 2.3 Preserve `TimingPhrase::RelativeTiming` with `offset: None`, complete qualified operands,
+  and optional precision in the resulting AST
+- [x] 2.4 Run `cargo test -p rh-cql parser` and resolve any neighboring expression regressions
+
+## 3. Close Emission and Evaluation Gaps
+
+- [x] 3.1 Add emitter regressions for simple `before`/`after` and canonical zero-offset
+  `SameOrBefore`/`SameOrAfter`, including precision propagation
+- [x] 3.2 Update emitter or semantic handling needed for the temporal AST while preserving simple
+  exclusive relationship semantics
+- [x] 3.3 Run all 17 affected bundled HL7 interval/date-time cases and implement any supported
+  temporal evaluator gaps exposed after parsing succeeds
+- [x] 3.4 Verify imported HL7 fixture expressions and expected values remain unchanged
+
+## 4. Validate and Document
+
+- [x] 4.1 Run `cargo test -p rh-cql parser`, `cargo test -p rh-cql --test
+  emit_conformance_tests`, and `cargo test -p rh-cql --test eval_integration_tests`
+- [x] 4.2 Run `cargo test -p rh-cql` and the full `hl7_eval_tests` command; confirm `fail=0` and
+  record compile/eval error deltas from baseline
+- [x] 4.3 Update `SPEC_COVERAGE.md` and `CONFORMANCE.md` only for forms supported by cited parser,
+  emitter, and evaluator evidence
+- [x] 4.4 Run `cargo fmt --all`, `just docs-sync`, and `just check`

--- a/openspec/changes/improve-cql-parse-diagnostics/.openspec.yaml
+++ b/openspec/changes/improve-cql-parse-diagnostics/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-07-15

--- a/openspec/changes/improve-cql-parse-diagnostics/design.md
+++ b/openspec/changes/improve-cql-parse-diagnostics/design.md
@@ -1,0 +1,89 @@
+## Context
+
+Several parser layers use recoverable `nom` errors and repetition combinators. Once an infix
+operator or declaration starter is recognized, a later failure can therefore backtrack and make
+the preceding parse appear complete. The top level then reports the remaining source as trailing
+content, losing the location and nature of the actual error. The CLI exposes that degraded error.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Commit after grammar points that unambiguously require a continuation.
+- Preserve the deepest useful source span through `CqlError` conversion.
+- Require structural EOF for complete libraries.
+- Stabilize CLI syntax-error exit and JSON-envelope behavior with integration tests.
+
+**Non-Goals:**
+
+- Apply `cut` indiscriminately across the grammar.
+- Change valid whitespace/newline behavior or public compiler APIs.
+- Redesign the entire diagnostic type hierarchy or error wording.
+
+## Decisions
+
+### Commit only after unambiguous grammar recognition
+
+Infix parsers will remain recoverable until an operator is recognized; the required right operand
+will then be committed. Statement parsing will use the same principle for recognized declaration
+starters. This preserves alternate parses before commitment while preventing false success after
+commitment.
+
+A broad `cut` around whole precedence levels was rejected because it could break constructs where
+the same tokens delimit `between`, queries, or collections.
+
+### Audit delimiter-sensitive constructs before each commitment
+
+`between ... and ...`, query clauses, list/tuple separators, and alternate statement productions
+will receive focused valid regressions. Commitment points will be introduced narrowly and reviewed
+against those cases.
+
+### Make EOF part of the complete-library grammar
+
+The library parser will require end of input structurally, while fragment parsers may continue to
+return remainders where that is their contract. The top-level declaration loop will propagate a
+failure after a recognized starter instead of allowing `many0` to stop successfully.
+
+### Treat the CLI envelope as a public diagnostic contract
+
+Parser error details will continue through the existing CLI mapping. Integration tests will assert
+exit code `4`, JSON validity, stable envelope fields, and a location at the failing construct; they
+will avoid overfitting incidental prose unless already documented as stable.
+
+## Risks / Trade-offs
+
+- [Overcommitment rejects valid alternatives] → Add valid neighbor tests before each parser cut.
+- [Deepest error is noisy rather than useful] → Prefer committed grammar context and verify source
+  spans with focused malformed examples.
+- [CLI tests become brittle] → Assert documented envelope structure and semantic location fields,
+  not arbitrary full-message snapshots.
+- [EOF changes fragment parser behavior] → Apply structural EOF only to the complete-library entry
+  point.
+
+## Migration Plan
+
+1. Add negative location tests and valid delimiter/alternative controls.
+2. Introduce expression and statement commitment incrementally.
+3. Add structural EOF and preserve the deepest span in error conversion.
+4. Add CLI JSON/exit-code coverage and run focused plus repository documentation checks.
+
+Rollback is a source revert; no user data or API migration is required.
+
+## Open Questions
+
+- Which diagnostic message fields are already documented as stable beyond exit code and the JSON
+  envelope shape?
+
+## Implementation Inventory
+
+- Logical, equality, comparison, union, additive, multiplicative, and power precedence levels use
+  recoverable repetition around an operator and its required right operand.
+- `between` uses a recoverable optional tuple containing both bounds and the `and` delimiter.
+- Interval and timing relationships use recoverable probing before parsing their required operand;
+  malformed continuations can therefore fall through to a shorter expression.
+- The complete-library parser uses recoverable optional/repeated productions for the library
+  header and declaration groups. A recognized but malformed starter can stop its group.
+- `parse_statement` recoverably probes function and expression definitions that share `define`.
+- `CqlParser::parse`, `statement::parse_library`, and `CqlParser::parse_expression` are complete
+  entry points. Internal expression and declaration parsers retain remainder-returning fragment
+  contracts for grammar composition.

--- a/openspec/changes/improve-cql-parse-diagnostics/proposal.md
+++ b/openspec/changes/improve-cql-parse-diagnostics/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Recognized infix operators and declaration starters can currently backtrack past their real
+failure, causing malformed expressions to be reported as unrelated trailing library content.
+Precise committed parsing and structural end-of-input handling are needed for actionable library
+and CLI diagnostics.
+
+## What Changes
+
+- Commit after recognized infix operators and declaration starters so missing or malformed
+  continuations propagate their deepest useful source span.
+- Require complete-library end of input structurally instead of relying only on a remainder check.
+- Apply commitment narrowly enough to preserve valid alternatives, query clauses, list
+  separators, and `between ... and ...` parsing.
+- Add negative parser tests for malformed temporal phrases and right operands.
+- Add `rh cql` CLI integration coverage for syntax-error exit code `4` and the stable JSON error
+  envelope.
+
+## Capabilities
+
+### New Capabilities
+
+- `cql-cli-diagnostics`: Defines stable CLI syntax-error exit and JSON-envelope behavior for CQL
+  commands.
+
+### Modified Capabilities
+
+- `cql-parser-conformance`: Require committed failures at recognized constructs, structural EOF,
+  and preservation of the deepest useful source span.
+
+## Impact
+
+- Affected code: `crates/rh-cql/src/parser/` and `apps/rh-cli` CQL integration tests
+- Primary parser areas: expression precedence, statement parsing, top-level library parsing, and
+  span-to-error conversion
+- CLI behavior is clarified and regression-tested; successful command behavior is unchanged
+- No public compiler API signature changes or whitespace/newline semantic changes

--- a/openspec/changes/improve-cql-parse-diagnostics/specs/cql-cli-diagnostics/spec.md
+++ b/openspec/changes/improve-cql-parse-diagnostics/specs/cql-cli-diagnostics/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: CQL syntax errors use the documented CLI exit code
+
+The `rh cql` commands SHALL exit with code `4` when compilation fails because the input contains a
+CQL syntax error.
+
+#### Scenario: Human-readable syntax error exit
+
+- **WHEN** a CQL command processes malformed source in the default output format
+- **THEN** the process exits with code `4` and reports the parser failure
+
+#### Scenario: JSON syntax error exit
+
+- **WHEN** a CQL command processes malformed source with global `--format json`
+- **THEN** the process exits with code `4`
+
+### Requirement: CQL syntax errors have a stable JSON envelope
+
+With global `--format json`, a CQL syntax error SHALL be emitted as a valid agent-consumable error
+envelope containing the established error fields and the useful source location.
+
+#### Scenario: JSON error is machine-readable
+
+- **WHEN** malformed CQL is processed with global `--format json`
+- **THEN** standard output or standard error, according to the documented CLI contract, contains
+  one valid JSON error envelope and no unstructured diagnostic mixed into that stream
+
+#### Scenario: JSON error locates the failing construct
+
+- **WHEN** the malformed input contains a recognized operator with an invalid right operand
+- **THEN** the JSON error location identifies that operand rather than unrelated trailing content
+
+#### Scenario: Successful CLI behavior is unchanged
+
+- **WHEN** valid CQL is processed in human-readable or JSON format
+- **THEN** the command retains its existing success exit code and output envelope

--- a/openspec/changes/improve-cql-parse-diagnostics/specs/cql-parser-conformance/spec.md
+++ b/openspec/changes/improve-cql-parse-diagnostics/specs/cql-parser-conformance/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Recognized constructs commit to required continuations
+
+After recognizing an infix operator or declaration starter, the parser SHALL propagate a malformed
+required continuation instead of backtracking to a shorter successful parse.
+
+#### Scenario: Malformed right operand reports after its operator
+
+- **WHEN** a recognized infix operator is followed by a malformed nested right operand
+- **THEN** parsing fails at the malformed operand rather than reporting trailing content beginning
+  at the preceding operator
+
+#### Scenario: Malformed temporal phrase reports its own location
+
+- **WHEN** a temporal relationship is recognized but its required direction or operand is malformed
+- **THEN** the error span identifies the temporal phrase or malformed operand
+
+#### Scenario: Invalid declaration propagates from its starter
+
+- **WHEN** a recognized library declaration starter is followed by an invalid declaration
+- **THEN** the statement loop propagates that declaration error rather than ending successfully
+
+### Requirement: Complete library parsing requires structural end of input
+
+The complete-library parser SHALL include end of input in its grammar and SHALL reject unconsumed
+source through the normal parse-error path.
+
+#### Scenario: Valid complete library reaches EOF
+
+- **WHEN** a valid library and its permitted trailing trivia are parsed
+- **THEN** parsing succeeds only after consuming the complete input
+
+#### Scenario: Unexpected trailing construct is rejected structurally
+
+- **WHEN** source remains after the final valid declaration
+- **THEN** the complete-library parser returns a located parse error instead of a successful result
+  plus a post-parse remainder
+
+### Requirement: Parser commitment preserves valid alternatives
+
+Commitment SHALL NOT change valid parsing of `between ... and ...`, query clauses, collection
+separators, or alternate statement productions.
+
+#### Scenario: Delimiter-sensitive controls remain valid
+
+- **WHEN** focused valid examples exercise each delimiter-sensitive or alternative construct
+- **THEN** each example produces its pre-change AST shape without a committed parse error
+
+### Requirement: Parse errors preserve the deepest useful span
+
+Conversion from parser errors to `CqlError` SHALL preserve the source span of the deepest useful
+committed failure.
+
+#### Scenario: Nested failure location survives conversion
+
+- **WHEN** a nested parser failure is converted to the public CQL error type
+- **THEN** its line and column identify the nested failing construct rather than an earlier Boolean
+  operator or the start of trailing content

--- a/openspec/changes/improve-cql-parse-diagnostics/tasks.md
+++ b/openspec/changes/improve-cql-parse-diagnostics/tasks.md
@@ -1,0 +1,39 @@
+## 1. Map Commitment Boundaries and Add Tests
+
+- [x] 1.1 Inventory recoverable expression and statement parsers that can stop after recognizing an
+  infix operator or declaration starter
+- [x] 1.2 Add negative tests for malformed temporal phrases, nested right operands, invalid
+  declarations, and unexpected trailing constructs with expected source spans
+- [x] 1.3 Add valid controls for `between ... and ...`, query clauses, list/tuple separators, and
+  alternate statement productions before introducing commitment
+- [x] 1.4 Document which complete-library versus fragment parser entry points require EOF
+
+## 2. Implement Precise Parser Failures
+
+- [x] 2.1 Commit narrowly to the required right operand after each recognized infix operator
+- [x] 2.2 Make recognized declaration starters propagate invalid declaration errors instead of
+  allowing the top-level repetition to stop successfully
+- [x] 2.3 Require structural EOF in the complete-library production while preserving fragment parser
+  remainder contracts
+- [x] 2.4 Preserve the deepest useful committed source span when converting parser failures to
+  `CqlError`
+- [x] 2.5 Run focused parser tests and remove or relocate any commitment that rejects a valid
+  alternative
+
+## 3. Stabilize CLI Diagnostic Behavior
+
+- [x] 3.1 Review the documented `rh cql` exit-code and global JSON-format contract before defining
+  integration assertions
+- [x] 3.2 Add CLI integration cases showing CQL syntax errors exit with code `4` in human and JSON
+  output modes
+- [x] 3.3 Assert the JSON error envelope is machine-readable, contains the established stable fields,
+  and reports the nested failing construct location
+- [x] 3.4 Verify valid CQL commands retain their existing success codes and human/JSON envelopes
+
+## 4. Validate
+
+- [x] 4.1 Run `cargo test -p rh-cql parser` and `cargo test -p rh-cli --test
+  cql_integration_test`
+- [x] 4.2 Run `cargo test -p rh-cql`, `cargo test -p rh-cli`, and the full HL7 evaluation suite,
+  confirming `fail=0`
+- [x] 4.3 Run `cargo fmt --all`, `just docs-sync`, and `just check`

--- a/openspec/plans/rh-cql-parser-conformance-fixes.md
+++ b/openspec/plans/rh-cql-parser-conformance-fixes.md
@@ -1,0 +1,305 @@
+# rh-cql Parser Conformance Fix Plan
+
+**Area**: `crates/rh-cql`  
+**Primary scope**: temporal relationships, Boolean/null tests, logical precedence, and parse
+diagnostics  
+**Baseline date**: 2026-07-14  
+**Status**: Completed 2026-07-15
+
+This plan addresses the parser defects exposed by the valid CQL function containing chained
+conjunctions, `is null`, `end of`, and `on or after`. The work should preserve the current
+zero-wrong-answer conformance invariant while converting affected compile errors into passing
+parse, emit, and evaluation cases.
+
+---
+
+## 1. Goals and Non-Goals
+
+### Goals
+
+- Parse the original `Is Current Medication Request` function without source rewrites.
+- Support the complete CQL 1.5.3 zero-offset temporal relationship forms, including
+  `on or after` and `on or before`.
+- Emit canonical `IsNull`, `IsTrue`, and `IsFalse` ELM for Boolean/null-test syntax.
+- Give `implies` lower precedence than `or`/`xor` and `and`.
+- Report malformed expressions at the actual failing construct instead of as trailing library
+  content at an earlier Boolean operator.
+- Add regression coverage at parser, emitter, evaluator, CLI, and HL7 conformance levels.
+- Correct conformance documentation so every claimed capability has test evidence.
+
+### Non-Goals
+
+- Redesigning the full hand-written parser or replacing `nom`.
+- Expanding unrelated CQL operator coverage.
+- Changing whitespace or newline semantics.
+- Completing offset/boundary timing semantics that are already documented as placeholders,
+  except where required by the zero-offset relationships in this plan.
+- Changing public compiler API signatures.
+
+---
+
+## 2. Current Baseline
+
+- Repeated conjunctions and left folding already work: `A and B and C` parses correctly.
+- Parenthesized Boolean operands, nested member access, qualified function calls, and `end of`
+  parse correctly in isolation.
+- The first syntax failure in the original function is the zero-offset `on or after` phrase.
+- `parse_relative_timing` recognizes an optional offset but rejects the expression before parsing
+  a timing direction when the offset is absent.
+- The AST and emitter already represent and emit `OnOrAfter`/`OnOrBefore` with `offset: None`.
+- All 17 single-line `on or after`/`on or before` expressions in the bundled HL7 interval and
+  date/time fixtures currently fail parsing.
+- `A is null`, `A is true`, and `A is false` currently parse as generic `Is` type tests. The
+  evaluator special-cases a type named `null`; `true is true` and `false is false` evaluate
+  incorrectly.
+- The current precedence chain makes `implies` bind more tightly than `and` and `or`.
+- The HL7 test harness reports remaining compile/evaluation errors as unimplemented outcomes, so
+  the affected cases do not currently fail the test target.
+
+Record the exact pre-change totals from a fresh run before implementation:
+
+```bash
+cargo test -p rh-cql --test hl7_eval_tests -- --nocapture
+```
+
+Expected starting summary from the investigation:
+
+```text
+pass=1241
+fail=0
+compile_err=89
+eval_err=23
+skip=45
+```
+
+---
+
+## 3. Implementation Sequence
+
+### Phase 1 — Add Focused Regression Coverage
+
+- [x] 1.1 Add parser tests for repeated `and`, parenthesized `and`/`or`, nested member access,
+  `is null`, qualified `ToInterval`, and `end of` so the already-working components remain
+  protected.
+- [x] 1.2 Add a parser regression containing the exact multiline
+  `Is Current Medication Request` function.
+- [x] 1.3 Add the same function on one physical line and assert that it produces the same AST
+  shape as the multiline version.
+- [x] 1.4 Add table-driven temporal relationship cases for:
+  - `on before`
+  - `on or before`
+  - `on after`
+  - `on or after`
+  - `before`
+  - `before or on`
+  - `after`
+  - `after or on`
+- [x] 1.5 Cover temporal relationships with no precision, with `month of`/`hour of`, and with
+  point and interval operands.
+- [x] 1.6 Add canonical AST tests for `is null`, `is true`, `is false`, and each `is not` form.
+- [x] 1.7 Add a precedence regression whose result differs between the correct and current
+  groupings, such as `false implies true and false`.
+
+The tests added alongside each implementation patch must fail against the old behavior and pass
+against the new behavior. Avoid merging a commit that leaves the default test suite red.
+
+### Phase 2 — Fix Zero-Offset Temporal Relationships
+
+- [x] 2.1 Refactor `parse_relative_timing` so `quantityOffset` remains optional through timing
+  direction parsing.
+- [x] 2.2 Parse the temporal relationship before deciding that the input is not a timing phrase;
+  do not use offset presence as the discriminator.
+- [x] 2.3 Preserve the existing `TimingPhrase::RelativeTiming` representation with
+  `offset: Option<TimingOffset>`.
+- [x] 2.4 Ensure longer multiword forms are attempted before their shorter prefixes.
+- [x] 2.5 Match the CQL 1.5.3 `temporalRelationship` production, including the optional `or` in
+  `on or? before|after` and the optional `or on` suffix after `before|after`.
+- [x] 2.6 Verify that simple `before` and `after` retain their current emitted ELM semantics even
+  if their internal AST route changes from `BinaryExpression` to `TimingExpression`.
+- [x] 2.7 Verify zero-offset `OnOrBefore` emits `SameOrBefore` and `OnOrAfter` emits
+  `SameOrAfter`, including precision propagation.
+- [x] 2.8 Run all 17 bundled HL7 `on or after`/`on or before` cases and close any downstream
+  semantic, emit, or evaluation gaps exposed after parsing succeeds.
+
+Likely code areas:
+
+- `src/parser/expression/precedence.rs`
+- `src/parser/ast.rs` only if an uncovered grammar form cannot use the existing variants
+- `src/emit/operators.rs`
+- `src/eval/operators/temporal.rs`
+- `tests/fixtures/hl7_cql_tests/CqlIntervalOperatorsTest.xml`
+- `tests/fixtures/hl7_cql_tests/CqlDateTimeOperatorsTest.xml`
+
+Do not edit the imported HL7 fixture expressions or expected values to accommodate the parser.
+
+### Phase 3 — Implement Canonical Boolean/Null Tests
+
+- [x] 3.1 Add a dedicated parser branch for
+  `expression is not? (null | true | false)` before generic `is/as typeSpecifier` parsing.
+- [x] 3.2 Lower positive forms to `UnaryOperator::IsNull`, `IsTrue`, or `IsFalse`.
+- [x] 3.3 Lower negative forms to `Not(IsNull(...))`, `Not(IsTrue(...))`, or
+  `Not(IsFalse(...))` unless a dedicated negated representation is required by canonical ELM.
+- [x] 3.4 Preserve generic type checks such as `value is FHIR.Quantity` and
+  `value is not FHIR.Quantity`.
+- [x] 3.5 Emit canonical ELM `IsNull`, `IsTrue`, and `IsFalse` nodes from source syntax.
+- [x] 3.6 Add evaluator assertions for true, false, and null operands using CQL three-valued
+  logic.
+- [x] 3.7 Retain the evaluator's legacy `Is`-type-`null` compatibility path initially if needed
+  for previously generated or external ELM, but ensure the compiler no longer emits that shape.
+- [x] 3.8 Add compile-to-ELM golden assertions so AST-only correctness cannot mask a
+  noncanonical emitted representation.
+
+Likely code areas:
+
+- `src/parser/expression/precedence.rs`
+- `src/parser/ast.rs`
+- `src/semantics/analyzer.rs`
+- `src/emit/operators.rs`
+- `src/eval/engine.rs`
+- `tests/golden/`
+- `tests/eval_integration_tests.rs`
+
+### Phase 4 — Correct Logical Precedence
+
+- [x] 4.1 Reorder the logical precedence entry points to match CQL, from lowest to highest:
+  `implies`, `or`/`xor`, `and`, then comparison and higher-precedence expressions.
+- [x] 4.2 Keep `and`, `or`, and `xor` left-associative.
+- [x] 4.3 Confirm the intended associativity of repeated `implies` against the CQL 1.5.3 grammar
+  and reference translator, then encode it explicitly in tests.
+- [x] 4.4 Add mixed logical tests covering all pairings of `and`, `or`, `xor`, and `implies`,
+  with and without parentheses.
+- [x] 4.5 Verify existing query `where` expressions and function bodies do not regress.
+
+Likely code area:
+
+- `src/parser/expression/precedence.rs`
+
+### Phase 5 — Improve Parse Commitment and EOF Diagnostics
+
+- [x] 5.1 Make a recognized infix operator commit to requiring its right operand so a nested
+  failure is not silently treated as the end of the expression.
+- [x] 5.2 Apply commitment narrowly; audit `between ... and ...`, query clauses, list separators,
+  and alternate statement parsers before adding `nom::combinator::cut` broadly.
+- [x] 5.3 Make the complete library production require EOF structurally instead of relying only
+  on a post-parse remainder check.
+- [x] 5.4 Change the top-level statement loop so a recognized declaration starter followed by an
+  invalid declaration propagates its error rather than ending `many0` successfully.
+- [x] 5.5 Preserve the deepest useful source span when converting `nom` errors to `CqlError`.
+- [x] 5.6 Add negative tests asserting that malformed temporal phrases point at the temporal
+  phrase and malformed right operands point after their operator.
+- [x] 5.7 Add CLI integration coverage for exit code `4` and stable JSON error envelopes on CQL
+  syntax errors.
+
+Likely code areas:
+
+- `src/parser/expression/precedence.rs`
+- `src/parser/statement.rs`
+- `src/parser/mod.rs`
+- `src/parser/span.rs`
+- `apps/rh-cli/tests/cql_integration_test.rs`
+
+---
+
+## 4. Acceptance Criteria
+
+The change is complete when all of the following are true:
+
+- [x] The exact original multiline function parses successfully without changing its CQL.
+- [x] Its outer AST is `And(And(status-in, intent-in), Or(is-null, on-or-after))`.
+- [x] `end of FHIRHelpers.ToInterval(...)` consumes the complete qualified invocation.
+- [x] `validityPeriod is null` produces an `IsNull` AST and canonical ELM node.
+- [x] `true is true`, `false is false`, and `null is null` evaluate to `true`.
+- [x] The corresponding `is not` forms evaluate correctly.
+- [x] All 17 bundled zero-offset `on or after`/`on or before` expressions compile, and their
+  supported evaluations match the existing HL7 expected outputs.
+- [x] `false implies true and false` groups as
+  `false implies (true and false)` and evaluates to `true`.
+- [x] Multiline and single-line forms produce equivalent AST structure.
+- [x] A malformed nested right operand is reported at the nested construct, not as unexpected
+  content beginning at the preceding `and`.
+- [x] No previously passing HL7 case becomes a wrong answer.
+- [x] The conformance `fail` count remains `0`.
+- [x] Compile/evaluation error counts improve from the recorded baseline.
+
+---
+
+## 5. Validation Commands
+
+Run focused checks during implementation:
+
+```bash
+cargo test -p rh-cql parser
+cargo test -p rh-cql --test emit_conformance_tests
+cargo test -p rh-cql --test eval_integration_tests
+cargo test -p rh-cli --test cql_integration_test
+```
+
+Run the full CQL and conformance checks before completion:
+
+```bash
+cargo test -p rh-cql
+cargo test -p rh-cql --test hl7_eval_tests -- --nocapture
+```
+
+Run repository gates after code and documentation are finalized:
+
+```bash
+cargo fmt --all
+just docs-sync
+just check
+```
+
+If the local Java reference translator is configured, compare the focused source and affected
+HL7 cases against it before updating conformance claims.
+
+---
+
+## 6. Documentation and Conformance Updates
+
+- [x] 6.1 Update `crates/rh-cql/SPEC_COVERAGE.md` only after canonical AST, emit, and eval tests
+  support each claimed status.
+- [x] 6.2 Correct the nullological rows if any stage remains partial.
+- [x] 6.3 Add an explicit temporal-relationship coverage note for zero-offset multiword forms.
+- [x] 6.4 Refresh `crates/rh-cql/CONFORMANCE.md` with dated pre/post totals.
+- [x] 6.5 Record how many of the 17 affected HL7 cases moved from compile error to pass or to a
+  newly exposed downstream category.
+- [x] 6.6 Keep generated reports under `conformance/results/` generated by their scripts rather
+  than editing them manually.
+
+---
+
+## 7. Risks and Mitigations
+
+- **Parser backtracking regressions**: Removing the offset gate may cause temporal parsing to
+  claim tokens intended for another construct. Mitigate with table-driven positive and negative
+  parser tests and by requiring a successfully parsed temporal direction before committing.
+- **AST-shape regressions for simple `before`/`after`**: A unified timing parser may change the
+  internal representation. Mitigate by asserting emitted ELM equivalence and evaluator behavior,
+  not only AST variants.
+- **Over-broad `cut` usage**: Commitment can prevent legitimate alternatives from backtracking.
+  Add commitment only after an unambiguous operator or declaration prefix and test neighboring
+  grammar alternatives.
+- **Hidden downstream timing gaps**: Fixing parsing may convert compile errors into emit or eval
+  errors. Treat the 17 focused HL7 cases as end-to-end scope rather than declaring completion at
+  parse success.
+- **Compatibility with previously emitted noncanonical ELM**: Keep evaluator compatibility for
+  `Is` with type `null` during the initial change while ensuring new compilation uses `IsNull`.
+- **Conformance metric drift**: Capture the baseline immediately before implementation and require
+  zero new wrong answers as a hard gate.
+
+---
+
+## 8. Suggested Review Boundaries
+
+The work can be delivered as three independently reviewable pull requests:
+
+1. **Temporal parsing and focused HL7 closure** — Phases 1–2 for timing relationships, including
+   exact-function regression coverage.
+2. **Canonical Boolean/null tests and precedence** — Phases 3–4 with golden ELM and evaluator
+   coverage.
+3. **Diagnostics and conformance refresh** — Phase 5 plus documentation, final metrics, and full
+   repository gates.
+
+PR 2 may proceed in parallel with PR 1 after the shared regression-test conventions are agreed.
+PR 3 should follow both because diagnostic expectations and conformance totals depend on their
+final parser behavior.


### PR DESCRIPTION
## Summary

- canonicalize source `is null`, `is true`, and `is false` forms through AST, ELM emission, and evaluation while retaining legacy generic-`Is` compatibility
- correct logical precedence to `implies` → `or`/`xor` → `and`, with explicit associativity and mixed-operator coverage
- parse, emit, and evaluate all zero-offset temporal relationship spellings, including precision and point/interval operands
- commit parser failures after recognized operators and declaration starters, require structural EOF, and preserve useful source locations
- add human/JSON syntax-error behavior for `cql compile`
- add the four OpenSpec changes, implementation plan, and refreshed conformance documentation

## Why

The parser could backtrack past recognized constructs, grouped logical expressions with the wrong hierarchy, treated Boolean/null identity tests as generic type tests, and rejected valid zero-offset temporal relationships. Together these defects prevented a real medication-request function and 17 bundled HL7 temporal cases from compiling.

## Impact

The medication-request regression now parses without rewriting, canonical ELM is emitted for nullological and temporal forms, and the affected HL7 cases move from compile errors to passing results. Parse failures also retain the nested failing location instead of surfacing as unrelated trailing content.

## Validation

- `just check`
- `just docs-sync`
- `cargo test -p rh-cql parser` — 148 passed
- `cargo test -p rh-cql --test emit_conformance_tests` — 24 passed
- `cargo test -p rh-cql --test eval_integration_tests` — 90 passed
- `cargo test -p rh-cli --test cql_integration_test` — 41 passed
- `cargo test -p rh-cql --test hl7_eval_tests -- --nocapture` — pass=1258, fail=0, compile_err=72, eval_err=23
- strict OpenSpec validation passed for all four changes

## Known verification follow-ups

This remains a draft because OpenSpec verification found:

- the syntax-error exit/envelope contract is implemented for `cql compile`, but `cql validate` and `cql eval` still use different exit/error paths
- logical coverage notes should cite the focused parser/evaluator test names directly
- temporal coverage should explicitly mark unsupported offset/boundary emission paths as partial
