### PR TITLE
Add rh-cpg: Rust-native PlanDefinition $apply core + rh cpg apply CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2052,6 +2052,7 @@ dependencies = [
  "openssl",
  "predicates",
  "rh-codegen",
+ "rh-cpg",
  "rh-cql",
  "rh-fhirpath",
  "rh-foundation",
@@ -2093,6 +2094,20 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tracing",
+]
+
+[[package]]
+name = "rh-cpg"
+version = "0.2.8"
+dependencies = [
+ "base64",
+ "rh-cql",
+ "rh-fhirpath",
+ "rh-hl7-fhir-r4-core",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "uuid",
 ]
 
 [[package]]
@@ -3199,6 +3214,7 @@ version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]

--- a/apps/rh-cli/Cargo.toml
+++ b/apps/rh-cli/Cargo.toml
@@ -35,6 +35,7 @@ is-terminal = "0.4"
 # Local workspace crates
 rh-foundation = { path = "../../crates/rh-foundation", version = "0.2.8", features = ["http"] }
 rh-codegen = { path = "../../crates/rh-codegen", version = "0.2.8" }
+rh-cpg = { path = "../../crates/rh-cpg" }
 rh-cql = { path = "../../crates/rh-cql", version = "0.2.8", features = ["repl"] }
 rh-fhirpath = { path = "../../crates/rh-fhirpath", version = "0.2.8", features = ["repl"] }
 rh-packager = { path = "../../crates/rh-packager", version = "0.2.8" }

--- a/apps/rh-cli/src/cpg.rs
+++ b/apps/rh-cli/src/cpg.rs
@@ -1,0 +1,134 @@
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use clap::Args;
+use clap::Subcommand;
+use serde_json::{json, Map, Value};
+
+use crate::output::{Envelope, OutputContext, OutputFormat};
+use rh_cpg::apply::plan_definition::apply_plan_definition;
+use rh_cpg::context::ApplyContext;
+use rh_cpg::resolver::BundleResolver;
+
+#[derive(Subcommand)]
+pub enum CpgCommands {
+    /// Apply a PlanDefinition via the FHIR $apply operation
+    Apply(ApplyArgs),
+}
+
+#[derive(Args)]
+pub struct ApplyArgs {
+    /// Path to the PlanDefinition JSON file
+    #[clap(long, value_name = "FILE")]
+    plan_definition: PathBuf,
+
+    /// Subject reference, e.g. "Patient/123"
+    #[clap(long)]
+    subject: String,
+
+    /// Path to the content FHIR Bundle JSON (definitions, libraries, terminology)
+    #[clap(long, value_name = "FILE")]
+    content: PathBuf,
+
+    /// Path to the data FHIR Bundle JSON (patient data)
+    #[clap(long, value_name = "FILE")]
+    data: Option<PathBuf>,
+
+    /// Encounter reference, optional
+    #[clap(long)]
+    encounter: Option<String>,
+
+    /// Practitioner reference, optional
+    #[clap(long)]
+    practitioner: Option<String>,
+
+    /// Organization reference, optional
+    #[clap(long)]
+    organization: Option<String>,
+}
+
+pub async fn handle_command(cmd: CpgCommands, ctx: &OutputContext) -> Result<()> {
+    let CpgCommands::Apply(args) = cmd;
+
+    let plan_definition = read_json(&args.plan_definition)?;
+    let content = read_json(&args.content)?;
+    let content_bundle = as_content_bundle(content)?;
+    let resolver = BundleResolver::new(&content_bundle)?;
+    let mut context = ApplyContext::new(Arc::new(resolver), args.subject);
+
+    if let Some(data) = args.data {
+        context.data = Some(read_json(&data)?);
+    }
+    context.encounter = args.encounter;
+    context.practitioner = args.practitioner;
+    context.organization = args.organization;
+
+    let result = apply_plan_definition(&plan_definition, &context)?;
+
+    if ctx.is_json() {
+        let envelope = Envelope::ok(result, "cpg apply");
+        let json = if matches!(ctx.format, OutputFormat::Json) {
+            serde_json::to_string_pretty(&envelope)?
+        } else {
+            serde_json::to_string(&envelope)?
+        };
+        println!("{json}");
+    } else {
+        println!("{}", serde_json::to_string_pretty(&result)?);
+    }
+
+    Ok(())
+}
+
+fn read_json(path: &PathBuf) -> Result<Value> {
+    let contents = fs::read_to_string(path)
+        .with_context(|| format!("failed to read JSON file {}", path.display()))?;
+    serde_json::from_str(&contents)
+        .with_context(|| format!("failed to parse JSON file {}", path.display()))
+}
+
+fn as_content_bundle(value: Value) -> Result<Value> {
+    if value.get("resourceType").and_then(Value::as_str) == Some("Bundle") {
+        return Ok(value);
+    }
+
+    let resources = match value {
+        Value::Array(resources) => resources,
+        Value::Object(_) => vec![value],
+        Value::Null => return Err(anyhow::anyhow!("content JSON must contain resources")),
+        other => {
+            return Err(anyhow::anyhow!(
+                "content JSON must be a Bundle, resource object, or resource array; got {}",
+                json_type_name(&other)
+            ))
+        }
+    };
+
+    let entries: Vec<Value> = resources
+        .into_iter()
+        .map(|resource| {
+            let mut entry = Map::new();
+            entry.insert("resource".to_string(), resource);
+            Value::Object(entry)
+        })
+        .collect();
+
+    Ok(json!({
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": entries,
+    }))
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "boolean",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}

--- a/apps/rh-cli/src/main.rs
+++ b/apps/rh-cli/src/main.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use clap::{Parser, Subcommand};
 
 mod codegen;
+mod cpg;
 mod cql;
 mod download;
 mod fhirpath;
@@ -48,6 +49,10 @@ struct Cli {
 enum Commands {
     /// Generate organized Rust crates from FHIR Packages
     Codegen(codegen::CodegenArgs),
+
+    /// Apply clinical practice guideline definitions (CPG)
+    #[clap(subcommand)]
+    Cpg(cpg::CpgCommands),
 
     /// Compile CQL (Clinical Quality Language) to ELM
     #[clap(subcommand)]
@@ -110,6 +115,7 @@ async fn main() -> Result<()> {
 
     let result = match cli.command {
         Commands::Codegen(cmd) => codegen::handle_command(cmd, &output_ctx).await,
+        Commands::Cpg(cmd) => cpg::handle_command(cmd, &output_ctx).await,
         Commands::Cql(cmd) => cql::handle_command(cmd, &output_ctx).await,
         Commands::Download(cmd) => download::handle_command(cmd, &output_ctx).await,
         Commands::Fhirpath(cmd) => fhirpath::handle_command(cmd, &output_ctx).await,

--- a/apps/rh-cli/tests/cpg_apply_test.rs
+++ b/apps/rh-cli/tests/cpg_apply_test.rs
@@ -1,0 +1,49 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+use serde_json::Value;
+use tempfile::TempDir;
+
+#[test]
+fn cpg_apply_outputs_request_group() {
+    let temp = TempDir::new().expect("temp dir");
+    let fixture = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../crates/rh-cpg/tests/fixtures/PlanDefinition-SimplePlanDefinition.json");
+    let plan_path = temp.path().join("plan.json");
+    fs::copy(fixture, &plan_path).expect("copy plan fixture");
+
+    let content_path = temp.path().join("content.json");
+    fs::write(
+        &content_path,
+        r#"{"resourceType":"Bundle","type":"collection","entry":[]}"#,
+    )
+    .expect("write content bundle");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_rh"))
+        .args([
+            "cpg",
+            "apply",
+            "--plan-definition",
+            plan_path.to_str().unwrap(),
+            "--subject",
+            "Patient/123",
+            "--content",
+            content_path.to_str().unwrap(),
+        ])
+        .output()
+        .expect("run rh cpg apply");
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let bundle: Value = serde_json::from_slice(&output.stdout).expect("parse JSON stdout");
+    assert_eq!(
+        bundle
+            .pointer("/entry/0/resource/resourceType")
+            .and_then(Value::as_str),
+        Some("RequestGroup")
+    );
+}

--- a/crates/rh-cpg/Cargo.toml
+++ b/crates/rh-cpg/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "rh-cpg"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Clinical Practice Guidelines (CPG) capabilities for FHIR resources"
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+rust-version.workspace = true
+keywords = ["cpg", "fhir", "clinical-guidelines", "healthcare"]
+categories = ["science", "api-bindings"]
+
+[dependencies]
+base64 = { workspace = true }
+uuid = { version = "1", features = ["v4"] }
+rh-cql = { path = "../rh-cql", version = "0.2.0-beta.2" }
+rh-fhirpath = { path = "../rh-fhirpath", version = "0.2.0-beta.2" }
+rh-hl7-fhir-r4-core = { path = "../rh-hl7_fhir_r4_core", version = "0.2.0-beta.2" }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }

--- a/crates/rh-cpg/src/apply/action.rs
+++ b/crates/rh-cpg/src/apply/action.rs
@@ -1,0 +1,357 @@
+use serde_json::{json, Map, Value};
+
+use crate::apply::activity_definition::apply_activity_definition;
+use crate::apply::dynamic_value::process_dynamic_value;
+use crate::apply::plan_definition::{apply_plan_definition, BASE_URL};
+use crate::context::ApplyContext;
+use crate::error::{CpgError, CpgResult};
+
+const ACTION_TYPE_SYSTEM: &str = "http://terminology.hl7.org/CodeSystem/action-type";
+const CREATE_ACTION_CODE: &str = "create";
+
+/// Apply a single PlanDefinition action to a subject, returning the resulting
+/// RequestGroupAction and appending created resources to the caller's bundle
+/// entries. Returns `None` when the action is not applicable.
+pub fn apply_plan_definition_action(
+    action: &Value,
+    plan_definition: &Value,
+    ctx: &ApplyContext,
+    resource_bundle_entries: &mut Vec<Value>,
+    libraries: &[Value],
+) -> CpgResult<Option<Value>> {
+    if !is_applicable(action, plan_definition, ctx, libraries)? {
+        return Ok(None);
+    }
+
+    let mut request_group_action = Map::new();
+    for field in [
+        "id",
+        "prefix",
+        "title",
+        "description",
+        "priority",
+        "textEquivalent",
+        "type",
+        "groupingBehavior",
+        "selectionBehavior",
+        "requiredBehavior",
+        "precheckBehavior",
+        "cardinalityBehavior",
+        "code",
+        "documentation",
+        "condition",
+        "relatedAction",
+    ] {
+        copy_non_null_field(&mut request_group_action, action, field);
+    }
+
+    for timing_field in [
+        "timingAge",
+        "timingDuration",
+        "timingDateTime",
+        "timingPeriod",
+        "timingRange",
+        "timingTiming",
+    ] {
+        if copy_non_null_field(&mut request_group_action, action, timing_field) {
+            break;
+        }
+    }
+
+    let library_canonicals = library_canonical_strings(libraries);
+    apply_definition(
+        action,
+        plan_definition,
+        ctx,
+        resource_bundle_entries,
+        &library_canonicals,
+        &mut request_group_action,
+    )?;
+
+    if let Some(children) = action.get("action").and_then(Value::as_array) {
+        if !children.is_empty() {
+            let mut child_actions = Vec::new();
+            for child in children {
+                if let Some(child_action) = apply_plan_definition_action(
+                    child,
+                    plan_definition,
+                    ctx,
+                    resource_bundle_entries,
+                    libraries,
+                )? {
+                    child_actions.push(child_action);
+                }
+            }
+
+            request_group_action.insert("action".to_string(), Value::Array(child_actions));
+        }
+    }
+
+    Ok(Some(Value::Object(request_group_action)))
+}
+
+fn apply_definition(
+    action: &Value,
+    plan_definition: &Value,
+    ctx: &ApplyContext,
+    resource_bundle_entries: &mut Vec<Value>,
+    library_canonicals: &[String],
+    request_group_action: &mut Map<String, Value>,
+) -> CpgResult<()> {
+    let Some(definition_canonical) =
+        non_null_field(action, "definitionCanonical").and_then(Value::as_str)
+    else {
+        return Ok(());
+    };
+
+    let Some(definition_resource) = ctx
+        .content_resolver
+        .resolve_canonical(definition_canonical)?
+    else {
+        return Ok(());
+    };
+
+    let definition_type = definition_resource
+        .get("resourceType")
+        .and_then(Value::as_str);
+
+    match definition_type {
+        Some("ActivityDefinition") => {
+            let applied = apply_activity_definition(
+                &definition_resource,
+                &library_canonical_strings(
+                    definition_resource
+                        .get("library")
+                        .and_then(Value::as_array)
+                        .map(Vec::as_slice)
+                        .unwrap_or_default(),
+                ),
+                ctx,
+            )?;
+
+            let Some(mut applied) = applied else {
+                return Ok(());
+            };
+
+            if applied.get("intent").is_some() {
+                set_field(&mut applied, "intent", json!("proposal"));
+            }
+
+            request_group_action.insert(
+                "type".to_string(),
+                json!({
+                    "coding": [{
+                        "system": ACTION_TYPE_SYSTEM,
+                        "code": CREATE_ACTION_CODE
+                    }]
+                }),
+            );
+
+            if let Some(dynamic_values) =
+                non_null_field(action, "dynamicValue").and_then(Value::as_array)
+            {
+                for dynamic_value in dynamic_values {
+                    process_dynamic_value(
+                        dynamic_value,
+                        plan_definition,
+                        &mut applied,
+                        library_canonicals,
+                        ctx,
+                    )?;
+                }
+            }
+
+            push_applied_resource(resource_bundle_entries, &applied);
+            set_resource_reference(request_group_action, &applied);
+        }
+        Some("PlanDefinition") => {
+            let sub_bundle = apply_plan_definition(&definition_resource, ctx)?;
+            let sub_entries = sub_bundle
+                .get("entry")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    CpgError::InvalidResource(
+                        "sub PlanDefinition result has no bundle entries".to_string(),
+                    )
+                })?;
+
+            let sub_request_group = sub_entries
+                .first()
+                .and_then(|entry| entry.get("resource"))
+                .filter(|resource| {
+                    resource.get("resourceType").and_then(Value::as_str) == Some("RequestGroup")
+                })
+                .ok_or_else(|| {
+                    CpgError::InvalidResource(
+                        "sub PlanDefinition result does not begin with a RequestGroup".to_string(),
+                    )
+                })?;
+
+            let mut sub_request_group = sub_request_group.clone();
+            set_field(&mut sub_request_group, "intent", json!("proposal"));
+            push_bundle_entry(resource_bundle_entries, &sub_request_group);
+            set_resource_reference(request_group_action, &sub_request_group);
+
+            for entry in sub_entries.iter().skip(1) {
+                resource_bundle_entries.push(entry.clone());
+            }
+        }
+        Some("Questionnaire") => {
+            let questionnaire_id = definition_resource
+                .get("id")
+                .and_then(Value::as_str)
+                .ok_or_else(|| {
+                    CpgError::InvalidResource("resolved Questionnaire has no id".to_string())
+                })?;
+            request_group_action.insert(
+                "resource".to_string(),
+                json!({"reference": format!("Questionnaire/{questionnaire_id}")}),
+            );
+        }
+        _ => {}
+    }
+
+    Ok(())
+}
+
+fn is_applicable(
+    action: &Value,
+    plan_definition: &Value,
+    ctx: &ApplyContext,
+    libraries: &[Value],
+) -> CpgResult<bool> {
+    let Some(conditions) = action.get("condition").and_then(Value::as_array) else {
+        return Ok(true);
+    };
+
+    let applicability_conditions = conditions
+        .iter()
+        .filter(|condition| condition.get("kind").and_then(Value::as_str) == Some("applicability"));
+
+    for condition in applicability_conditions {
+        let Some(expression) = expression_for_condition(condition) else {
+            continue;
+        };
+
+        let result = crate::expression::evaluate_expression(
+            expression,
+            plan_definition,
+            &library_canonical_strings(libraries),
+            ctx,
+        )?;
+
+        if result != Value::Bool(true) {
+            return Ok(false);
+        }
+    }
+
+    Ok(true)
+}
+
+fn expression_for_condition(condition: &Value) -> Option<&Value> {
+    let expression = condition.get("expression")?;
+    let has_source = expression
+        .get("expression")
+        .and_then(Value::as_str)
+        .is_some_and(|source| !source.trim().is_empty());
+    has_source.then_some(expression)
+}
+
+fn library_canonical_strings(libraries: &[Value]) -> Vec<String> {
+    libraries
+        .iter()
+        .filter_map(|library| library.get("url").and_then(Value::as_str))
+        .map(str::to_string)
+        .collect()
+}
+
+fn push_applied_resource(resource_bundle_entries: &mut Vec<Value>, resource: &Value) {
+    push_bundle_entry(resource_bundle_entries, resource);
+}
+
+fn push_bundle_entry(resource_bundle_entries: &mut Vec<Value>, resource: &Value) {
+    let mut entry = Map::new();
+    if let Some(resource_type) = resource.get("resourceType").and_then(Value::as_str) {
+        if let Some(id) = resource.get("id").and_then(Value::as_str) {
+            entry.insert(
+                "fullUrl".to_string(),
+                json!(format!("{BASE_URL}/{resource_type}/{id}")),
+            );
+        }
+    }
+
+    entry.insert("resource".to_string(), resource.clone());
+    resource_bundle_entries.push(Value::Object(entry));
+}
+
+fn set_resource_reference(request_group_action: &mut Map<String, Value>, resource: &Value) {
+    let Some((resource_type, id)) = resource
+        .get("resourceType")
+        .and_then(Value::as_str)
+        .zip(resource.get("id").and_then(Value::as_str))
+    else {
+        return;
+    };
+
+    request_group_action.insert(
+        "resource".to_string(),
+        json!({"reference": format!("{resource_type}/{id}")}),
+    );
+}
+
+fn copy_non_null_field(target: &mut Map<String, Value>, source: &Value, field: &str) -> bool {
+    match non_null_field(source, field) {
+        Some(value) => {
+            target.insert(field.to_string(), value.clone());
+            true
+        }
+        None => false,
+    }
+}
+
+fn non_null_field<'a>(resource: &'a Value, field: &str) -> Option<&'a Value> {
+    resource.get(field).filter(|value| !value.is_null())
+}
+
+fn set_field(target: &mut Value, field: &str, value: Value) {
+    target
+        .as_object_mut()
+        .expect("target resource must be an object")
+        .insert(field.to_string(), value);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::resolver::BundleResolver;
+    use serde_json::json;
+
+    #[test]
+    fn non_boolean_applicability_result_makes_action_not_applicable() {
+        let plan_definition = json!({
+            "resourceType": "PlanDefinition",
+            "title": "Skipped"
+        });
+        let action = json!({
+            "title": "Action",
+            "condition": [{
+                "kind": "applicability",
+                "expression": {
+                    "language": "text/fhirpath",
+                    "expression": "title"
+                }
+            }]
+        });
+        let ctx = ApplyContext::new(Arc::new(BundleResolver::default()), "Patient/123");
+        let mut entries = Vec::new();
+
+        let result =
+            apply_plan_definition_action(&action, &plan_definition, &ctx, &mut entries, &[])
+                .unwrap();
+
+        assert!(result.is_none());
+        assert!(entries.is_empty());
+    }
+}

--- a/crates/rh-cpg/src/apply/activity_definition.rs
+++ b/crates/rh-cpg/src/apply/activity_definition.rs
@@ -1,0 +1,725 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+use crate::apply::dynamic_value::process_dynamic_value;
+use crate::context::ApplyContext;
+use crate::error::CpgResult;
+
+/// Apply an ActivityDefinition to a subject, producing the target request
+/// resource. Returns `None` when the definition has no supported request kind.
+pub fn apply_activity_definition(
+    activity_definition: &Value,
+    library_canonicals: &[String],
+    ctx: &ApplyContext,
+) -> CpgResult<Option<Value>> {
+    let Some(kind) = non_null_field(activity_definition, "kind").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+
+    if !matches!(
+        kind,
+        "Appointment"
+            | "AppointmentResponse"
+            | "CarePlan"
+            | "Claim"
+            | "CommunicationRequest"
+            | "Contract"
+            | "DeviceRequest"
+            | "EnrollmentRequest"
+            | "ImmunizationRecommendation"
+            | "MedicationRequest"
+            | "NutritionOrder"
+            | "ServiceRequest"
+            | "SupplyRequest"
+            | "Task"
+            | "VisionPrescription"
+    ) {
+        return Ok(None);
+    }
+
+    let mut target = json!({
+        "id": Uuid::new_v4().to_string(),
+        "resourceType": kind,
+        "status": "draft"
+    });
+    let canonical = canonicalize(activity_definition);
+
+    if supports_intent(kind) {
+        if let Some(intent) = non_null_field(activity_definition, "intent") {
+            set_field(&mut target, "intent", intent.clone());
+        }
+    }
+
+    let subject = &ctx.subject;
+    match kind {
+        "Appointment" => {
+            if let Some(timing_period) = field(activity_definition, "timingPeriod") {
+                push_or_create_array(&mut target, "requestedPeriod", timing_period.clone());
+            }
+            set_field(
+                &mut target,
+                "participant",
+                json!([{
+                    "actor": reference_from_string(subject, "Patient"),
+                    "status": "needs-action"
+                }]),
+            );
+        }
+        "AppointmentResponse" => {
+            set_field(&mut target, "participantStatus", json!("needs-action"));
+            if let Some(timing_period) = field(activity_definition, "timingPeriod") {
+                if let Some(start) = timing_period.get("start") {
+                    set_field(&mut target, "start", start.clone());
+                }
+                if let Some(end) = timing_period.get("end") {
+                    set_field(&mut target, "end", end.clone());
+                }
+            }
+        }
+        "CarePlan" => {
+            push_canonical(&mut target, canonical.as_deref());
+            copy_field(&mut target, activity_definition, "timingPeriod", "period");
+            if let Some(encounter) = &ctx.encounter {
+                set_field(
+                    &mut target,
+                    "encounter",
+                    reference_from_string(encounter, "Encounter"),
+                );
+            }
+            if let Some(practitioner) = &ctx.practitioner {
+                set_field(
+                    &mut target,
+                    "author",
+                    reference_from_string(practitioner, "Practitioner"),
+                );
+            }
+            if let Some(organization) = &ctx.organization {
+                push_or_create_array(
+                    &mut target,
+                    "contributor",
+                    reference_from_string(organization, "Organization"),
+                );
+            }
+            set_reference(&mut target, "subject", subject, "Patient");
+        }
+        "Claim" => {
+            if let Some(practitioner) = &ctx.practitioner {
+                set_field(
+                    &mut target,
+                    "provider",
+                    reference_from_string(practitioner, "Practitioner"),
+                );
+            }
+        }
+        "CommunicationRequest" => {
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingDateTime",
+                "occurrenceDateTime",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingPeriod",
+                "occurrencePeriod",
+            );
+            if let Some(practitioner) = &ctx.practitioner {
+                set_field(
+                    &mut target,
+                    "requester",
+                    reference_from_string(practitioner, "Practitioner"),
+                );
+            }
+            if let Some(encounter) = &ctx.encounter {
+                set_field(
+                    &mut target,
+                    "encounter",
+                    reference_from_string(encounter, "Encounter"),
+                );
+            }
+            set_reference(&mut target, "subject", subject, "Patient");
+            copy_field(
+                &mut target,
+                activity_definition,
+                "doNotPerform",
+                "doNotPerform",
+            );
+        }
+        "Contract" => {
+            if let Some(practitioner) = &ctx.practitioner {
+                set_field(
+                    &mut target,
+                    "author",
+                    reference_from_string(practitioner, "Practitioner"),
+                );
+            }
+            if let Some(organization) = &ctx.organization {
+                push_or_create_array(
+                    &mut target,
+                    "authority",
+                    reference_from_string(organization, "Organization"),
+                );
+            }
+        }
+        "DeviceRequest" => {
+            push_canonical(&mut target, canonical.as_deref());
+            copy_field(
+                &mut target,
+                activity_definition,
+                "code",
+                "codeCodeableConcept",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productCodeableConcept",
+                "codeCodeableConcept",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productReference",
+                "codeReference",
+            );
+            set_context_reference(&mut target, &ctx.encounter, "encounter", "Encounter");
+            set_context_reference(&mut target, &ctx.practitioner, "requester", "Practitioner");
+            set_reference(&mut target, "subject", subject, "Patient");
+        }
+        "EnrollmentRequest" => {
+            set_reference(&mut target, "candidate", subject, "Patient");
+            set_context_reference(&mut target, &ctx.practitioner, "provider", "Practitioner");
+        }
+        "ImmunizationRecommendation" => {
+            set_reference(&mut target, "patient", subject, "Patient");
+            if let Some(product) = field(activity_definition, "productCodeableConcept") {
+                set_field(
+                    &mut target,
+                    "recommendation",
+                    json!([{
+                        "vaccineCode": [product],
+                        "forecastStatus": {
+                            "coding": [{
+                                "system": "http://terminology.hl7.org/CodeSystem/immunization-recommendation-status",
+                                "code": "due",
+                                "display": "Due"
+                            }]
+                        }
+                    }]),
+                );
+            }
+            set_field(&mut target, "date", json!(now_iso8601()));
+        }
+        "MedicationRequest" => {
+            push_canonical(&mut target, canonical.as_deref());
+            set_reference(&mut target, "subject", subject, "Patient");
+            set_context_reference(&mut target, &ctx.practitioner, "requester", "Practitioner");
+            set_context_reference(&mut target, &ctx.encounter, "encounter", "Encounter");
+            copy_field(
+                &mut target,
+                activity_definition,
+                "doNotPerform",
+                "doNotPerform",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productCodeableConcept",
+                "medicationCodeableConcept",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productReference",
+                "medicationReference",
+            );
+            if let Some(Value::Array(dosage)) = field(activity_definition, "dosage") {
+                for dosage_entry in dosage {
+                    push_or_create_array(&mut target, "dosageInstruction", dosage_entry.clone());
+                }
+            }
+
+            let mut new_dosage = Map::new();
+            if let Some(timing_date_time) = field(activity_definition, "timingDateTime") {
+                let timing = new_dosage
+                    .entry("timing".to_string())
+                    .or_insert_with(|| json!({}));
+                push_or_create_array(timing, "event", timing_date_time.clone());
+            }
+            let timing_targets = [
+                ("timingDuration", "boundsDuration"),
+                ("timingPeriod", "boundsPeriod"),
+                ("timingRange", "boundsRange"),
+            ];
+            for (source_field, target_field) in timing_targets {
+                if let Some(timing_value) = field(activity_definition, source_field) {
+                    let timing = new_dosage
+                        .entry("timing".to_string())
+                        .or_insert_with(|| json!({}));
+                    let repeat = timing
+                        .as_object_mut()
+                        .unwrap()
+                        .entry("repeat".to_string())
+                        .or_insert_with(|| json!({}));
+                    set_field(repeat, target_field, timing_value.clone());
+                }
+            }
+            if let Some(timing_timing) = field(activity_definition, "timingTiming") {
+                new_dosage.insert("timing".to_string(), timing_timing.clone());
+            }
+            if let Some(Value::Array(body_site)) = field(activity_definition, "bodySite") {
+                if let Some(site) = body_site.first() {
+                    new_dosage.insert("site".to_string(), site.clone());
+                }
+            }
+            if let Some(quantity) = field(activity_definition, "quantity") {
+                new_dosage.insert(
+                    "doseAndRate".to_string(),
+                    json!([{"doseQuantity": quantity}]),
+                );
+            }
+            push_or_create_array(&mut target, "dosageInstruction", Value::Object(new_dosage));
+        }
+        "NutritionOrder" => {
+            push_canonical(&mut target, canonical.as_deref());
+            set_reference(&mut target, "patient", subject, "Patient");
+            set_context_reference(&mut target, &ctx.encounter, "encounter", "Encounter");
+            set_context_reference(&mut target, &ctx.practitioner, "orderer", "Practitioner");
+        }
+        "ServiceRequest" => {
+            push_canonical(&mut target, canonical.as_deref());
+            set_reference(&mut target, "subject", subject, "Patient");
+            set_context_reference(&mut target, &ctx.encounter, "encounter", "Encounter");
+            set_context_reference(&mut target, &ctx.practitioner, "requester", "Practitioner");
+            copy_field(
+                &mut target,
+                activity_definition,
+                "doNotPerform",
+                "doNotPerform",
+            );
+            copy_field(&mut target, activity_definition, "code", "code");
+            copy_field(
+                &mut target,
+                activity_definition,
+                "quantity",
+                "quantityQuantity",
+            );
+            copy_field(&mut target, activity_definition, "bodySite", "bodySite");
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productCodeableConcept",
+                "code",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingTiming",
+                "occurrenceTiming",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingDateTime",
+                "occurrenceDateTime",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingPeriod",
+                "occurrencePeriod",
+            );
+        }
+        "SupplyRequest" => {
+            set_context_reference(&mut target, &ctx.practitioner, "requester", "Practitioner");
+            copy_field(&mut target, activity_definition, "quantity", "quantity");
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productCodeableConcept",
+                "itemCodeableConcept",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "productReference",
+                "itemReference",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingTiming",
+                "occurrenceTiming",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingDateTime",
+                "occurrenceDateTime",
+            );
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingPeriod",
+                "occurrencePeriod",
+            );
+        }
+        "Task" => {
+            if let Some(canonical) = canonical.as_deref() {
+                set_field(&mut target, "instantiatesCanonical", json!(canonical));
+            }
+            set_reference(&mut target, "for", subject, "Patient");
+            set_context_reference(&mut target, &ctx.encounter, "encounter", "Encounter");
+            set_context_reference(&mut target, &ctx.practitioner, "requester", "Practitioner");
+            copy_field(&mut target, activity_definition, "code", "code");
+            copy_field(&mut target, activity_definition, "priority", "priority");
+            if let Some(intent) = field(activity_definition, "intent").and_then(Value::as_str) {
+                set_field(
+                    &mut target,
+                    "intent",
+                    json!(if intent == "directive" {
+                        "unknown"
+                    } else {
+                        intent
+                    }),
+                );
+            }
+            copy_field(
+                &mut target,
+                activity_definition,
+                "timingPeriod",
+                "executionPeriod",
+            );
+            if field(activity_definition, "doNotPerform") == Some(&json!(true)) {
+                set_field(
+                    &mut target,
+                    "modifierExtension",
+                    json!([{
+                        "url": "http://hl7.org/fhir/StructureDefinition/request-doNotPerform",
+                        "valueBoolean": true
+                    }]),
+                );
+            }
+        }
+        "VisionPrescription" => {
+            set_reference(&mut target, "patient", subject, "Patient");
+            set_context_reference(&mut target, &ctx.encounter, "encounter", "Encounter");
+            set_context_reference(&mut target, &ctx.practitioner, "prescriber", "Practitioner");
+            set_field(&mut target, "created", json!(now_iso8601()));
+        }
+        _ => {}
+    }
+
+    let dynamic_values = activity_definition
+        .get("dynamicValue")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    for dynamic_value in dynamic_values {
+        process_dynamic_value(
+            &dynamic_value,
+            activity_definition,
+            &mut target,
+            library_canonicals,
+            ctx,
+        )?;
+    }
+
+    // ActivityDefinition.transform is intentionally unsupported.
+    Ok(Some(target))
+}
+
+fn canonicalize(activity_definition: &Value) -> Option<String> {
+    let url = activity_definition.get("url").and_then(Value::as_str)?;
+    let canonical = match activity_definition.get("version").and_then(Value::as_str) {
+        Some(version) => format!("{url}|{version}"),
+        None => url.to_string(),
+    };
+    Some(canonical)
+}
+
+fn non_null_field<'a>(resource: &'a Value, field: &str) -> Option<&'a Value> {
+    resource.get(field).filter(|value| !value.is_null())
+}
+
+fn field<'a>(resource: &'a Value, field: &str) -> Option<&'a Value> {
+    non_null_field(resource, field)
+}
+
+fn copy_field(target: &mut Value, source: &Value, source_field: &str, target_field: &str) {
+    if let Some(value) = field(source, source_field) {
+        set_field(target, target_field, value.clone());
+    }
+}
+
+fn set_field(target: &mut Value, field: &str, value: Value) {
+    target
+        .as_object_mut()
+        .expect("target resource must be an object")
+        .insert(field.to_string(), value);
+}
+
+fn push_or_create_array(target: &mut Value, field: &str, value: Value) {
+    let object = target.as_object_mut().expect("target must be an object");
+    let array = object
+        .entry(field.to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    if !array.is_array() {
+        *array = Value::Array(Vec::new());
+    }
+    array
+        .as_array_mut()
+        .expect("array was just normalized")
+        .push(value);
+}
+
+fn push_canonical(target: &mut Value, canonical: Option<&str>) {
+    if let Some(canonical) = canonical {
+        push_or_create_array(target, "instantiatesCanonical", json!(canonical));
+    }
+}
+
+fn set_reference(target: &mut Value, field: &str, reference: &str, resource_type: &str) {
+    set_field(
+        target,
+        field,
+        reference_from_string(reference, resource_type),
+    );
+}
+
+fn set_context_reference(
+    target: &mut Value,
+    reference: &Option<String>,
+    field: &str,
+    resource_type: &str,
+) {
+    if let Some(reference) = reference {
+        set_reference(target, field, reference, resource_type);
+    }
+}
+
+fn reference_from_string(reference: &str, resource_type: &str) -> Value {
+    if reference.contains('/') {
+        json!({ "reference": reference })
+    } else {
+        json!({
+            "reference": format!("{resource_type}/{reference}"),
+            "type": resource_type
+        })
+    }
+}
+
+fn supports_intent(kind: &str) -> bool {
+    matches!(
+        kind,
+        "CarePlan" | "DeviceRequest" | "MedicationRequest" | "ServiceRequest" | "Task"
+    )
+}
+
+fn now_iso8601() -> String {
+    let duration = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time is after the Unix epoch");
+    let seconds = duration.as_secs();
+    let milliseconds = duration.subsec_millis();
+    let days = (seconds / 86_400) as i64;
+    let time_seconds = seconds % 86_400;
+    let (year, month, day) = civil_from_days(days);
+    format!(
+        "{year:04}-{month:02}-{day:02}T{:02}:{:02}:{:02}.{milliseconds:03}Z",
+        time_seconds / 3_600,
+        (time_seconds % 3_600) / 60,
+        time_seconds % 60
+    )
+}
+
+fn civil_from_days(days: i64) -> (i64, u32, u32) {
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let day_of_era = (z - era * 146_097) as u64;
+    let year_of_era =
+        (day_of_era - day_of_era / 1_460 + day_of_era / 36_524 - day_of_era / 146_096) / 365;
+    let year = year_of_era as i64 + era * 400;
+    let day_of_year = day_of_era - (365 * year_of_era + year_of_era / 4 - year_of_era / 100);
+    let mp = (5 * day_of_year + 2) / 153;
+    let day = day_of_year - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+    (year, month as u32, day as u32)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::context::ApplyContext;
+    use crate::resolver::BundleResolver;
+    use serde_json::json;
+
+    use super::*;
+
+    #[test]
+    fn applies_service_request_with_timing_and_dynamic_value() {
+        let activity_definition = json!({
+            "resourceType": "ActivityDefinition",
+            "url": "http://example.org/ad",
+            "title": "Screening",
+            "kind": "ServiceRequest",
+            "intent": "proposal",
+            "code": {"text": "screening"},
+            "timingTiming": {"event": ["2026-01-01"]},
+            "dynamicValue": [{
+                "path": "authoredOn",
+                "expression": {
+                    "language": "text/fhirpath",
+                    "expression": "title"
+                }
+            }]
+        });
+        let ctx = test_context(json!({
+            "resourceType": "Bundle",
+            "entry": []
+        }));
+
+        let applied = apply_activity_definition(&activity_definition, &[], &ctx)
+            .expect("apply should succeed")
+            .expect("ServiceRequest should be supported");
+
+        assert_eq!(applied["resourceType"], "ServiceRequest");
+        assert_eq!(applied["intent"], "proposal");
+        assert_eq!(applied["subject"], json!({"reference": "Patient/123"}));
+        assert_eq!(
+            applied["requester"],
+            json!({"reference": "Practitioner/456"})
+        );
+        assert_eq!(applied["encounter"], json!({"reference": "Encounter/789"}));
+        assert_eq!(applied["code"], json!({"text": "screening"}));
+        assert_eq!(
+            applied["occurrenceTiming"],
+            json!({"event": ["2026-01-01"]})
+        );
+        assert_eq!(
+            applied["instantiatesCanonical"],
+            json!(["http://example.org/ad"])
+        );
+        assert_eq!(applied["authoredOn"], "Screening");
+    }
+
+    #[test]
+    fn applies_medication_request_structural_fields() {
+        let activity_definition = json!({
+            "resourceType": "ActivityDefinition",
+            "kind": "MedicationRequest",
+            "productCodeableConcept": {"text": "aspirin"},
+            "dosage": [{"text": "existing"}],
+            "timingDateTime": "2026-01-01T10:00:00Z",
+            "quantity": {"value": 2}
+        });
+        let ctx = test_context(json!({"resourceType": "Bundle", "entry": []}));
+
+        let applied = apply_activity_definition(&activity_definition, &[], &ctx)
+            .expect("apply should succeed")
+            .expect("MedicationRequest should be supported");
+
+        assert_eq!(applied["resourceType"], "MedicationRequest");
+        assert_eq!(
+            applied["medicationCodeableConcept"],
+            json!({"text": "aspirin"})
+        );
+        assert_eq!(applied["subject"], json!({"reference": "Patient/123"}));
+        assert_eq!(
+            applied["requester"],
+            json!({"reference": "Practitioner/456"})
+        );
+        assert_eq!(applied["dosageInstruction"].as_array().unwrap().len(), 2);
+        assert_eq!(applied["dosageInstruction"][0], json!({"text": "existing"}));
+        assert_eq!(
+            applied["dosageInstruction"][1]["timing"]["event"],
+            json!(["2026-01-01T10:00:00Z"])
+        );
+        assert_eq!(
+            applied["dosageInstruction"][1]["doseAndRate"],
+            json!([{"doseQuantity": {"value": 2}}])
+        );
+    }
+
+    #[test]
+    fn applies_task_with_reference_and_intent_mapping() {
+        let activity_definition = json!({
+            "resourceType": "ActivityDefinition",
+            "url": "http://example.org/task-ad",
+            "kind": "Task",
+            "intent": "directive",
+            "code": {"text": "follow-up"},
+            "priority": "routine"
+        });
+        let ctx = test_context(json!({"resourceType": "Bundle", "entry": []}));
+
+        let applied = apply_activity_definition(&activity_definition, &[], &ctx)
+            .expect("apply should succeed")
+            .expect("Task should be supported");
+
+        assert_eq!(applied["for"], json!({"reference": "Patient/123"}));
+        assert_eq!(applied["encounter"], json!({"reference": "Encounter/789"}));
+        assert_eq!(
+            applied["requester"],
+            json!({"reference": "Practitioner/456"})
+        );
+        assert_eq!(applied["code"], json!({"text": "follow-up"}));
+        assert_eq!(applied["priority"], "routine");
+        assert_eq!(applied["intent"], "unknown");
+        assert_eq!(
+            applied["instantiatesCanonical"],
+            "http://example.org/task-ad"
+        );
+    }
+
+    #[test]
+    fn returns_none_for_unknown_kind() {
+        let activity_definition = json!({"kind": "NotAResource"});
+        let ctx = test_context(json!({"resourceType": "Bundle", "entry": []}));
+
+        assert_eq!(
+            apply_activity_definition(&activity_definition, &[], &ctx)
+                .expect("unknown kind should not fail"),
+            None
+        );
+    }
+
+    #[test]
+    fn applies_do_not_perform_to_communication_request() {
+        let activity_definition = json!({
+            "resourceType": "ActivityDefinition",
+            "kind": "CommunicationRequest",
+            "doNotPerform": true
+        });
+        let ctx = test_context(json!({"resourceType": "Bundle", "entry": []}));
+
+        let applied = apply_activity_definition(&activity_definition, &[], &ctx)
+            .expect("apply should succeed")
+            .expect("CommunicationRequest should be supported");
+
+        assert_eq!(applied["doNotPerform"], true);
+    }
+
+    #[test]
+    fn returns_none_when_kind_is_missing() {
+        let ctx = test_context(json!({"resourceType": "Bundle", "entry": []}));
+
+        assert_eq!(
+            apply_activity_definition(&json!({}), &[], &ctx)
+                .expect("empty definition should not fail"),
+            None
+        );
+    }
+
+    fn test_context(bundle: Value) -> ApplyContext {
+        let resolver = Arc::new(BundleResolver::new(&bundle).expect("test bundle should be valid"));
+        let mut context = ApplyContext::new(resolver, "Patient/123");
+        context.encounter = Some("Encounter/789".to_string());
+        context.practitioner = Some("Practitioner/456".to_string());
+        context
+    }
+}

--- a/crates/rh-cpg/src/apply/dynamic_value.rs
+++ b/crates/rh-cpg/src/apply/dynamic_value.rs
@@ -1,0 +1,219 @@
+use serde_json::Value;
+
+use crate::context::ApplyContext;
+use crate::error::CpgResult;
+use crate::expression::evaluate_expression;
+
+/// Evaluate a dynamicValue element and set the result at `path` on
+/// `target_resource`, mutating the resource in place.
+pub fn process_dynamic_value(
+    dynamic_value: &Value,
+    definitional_resource: &Value,
+    target_resource: &mut Value,
+    library_canonicals: &[String],
+    ctx: &ApplyContext,
+) -> CpgResult<()> {
+    let path = dynamic_value.get("path").and_then(Value::as_str);
+    let expression = dynamic_value.get("expression");
+
+    let (Some(path), Some(expression)) = (path, expression) else {
+        return Ok(());
+    };
+
+    let language = expression.get("language").and_then(Value::as_str);
+    if !matches!(
+        language,
+        Some("text/fhirpath") | Some("text/cql-identifier")
+    ) {
+        return Ok(());
+    }
+
+    let mut result =
+        evaluate_expression(expression, definitional_resource, library_canonicals, ctx)?;
+    if language == Some("text/fhirpath") {
+        if let Value::Array(items) = &result {
+            result = items.first().cloned().unwrap_or(Value::Null);
+        }
+    }
+
+    if path.is_empty() {
+        return Ok(());
+    }
+
+    set_path(target_resource, path, result);
+    Ok(())
+}
+
+fn set_path(target: &mut Value, path: &str, value: Value) -> Option<()> {
+    if path.is_empty() {
+        return Some(());
+    }
+
+    let segment_count = path.split('.').count();
+    let mut current = target;
+    for (index, segment) in path.split('.').enumerate() {
+        let is_last = index == segment_count - 1;
+        let (field_name, array_indices) = parse_segment(segment);
+
+        if array_indices.is_empty() {
+            if is_last {
+                set_field(current, field_name, value);
+                return Some(());
+            }
+
+            current = navigate_field(current, field_name)?;
+        } else {
+            current = get_or_create_array(current, field_name)?;
+
+            let last_array_index = array_indices.len() - 1;
+            for (array_index_position, array_index) in array_indices.iter().enumerate() {
+                let is_last_array_step = is_last && array_index_position == last_array_index;
+                let array_len = current.as_array().map_or(0, |array| array.len());
+                if *array_index >= array_len {
+                    current
+                        .as_array_mut()
+                        .expect("current is an array")
+                        .resize(*array_index + 1, Value::Null);
+                }
+
+                current = if is_last_array_step {
+                    let element = current
+                        .as_array_mut()
+                        .expect("current is an array")
+                        .get_mut(*array_index)
+                        .expect("array was just padded");
+                    *element = value;
+                    return Some(());
+                } else {
+                    current = navigate_element(current.as_array_mut()?.get_mut(*array_index)?)?;
+                    current
+                };
+            }
+        }
+    }
+
+    Some(())
+}
+
+fn parse_segment(segment: &str) -> (&str, Vec<usize>) {
+    let Some(open_bracket) = segment.find('[') else {
+        return (segment, Vec::new());
+    };
+
+    let field_name = &segment[..open_bracket];
+    let mut indices = Vec::new();
+    for index_text in segment[open_bracket..]
+        .split_inclusive(']')
+        .filter_map(|part| {
+            part.strip_prefix('[')
+                .and_then(|value| value.strip_suffix(']'))
+        })
+    {
+        match index_text.parse::<usize>() {
+            Ok(index) => indices.push(index),
+            Err(_) => return (field_name, Vec::new()),
+        }
+    }
+
+    (field_name, indices)
+}
+
+fn set_field(target: &mut Value, field_name: &str, value: Value) {
+    let Some(object) = target.as_object_mut() else {
+        return;
+    };
+    object.insert(field_name.to_string(), value);
+}
+
+fn get_or_create_array<'a>(target: &'a mut Value, field_name: &str) -> Option<&'a mut Value> {
+    let object = target.as_object_mut()?;
+    if !object.contains_key(field_name) {
+        object.insert(field_name.to_string(), Value::Array(Vec::new()));
+    }
+
+    match object.get_mut(field_name) {
+        Some(Value::Array(_)) | Some(Value::Null) => object.get_mut(field_name),
+        _ => None,
+    }
+}
+
+fn navigate_field<'a>(target: &'a mut Value, field_name: &str) -> Option<&'a mut Value> {
+    let object = target.as_object_mut()?;
+    if !object.contains_key(field_name) {
+        object.insert(
+            field_name.to_string(),
+            Value::Object(serde_json::Map::new()),
+        );
+    }
+
+    let Some(field) = object.get_mut(field_name) else {
+        return None;
+    };
+
+    match field {
+        Value::Object(_) | Value::Array(_) => Some(field),
+        Value::Null => {
+            *field = Value::Object(serde_json::Map::new());
+            Some(field)
+        }
+        _ => None,
+    }
+}
+
+fn navigate_element(target: &mut Value) -> Option<&mut Value> {
+    match target {
+        Value::Object(_) | Value::Array(_) => Some(target),
+        Value::Null => {
+            *target = Value::Object(serde_json::Map::new());
+            Some(target)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn set_path_sets_simple_key() {
+        let mut target = serde_json::json!({});
+        set_path(&mut target, "authoredOn", serde_json::json!("2026-01-01"));
+        assert_eq!(target, serde_json::json!({"authoredOn": "2026-01-01"}));
+    }
+
+    #[test]
+    fn set_path_sets_nested_path() {
+        let mut target = serde_json::json!({});
+        set_path(&mut target, "a.b.c", serde_json::json!(1));
+        assert_eq!(target, serde_json::json!({"a": {"b": {"c": 1}}}));
+    }
+
+    #[test]
+    fn set_path_sets_array_index_path() {
+        let mut target = serde_json::json!({});
+        set_path(
+            &mut target,
+            "dosageInstruction[0].timing",
+            serde_json::json!(2),
+        );
+        assert_eq!(
+            target,
+            serde_json::json!({"dosageInstruction": [{"timing": 2}]})
+        );
+    }
+
+    #[test]
+    fn set_path_creates_intermediate_objects() {
+        let mut target = serde_json::json!({"a": {"b": null}});
+        set_path(&mut target, "a.b.c", serde_json::json!("value"));
+        assert_eq!(target, serde_json::json!({"a": {"b": {"c": "value"}}}));
+    }
+
+    #[test]
+    fn set_path_pads_arrays_with_null() {
+        let mut target = serde_json::json!({});
+        set_path(&mut target, "items[1]", serde_json::json!("second"));
+        assert_eq!(target, serde_json::json!({"items": [null, "second"]}));
+    }
+}

--- a/crates/rh-cpg/src/apply/mod.rs
+++ b/crates/rh-cpg/src/apply/mod.rs
@@ -1,0 +1,4 @@
+pub mod action;
+pub mod activity_definition;
+pub mod dynamic_value;
+pub mod plan_definition;

--- a/crates/rh-cpg/src/apply/plan_definition.rs
+++ b/crates/rh-cpg/src/apply/plan_definition.rs
@@ -1,0 +1,382 @@
+use serde_json::{json, Map, Value};
+use uuid::Uuid;
+
+use crate::apply::action::apply_plan_definition_action;
+use crate::context::ApplyContext;
+use crate::error::{CpgError, CpgResult};
+pub(crate) const BASE_URL: &str = "http://apply-processor";
+const GOAL_EXTENSION_URL: &str = "http://hl7.org/fhir/StructureDefinition/resource-pertainsToGoal";
+
+/// Apply a PlanDefinition ($apply) to a subject, producing a FHIR collection
+/// Bundle whose first entry is the primary RequestGroup.
+pub fn apply_plan_definition(plan_definition: &Value, ctx: &ApplyContext) -> CpgResult<Value> {
+    if plan_definition.get("resourceType").and_then(Value::as_str) != Some("PlanDefinition") {
+        return Err(CpgError::InvalidResource(
+            "expected a FHIR PlanDefinition object".to_string(),
+        ));
+    }
+
+    let mut entries = Vec::new();
+    let mut request_group = json!({
+        "resourceType": "RequestGroup",
+        "id": Uuid::new_v4().to_string(),
+        "intent": "proposal",
+        "status": "draft",
+        "subject": {"reference": ctx.subject},
+    });
+
+    if let Some(canonical) = canonicalize(plan_definition) {
+        set_field(
+            &mut request_group,
+            "instantiatesCanonical",
+            json!([canonical]),
+        );
+    }
+
+    if let Some(practitioner) = &ctx.practitioner {
+        if let Some(organization) = &ctx.organization {
+            let practitioner_role = json!({
+                "resourceType": "PractitionerRole",
+                "id": Uuid::new_v4().to_string(),
+                "practitioner": {"reference": practitioner},
+                "organization": {"reference": organization},
+            });
+            push_bundle_entry(&mut entries, &practitioner_role);
+            set_field(
+                &mut request_group,
+                "author",
+                json!({"reference": format!("PractitionerRole/{}", practitioner_role["id"]) }),
+            );
+        } else {
+            set_field(
+                &mut request_group,
+                "author",
+                json!({"reference": practitioner}),
+            );
+        }
+    }
+
+    if let Some(encounter) = &ctx.encounter {
+        set_field(
+            &mut request_group,
+            "encounter",
+            json!({"reference": encounter}),
+        );
+    }
+
+    if let Some(goals) = plan_definition.get("goal").and_then(Value::as_array) {
+        if !goals.is_empty() {
+            let mut extensions = Vec::new();
+            for goal_properties in goals {
+                let mut goal = Map::new();
+                goal.insert("resourceType".to_string(), json!("Goal"));
+                goal.insert("id".to_string(), json!(Uuid::new_v4().to_string()));
+                goal.insert("subject".to_string(), json!({"reference": ctx.subject}));
+                goal.insert("lifecycleStatus".to_string(), json!("proposed"));
+                for (field, value) in goal_properties.as_object().into_iter().flatten() {
+                    if field == "category" {
+                        goal.insert(field.clone(), json!([value.clone()]));
+                    } else {
+                        goal.insert(field.clone(), value.clone());
+                    }
+                }
+
+                let goal = Value::Object(goal);
+                let goal_id = goal
+                    .get("id")
+                    .and_then(Value::as_str)
+                    .expect("goal id was just generated");
+                extensions.push(json!({
+                    "url": GOAL_EXTENSION_URL,
+                    "valueReference": {"reference": format!("Goal/{goal_id}")}
+                }));
+                push_bundle_entry(&mut entries, &goal);
+            }
+
+            set_field(&mut request_group, "extension", Value::Array(extensions));
+        }
+    }
+
+    let libraries = resolve_libraries(plan_definition, ctx)?;
+    if let Some(actions) = plan_definition.get("action").and_then(Value::as_array) {
+        let mut request_group_actions = Vec::new();
+        for action in actions {
+            if let Some(request_group_action) = apply_plan_definition_action(
+                action,
+                plan_definition,
+                ctx,
+                &mut entries,
+                &libraries,
+            )? {
+                request_group_actions.push(request_group_action);
+            }
+        }
+
+        if !request_group_actions.is_empty() {
+            set_field(
+                &mut request_group,
+                "action",
+                Value::Array(request_group_actions),
+            );
+        }
+    }
+
+    let mut bundle = Map::new();
+    bundle.insert("resourceType".to_string(), json!("Bundle"));
+    bundle.insert("id".to_string(), json!(Uuid::new_v4().to_string()));
+    bundle.insert("type".to_string(), json!("collection"));
+    bundle.insert(
+        "entry".to_string(),
+        json!([bundle_entry(&request_group)]
+            .into_iter()
+            .collect::<Vec<_>>()),
+    );
+
+    let mut bundle = Value::Object(bundle);
+    if let Some(bundle_entries) = bundle.get_mut("entry").and_then(Value::as_array_mut) {
+        bundle_entries.extend(entries);
+    }
+
+    Ok(bundle)
+}
+
+pub(crate) fn canonicalize(resource: &Value) -> Option<String> {
+    let url = resource.get("url").and_then(Value::as_str)?;
+    Some(match resource.get("version").and_then(Value::as_str) {
+        Some(version) => format!("{url}|{version}"),
+        None => url.to_string(),
+    })
+}
+
+fn resolve_libraries(plan_definition: &Value, ctx: &ApplyContext) -> CpgResult<Vec<Value>> {
+    let mut libraries = Vec::new();
+    for canonical in plan_definition
+        .get("library")
+        .and_then(Value::as_array)
+        .map(Vec::as_slice)
+        .unwrap_or_default()
+        .iter()
+        .filter_map(Value::as_str)
+    {
+        if let Some(library) = ctx.content_resolver.resolve_canonical(canonical)? {
+            libraries.push(library);
+        }
+    }
+
+    Ok(libraries)
+}
+
+fn push_bundle_entry(resource_bundle_entries: &mut Vec<Value>, resource: &Value) {
+    resource_bundle_entries.push(bundle_entry(resource));
+}
+
+fn bundle_entry(resource: &Value) -> Value {
+    let mut entry = Map::new();
+    if let Some((resource_type, id)) = resource
+        .get("resourceType")
+        .and_then(Value::as_str)
+        .zip(resource.get("id").and_then(Value::as_str))
+    {
+        entry.insert(
+            "fullUrl".to_string(),
+            json!(format!("{BASE_URL}/{resource_type}/{id}")),
+        );
+    }
+
+    entry.insert("resource".to_string(), resource.clone());
+    Value::Object(entry)
+}
+
+fn set_field(target: &mut Value, field: &str, value: Value) {
+    target
+        .as_object_mut()
+        .expect("target resource must be an object")
+        .insert(field.to_string(), value);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+    use crate::resolver::BundleResolver;
+    use serde_json::json;
+
+    fn content_bundle(include_sub_plan: bool) -> Value {
+        let mut plan_definition = json!({
+            "resourceType": "PlanDefinition",
+            "id": "main",
+            "url": "http://test/PlanDefinition/Main",
+            "version": "1.0",
+            "goal": [{
+                "category": {"coding": [{"system": "http://terminology.hl7.org/CodeSystem/goal-category", "code": "physiotherapy"}]},
+                "description": {"text": "Improve mobility"}
+            }],
+            "action": [
+                {
+                    "title": "Order lab",
+                    "definitionCanonical": "http://test/ActivityDefinition/order-lab"
+                },
+                {
+                    "title": "Skipped action",
+                    "condition": [{
+                        "kind": "applicability",
+                        "expression": {
+                            "language": "text/fhirpath",
+                            "expression": "title = 'Skip me'"
+                        }
+                    }]
+                }
+            ]
+        });
+
+        if include_sub_plan {
+            plan_definition["action"]
+                .as_array_mut()
+                .unwrap()
+                .push(json!({
+                    "title": "Use sub plan",
+                    "definitionCanonical": "http://test/PlanDefinition/Sub"
+                }));
+        }
+
+        let mut entries = vec![
+            json!({"resource": plan_definition}),
+            json!({"resource": {
+                "resourceType": "ActivityDefinition",
+                "id": "order-lab",
+                "url": "http://test/ActivityDefinition/order-lab",
+                "kind": "ServiceRequest",
+                "code": {"coding": [{"system": "http://loinc.org", "code": "24357-6"}]}
+            }}),
+        ];
+
+        if include_sub_plan {
+            entries.insert(
+                1,
+                json!({"resource": json!({
+                    "resourceType": "PlanDefinition",
+                    "id": "sub",
+                    "url": "http://test/PlanDefinition/Sub",
+                    "action": [{
+                        "action": [{
+                            "title": "Nested order",
+                            "definitionCanonical": "http://test/ActivityDefinition/order-lab"
+                        }]
+                    }]
+                })}),
+            );
+        }
+
+        json!({"resourceType": "Bundle", "entry": entries})
+    }
+
+    fn context(bundle: &Value) -> ApplyContext {
+        ApplyContext::new(
+            Arc::new(BundleResolver::new(bundle).unwrap()),
+            "Patient/123",
+        )
+    }
+
+    fn main_plan(bundle: &Value) -> Value {
+        bundle.get("entry").and_then(Value::as_array).unwrap()[0]
+            .get("resource")
+            .unwrap()
+            .clone()
+    }
+
+    #[test]
+    fn applies_primary_request_group_and_activity_definition() {
+        let bundle = content_bundle(false);
+        let ctx = context(&bundle);
+        let result = apply_plan_definition(&main_plan(&bundle), &ctx).unwrap();
+
+        let entries = result["entry"].as_array().unwrap();
+        let request_group = &entries[0]["resource"];
+        assert_eq!(result["resourceType"], "Bundle");
+        assert_eq!(result["type"], "collection");
+        assert_eq!(request_group["resourceType"], "RequestGroup");
+        assert_eq!(request_group["intent"], "proposal");
+        assert_eq!(request_group["status"], "draft");
+        assert_eq!(
+            request_group["subject"],
+            json!({"reference": "Patient/123"})
+        );
+        assert_eq!(
+            request_group["instantiatesCanonical"],
+            json!(["http://test/PlanDefinition/Main|1.0"])
+        );
+        assert_eq!(request_group["action"].as_array().unwrap().len(), 1);
+        let first_action_reference = request_group["action"][0]["resource"]["reference"]
+            .as_str()
+            .unwrap();
+        assert!(first_action_reference.starts_with("ServiceRequest/"));
+        assert!(entries
+            .iter()
+            .any(|entry| entry["resource"]["resourceType"] == "Goal"));
+        assert!(entries
+            .iter()
+            .any(|entry| entry["resource"]["resourceType"] == "ServiceRequest"));
+        assert!(request_group["extension"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|extension| { extension["url"] == GOAL_EXTENSION_URL }));
+    }
+
+    #[test]
+    fn appends_goal_resource_and_reference_extension() {
+        let bundle = content_bundle(false);
+        let ctx = context(&bundle);
+        let result = apply_plan_definition(&main_plan(&bundle), &ctx).unwrap();
+        let entries = result["entry"].as_array().unwrap();
+
+        let goal_entry = entries
+            .iter()
+            .find(|entry| entry["resource"]["resourceType"] == "Goal")
+            .unwrap();
+        assert!(goal_entry["fullUrl"]
+            .as_str()
+            .unwrap()
+            .starts_with(BASE_URL));
+        assert_eq!(goal_entry["resource"]["lifecycleStatus"], "proposed");
+        assert_eq!(
+            goal_entry["resource"]["category"].as_array().unwrap().len(),
+            1
+        );
+    }
+
+    #[test]
+    fn applies_sub_plan_and_references_sub_request_group() {
+        let bundle = content_bundle(true);
+        let ctx = context(&bundle);
+        let result = apply_plan_definition(&main_plan(&bundle), &ctx).unwrap();
+        let request_group = &result["entry"][0]["resource"];
+        let parent_actions = request_group["action"].as_array().unwrap();
+        let sub_reference = parent_actions
+            .iter()
+            .find_map(|action| {
+                action["resource"]["reference"]
+                    .as_str()
+                    .filter(|reference| reference.starts_with("RequestGroup/"))
+            })
+            .unwrap();
+
+        let sub_id = sub_reference.strip_prefix("RequestGroup/").unwrap();
+        let sub_entry = result["entry"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|entry| {
+                entry["resource"]["resourceType"] == "RequestGroup"
+                    && entry["resource"]["id"] == sub_id
+            })
+            .unwrap();
+
+        assert_eq!(sub_entry["resource"]["intent"], "proposal");
+        assert_eq!(
+            sub_entry["resource"]["instantiatesCanonical"],
+            json!(["http://test/PlanDefinition/Sub"])
+        );
+    }
+}

--- a/crates/rh-cpg/src/context.rs
+++ b/crates/rh-cpg/src/context.rs
@@ -1,0 +1,98 @@
+use std::sync::Arc;
+
+use serde_json::Value;
+
+use crate::resolver::ContentResolver;
+
+pub struct ApplyContext {
+    pub content_resolver: Arc<dyn ContentResolver>,
+    /// Subject reference, e.g. "Patient/123".
+    pub subject: String,
+    pub encounter: Option<String>,
+    pub practitioner: Option<String>,
+    pub organization: Option<String>,
+    /// FHIR Bundle of patient data (may be a collection bundle).
+    pub data: Option<Value>,
+}
+
+impl ApplyContext {
+    pub fn new(content_resolver: Arc<dyn ContentResolver>, subject: impl Into<String>) -> Self {
+        Self {
+            content_resolver,
+            subject: subject.into(),
+            encounter: None,
+            practitioner: None,
+            organization: None,
+            data: None,
+        }
+    }
+
+    pub fn data_resources(&self) -> Vec<Value> {
+        self.data
+            .as_ref()
+            .map(|bundle| {
+                bundle
+                    .get("entry")
+                    .and_then(Value::as_array)
+                    .map(|entries| {
+                        entries
+                            .iter()
+                            .filter_map(|entry| entry.get("resource"))
+                            .filter(|resource| resource.is_object())
+                            .cloned()
+                            .collect()
+                    })
+                    .unwrap_or_default()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn resolve_context_resource(&self, reference: &str) -> Option<Value> {
+        let canonical_reference = canonical_reference(reference);
+        self.data_resources()
+            .into_iter()
+            .find(|resource| {
+                matches_context_reference(
+                    &canonical_reference,
+                    resource.get("resourceType").and_then(Value::as_str),
+                    resource.get("id").and_then(Value::as_str),
+                )
+            })
+            .or_else(|| {
+                self.content_resolver
+                    .resolve_reference(reference)
+                    .ok()
+                    .flatten()
+            })
+    }
+}
+
+fn canonical_reference(reference: &str) -> String {
+    reference
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(reference)
+        .split('/')
+        .filter(|segment| !segment.is_empty())
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .take(2)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
+fn matches_context_reference(
+    reference: &str,
+    resource_type: Option<&str>,
+    resource_id: Option<&str>,
+) -> bool {
+    let Some((resource_type, resource_id)) = resource_type.zip(resource_id) else {
+        return false;
+    };
+
+    reference == format!("{resource_type}/{resource_id}")
+}

--- a/crates/rh-cpg/src/error.rs
+++ b/crates/rh-cpg/src/error.rs
@@ -1,0 +1,24 @@
+use serde_json::Error as JsonError;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum CpgError {
+    #[error("invalid resource: {0}")]
+    InvalidResource(String),
+    #[error("canonical not found: {0}")]
+    CanonicalNotFound(String),
+    #[error("reference not found: {0}")]
+    ReferenceNotFound(String),
+    #[error("expression error: {0}")]
+    ExpressionError(String),
+    #[error("unsupported expression language: {0}")]
+    UnsupportedExpressionLanguage(String),
+    #[error("evaluation error: {0}")]
+    EvaluationError(String),
+    #[error(transparent)]
+    Json(#[from] JsonError),
+    #[error("CQL evaluation error: {0}")]
+    CqlEval(String),
+}
+
+pub type CpgResult<T> = Result<T, CpgError>;

--- a/crates/rh-cpg/src/expression.rs
+++ b/crates/rh-cpg/src/expression.rs
@@ -1,0 +1,314 @@
+use std::collections::HashMap;
+
+use base64::Engine;
+use rh_cql::compile;
+use rh_cql::elm::Library;
+use rh_cql::eval::engine::evaluate_elm_with_libraries;
+use rh_cql::eval::{CqlDateTime, EvalContextBuilder, FixedClock, InMemoryTerminologyProvider};
+use rh_fhirpath::{EvaluationContext, FhirPathEvaluator, FhirPathParser, FhirPathValue};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::context::ApplyContext;
+use crate::error::{CpgError, CpgResult};
+use crate::fhir_to_cql::{cql_value_to_json, fhir_to_cql_value, FhirDataProvider};
+
+pub fn evaluate_expression(
+    expression: &Value,
+    definitional_resource: &Value,
+    library_canonicals: &[String],
+    ctx: &ApplyContext,
+) -> CpgResult<Value> {
+    match language(expression)? {
+        "text/fhirpath" => evaluate_fhirpath(expression, definitional_resource, ctx),
+        "text/cql-identifier" => evaluate_cql_identifier(expression, library_canonicals, ctx),
+        unsupported => Err(CpgError::UnsupportedExpressionLanguage(
+            unsupported.to_string(),
+        )),
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct ElmWrapper {
+    library: Library,
+}
+
+fn language(expression: &Value) -> CpgResult<&str> {
+    expression
+        .get("language")
+        .and_then(Value::as_str)
+        .ok_or_else(|| CpgError::ExpressionError("expression language is required".to_string()))
+}
+
+fn evaluate_fhirpath(
+    expression: &Value,
+    definitional_resource: &Value,
+    ctx: &ApplyContext,
+) -> CpgResult<Value> {
+    let source = expression_source(expression)?;
+    let parsed = FhirPathParser::new()
+        .parse(source)
+        .map_err(|error| CpgError::ExpressionError(error.to_string()))?;
+
+    let mut context = EvaluationContext::new(definitional_resource.clone());
+    for constant_name in ["subject", "encounter", "practitioner", "organization"] {
+        if let Some(reference) = context_reference(ctx, constant_name) {
+            if let Some(resource) = ctx.resolve_context_resource(reference) {
+                context.add_constant(constant_name.to_string(), FhirPathValue::Object(resource));
+            }
+        }
+    }
+
+    let result = FhirPathEvaluator::new()
+        .evaluate(&parsed, &context)
+        .map_err(|error| CpgError::ExpressionError(error.to_string()))?;
+
+    Ok(fhir_path_result_to_json(result))
+}
+
+fn context_reference<'ctx>(ctx: &'ctx ApplyContext, constant_name: &str) -> Option<&'ctx str> {
+    match constant_name {
+        "subject" => Some(&ctx.subject),
+        "encounter" => ctx.encounter.as_deref(),
+        "practitioner" => ctx.practitioner.as_deref(),
+        "organization" => ctx.organization.as_deref(),
+        _ => None,
+    }
+}
+
+fn fhir_path_result_to_json(result: FhirPathValue) -> Value {
+    let items = match result {
+        FhirPathValue::Collection(items) => items,
+        item => vec![item],
+    };
+
+    match items.as_slice() {
+        [] => Value::Null,
+        [item] => item.to_json(),
+        items => Value::Array(items.iter().map(FhirPathValue::to_json).collect()),
+    }
+}
+
+fn evaluate_cql_identifier(
+    expression: &Value,
+    library_canonicals: &[String],
+    ctx: &ApplyContext,
+) -> CpgResult<Value> {
+    let canonical = expression
+        .get("reference")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| library_canonicals.first().cloned())
+        .ok_or_else(|| {
+            CpgError::ExpressionError(
+                "CQL identifier expression has no library reference".to_string(),
+            )
+        })?;
+    let library = ctx
+        .content_resolver
+        .resolve_canonical(&canonical)
+        .map_err(|error| {
+            CpgError::ExpressionError(format!("failed to resolve library {canonical}: {error}"))
+        })?
+        .ok_or_else(|| CpgError::CanonicalNotFound(canonical.clone()))?;
+    let elm = extract_elm(&library)?;
+    let included_libraries = included_libraries(ctx, &canonical)?;
+
+    let patient = ctx.resolve_context_resource(&ctx.subject);
+    let mut builder = EvalContextBuilder::new(FixedClock::new(fixed_now()))
+        .data_provider(FhirDataProvider::from_bundle(
+            ctx.data.as_ref().unwrap_or(&Value::Null),
+        ))
+        .terminology_provider(InMemoryTerminologyProvider::new());
+    if let Some(patient) = patient {
+        builder = builder.context_value(fhir_to_cql_value(&patient));
+    }
+    let eval_context = builder.build();
+
+    let definition_name = expression_source(expression)?;
+    let result = evaluate_elm_with_libraries(
+        elm.as_ref()
+            .expect("library must contain ELM or CQL content"),
+        &included_libraries,
+        definition_name,
+        &eval_context,
+    )
+    .map_err(|error| CpgError::CqlEval(error.to_string()))?;
+
+    Ok(cql_value_to_json(&result))
+}
+
+fn included_libraries(
+    ctx: &ApplyContext,
+    target_canonical: &str,
+) -> CpgResult<HashMap<String, Library>> {
+    let mut libraries = HashMap::new();
+    for library in ctx.content_resolver.all_by_type("Library")? {
+        let is_target = library
+            .get("url")
+            .and_then(Value::as_str)
+            .is_some_and(|url| {
+                url == target_canonical || target_canonical.starts_with(&format!("{url}|"))
+            });
+        if !is_target {
+            if let Some(name) = library.get("name").and_then(Value::as_str) {
+                if let Some(elm) = extract_elm(&library)? {
+                    libraries.insert(name.to_string(), elm);
+                }
+            }
+        }
+    }
+
+    Ok(libraries)
+}
+
+fn extract_elm(library: &Value) -> CpgResult<Option<Library>> {
+    let Some(elm_attachment) = content_by_type(library, "application/elm+json") else {
+        return extract_elm_from_cql(library);
+    };
+
+    let data = elm_attachment
+        .get("data")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CpgError::ExpressionError("ELM attachment has no base64 data".to_string())
+        })?;
+    let decoded = decode_base64(data)?;
+    let wrapper: ElmWrapper = serde_json::from_str(&decoded)
+        .map_err(|error| CpgError::ExpressionError(error.to_string()))?;
+
+    Ok(Some(wrapper.library))
+}
+
+fn extract_elm_from_cql(library: &Value) -> CpgResult<Option<Library>> {
+    let Some(cql_attachment) = content_by_type(library, "text/cql") else {
+        return Ok(None);
+    };
+    let data = cql_attachment
+        .get("data")
+        .and_then(Value::as_str)
+        .ok_or_else(|| {
+            CpgError::ExpressionError("CQL attachment has no base64 data".to_string())
+        })?;
+    let source = decode_base64(data)?;
+    let compiled = compile(&source, None)
+        .map_err(|error| CpgError::ExpressionError(format!("failed to compile CQL: {error}")))?;
+
+    Ok(Some(compiled.library))
+}
+
+fn content_by_type<'value>(library: &'value Value, content_type: &str) -> Option<&'value Value> {
+    library
+        .get("content")
+        .and_then(Value::as_array)?
+        .iter()
+        .find(|attachment| {
+            attachment.get("contentType").and_then(Value::as_str) == Some(content_type)
+        })
+}
+
+fn decode_base64(data: &str) -> CpgResult<String> {
+    let bytes = base64::engine::general_purpose::STANDARD
+        .decode(data)
+        .map_err(|error| CpgError::ExpressionError(error.to_string()))?;
+    String::from_utf8(bytes).map_err(|error| CpgError::ExpressionError(error.to_string()))
+}
+
+fn expression_source(expression: &Value) -> CpgResult<&str> {
+    expression
+        .get("expression")
+        .and_then(Value::as_str)
+        .ok_or_else(|| CpgError::ExpressionError("expression value is required".to_string()))
+}
+
+fn fixed_now() -> CqlDateTime {
+    CqlDateTime {
+        year: 2026,
+        month: Some(1),
+        day: Some(1),
+        hour: Some(0),
+        minute: Some(0),
+        second: Some(0),
+        millisecond: None,
+        offset_seconds: Some(0),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use crate::resolver::BundleResolver;
+    use serde_json::json;
+
+    use super::*;
+    use crate::context::ApplyContext;
+
+    #[test]
+    fn evaluates_fhirpath_against_definitional_resource() {
+        let plan_definition = json!({
+            "resourceType": "PlanDefinition",
+            "title": "Diabetes Screening"
+        });
+        let expression = json!({
+            "language": "text/fhirpath",
+            "expression": "title"
+        });
+        let ctx = test_context(None);
+
+        let result = evaluate_expression(&expression, &plan_definition, &[], &ctx)
+            .expect("FHIRPath evaluation should succeed");
+
+        assert_eq!(result, json!("Diabetes Screening"));
+    }
+
+    #[test]
+    fn evaluates_cql_identifier_from_elm_library() {
+        let library = compiled_test_library();
+        let library_resource = json!({
+            "resourceType": "Library",
+            "url": "http://test/Library/TestLib",
+            "name": "TestLib",
+            "content": [{
+                "contentType": "application/elm+json",
+                "data": encode_elm(&library)
+            }]
+        });
+        let expression = json!({
+            "language": "text/cql-identifier",
+            "expression": "IsAdult",
+            "reference": "http://test/Library/TestLib"
+        });
+        let ctx = test_context(Some(json!({
+            "resourceType": "Bundle",
+            "entry": [{ "resource": library_resource }]
+        })));
+
+        let result = evaluate_expression(&expression, &json!({}), &[], &ctx)
+            .expect("CQL evaluation should succeed");
+
+        assert_eq!(result, json!(true));
+    }
+
+    fn test_context(bundle: Option<Value>) -> ApplyContext {
+        let content_bundle = bundle.unwrap_or(json!({ "resourceType": "Bundle" }));
+        let resolver =
+            Arc::new(BundleResolver::new(&content_bundle).expect("test bundle should be valid"));
+        ApplyContext::new(resolver, "Patient/123")
+    }
+
+    fn compiled_test_library() -> Library {
+        let source = "library TestLib version '1.0' define \"IsAdult\": true";
+        compile(source, None)
+            .expect("test CQL should compile")
+            .library
+    }
+
+    fn encode_elm(library: &Library) -> String {
+        let wrapper = ElmWrapper {
+            library: library.clone(),
+        };
+        let encoded = serde_json::to_string(&wrapper).expect("ELM library should serialize");
+        base64::engine::general_purpose::STANDARD.encode(encoded)
+    }
+}

--- a/crates/rh-cpg/src/fhir_to_cql.rs
+++ b/crates/rh-cpg/src/fhir_to_cql.rs
@@ -1,0 +1,224 @@
+use std::collections::HashMap;
+
+use rh_cql::eval::Value as CqlValue;
+use rh_cql::eval::{CqlQuantity, EvalError};
+use serde_json::Value;
+
+pub fn fhir_to_cql_value(json: &Value) -> CqlValue {
+    match json {
+        Value::Null => CqlValue::Null,
+        Value::Bool(boolean) => CqlValue::Boolean(*boolean),
+        Value::Number(number) => match number.as_i64() {
+            Some(integer) => CqlValue::Integer(integer),
+            None => CqlValue::Decimal(number.as_f64().unwrap_or_default()),
+        },
+        Value::String(string) => CqlValue::String(string.clone()),
+        Value::Array(items) => CqlValue::List(items.iter().map(fhir_to_cql_value).collect()),
+        Value::Object(object) => CqlValue::Tuple(
+            object
+                .iter()
+                .map(|(key, value)| (key.to_string(), fhir_to_cql_value(value)))
+                .collect(),
+        ),
+    }
+}
+
+pub fn cql_value_to_json(value: &CqlValue) -> Value {
+    match value {
+        CqlValue::Null => Value::Null,
+        CqlValue::Boolean(boolean) => Value::Bool(*boolean),
+        CqlValue::Integer(integer) => Value::from(*integer),
+        CqlValue::Long(integer) => i64::try_from(*integer).map_or_else(
+            |_| Value::String(integer.to_string()),
+            |integer| Value::from(integer),
+        ),
+        CqlValue::Decimal(decimal) => {
+            serde_json::Number::from_f64(*decimal).map_or(Value::Null, Value::Number)
+        }
+        CqlValue::String(string) => Value::String(string.clone()),
+        CqlValue::Date(date) => Value::String(date.to_string()),
+        CqlValue::DateTime(date_time) => Value::String(date_time.to_string()),
+        CqlValue::Time(time) => Value::String(time.to_string()),
+        CqlValue::Quantity(quantity) => {
+            let mut object = serde_json::Map::new();
+            object.insert("value".to_string(), cql_scalar_to_json(quantity.value));
+            object.insert("unit".to_string(), Value::String(quantity.unit.clone()));
+            Value::Object(object)
+        }
+        CqlValue::Ratio {
+            numerator,
+            denominator,
+        } => {
+            let mut object = serde_json::Map::new();
+            object.insert("numerator".to_string(), cql_quantity_to_json(numerator));
+            object.insert("denominator".to_string(), cql_quantity_to_json(denominator));
+            Value::Object(object)
+        }
+        CqlValue::Code(code) => Value::String(code.code.clone()),
+        CqlValue::Concept(concept) => {
+            let mut object = serde_json::Map::new();
+            object.insert(
+                "codes".to_string(),
+                Value::Array(
+                    concept
+                        .codes
+                        .iter()
+                        .map(|code| Value::String(code.code.clone()))
+                        .collect(),
+                ),
+            );
+            if let Some(display) = concept.display.as_ref() {
+                object.insert("display".to_string(), Value::String(display.clone()));
+            }
+            Value::Object(object)
+        }
+        CqlValue::List(items) => Value::Array(items.iter().map(cql_value_to_json).collect()),
+        CqlValue::Tuple(fields) => {
+            let mut object = serde_json::Map::new();
+            for (key, field) in fields {
+                object.insert(key.clone(), cql_value_to_json(field));
+            }
+            Value::Object(object)
+        }
+        CqlValue::Interval { .. } => Value::Null,
+    }
+}
+
+fn cql_quantity_to_json(quantity: &CqlQuantity) -> Value {
+    let mut object = serde_json::Map::new();
+    object.insert("value".to_string(), cql_scalar_to_json(quantity.value));
+    object.insert("unit".to_string(), Value::String(quantity.unit.clone()));
+    Value::Object(object)
+}
+
+fn cql_scalar_to_json(value: f64) -> Value {
+    serde_json::Number::from_f64(value).map_or(Value::Null, Value::Number)
+}
+
+pub struct FhirDataProvider {
+    resources: HashMap<String, Vec<CqlValue>>,
+}
+
+impl FhirDataProvider {
+    pub fn from_bundle(bundle: &Value) -> Self {
+        Self {
+            resources: bundle
+                .get("entry")
+                .and_then(Value::as_array)
+                .map(|entries| {
+                    let mut resources: HashMap<String, Vec<CqlValue>> = HashMap::new();
+                    for resource in entries
+                        .iter()
+                        .filter_map(|entry| entry.get("resource"))
+                        .filter(|resource| resource.is_object())
+                    {
+                        if let Some(resource_type) =
+                            resource.get("resourceType").and_then(Value::as_str)
+                        {
+                            resources
+                                .entry(resource_type.to_string())
+                                .or_default()
+                                .push(fhir_to_cql_value(resource));
+                        }
+                    }
+                    resources
+                })
+                .unwrap_or_default(),
+        }
+    }
+}
+
+impl rh_cql::eval::DataProvider for FhirDataProvider {
+    fn retrieve(
+        &self,
+        _context: Option<&str>,
+        data_type: &str,
+        _code_path: Option<&str>,
+        _codes: Option<&CqlValue>,
+        _date_path: Option<&str>,
+        _date_range: Option<&CqlValue>,
+    ) -> Result<Vec<CqlValue>, EvalError> {
+        Ok(self
+            .resources
+            .get(&normalize_data_type(data_type))
+            .cloned()
+            .unwrap_or_default())
+    }
+}
+
+fn normalize_data_type(data_type: &str) -> String {
+    let data_type = data_type
+        .strip_prefix('{')
+        .and_then(|prefixed| prefixed.split_once('}'))
+        .map(|(_, name)| name)
+        .unwrap_or(data_type);
+
+    data_type
+        .split("FHIR.")
+        .last()
+        .unwrap_or(data_type)
+        .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use rh_cql::eval::{CqlDateTime, DataProvider};
+
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn converts_scalars_objects_and_arrays_round_trip() {
+        let json = json!({
+            "boolean": true,
+            "integer": 42,
+            "decimal": 4.5,
+            "string": "value",
+            "array": [1, "two"],
+            "object": { "nested": true }
+        });
+
+        assert_eq!(cql_value_to_json(&fhir_to_cql_value(&json)), json);
+    }
+
+    #[test]
+    fn converts_cql_datetime_to_iso_string() {
+        let date_time = CqlDateTime {
+            year: 2026,
+            month: Some(1),
+            day: Some(1),
+            hour: Some(0),
+            minute: Some(0),
+            second: Some(0),
+            millisecond: None,
+            offset_seconds: Some(0),
+        };
+
+        assert_eq!(
+            cql_value_to_json(&CqlValue::DateTime(date_time)),
+            json!("2026-01-01T00:00:00Z")
+        );
+    }
+
+    #[test]
+    fn retrieves_resources_by_qualified_and_plain_type() {
+        let bundle = json!({
+            "resourceType": "Bundle",
+            "entry": [{
+                "resource": {
+                    "resourceType": "Observation",
+                    "id": "observation-1",
+                    "status": "final"
+                }
+            }]
+        });
+        let provider = FhirDataProvider::from_bundle(&bundle);
+
+        for data_type in ["{http://hl7.org/fhir}Observation", "Observation"] {
+            let resources = provider
+                .retrieve(None, data_type, None, None, None, None)
+                .expect("retrieve should succeed");
+            assert_eq!(resources.len(), 1);
+        }
+    }
+}

--- a/crates/rh-cpg/src/lib.rs
+++ b/crates/rh-cpg/src/lib.rs
@@ -1,0 +1,10 @@
+//! Clinical Practice Guidelines (CPG) support for FHIR resources.
+
+pub mod error;
+pub mod resolver;
+
+pub mod apply;
+
+pub mod context;
+pub mod expression;
+pub mod fhir_to_cql;

--- a/crates/rh-cpg/src/resolver/mod.rs
+++ b/crates/rh-cpg/src/resolver/mod.rs
@@ -1,0 +1,241 @@
+use std::collections::HashMap;
+
+use serde_json::Value;
+
+use crate::error::{CpgError, CpgResult};
+
+pub trait ContentResolver: Send + Sync {
+    /// Resolve a resource by canonical URL (e.g. "http://example.org/PlanDefinition/x|1.0").
+    /// Version is optional; if given, match `url|version`; otherwise match `url` alone.
+    fn resolve_canonical(&self, canonical: &str) -> CpgResult<Option<Value>>;
+    /// Resolve a resource by reference (e.g. "Patient/123" or "http://server/Patient/123").
+    fn resolve_reference(&self, reference: &str) -> CpgResult<Option<Value>>;
+    /// Return all resources of a given resourceType (e.g. "Library"), optionally filtered by subject.
+    fn all_by_type(&self, resource_type: &str) -> CpgResult<Vec<Value>>;
+    /// Find a ValueSet by canonical URL.
+    fn find_value_set(&self, url: &str) -> CpgResult<Option<Value>>;
+}
+
+#[derive(Debug, Default)]
+pub struct BundleResolver {
+    canonical: HashMap<String, Value>,
+    references: HashMap<String, Value>,
+    by_type: HashMap<String, Vec<Value>>,
+}
+
+impl BundleResolver {
+    pub fn new(bundle: &Value) -> CpgResult<Self> {
+        if bundle
+            .as_object()
+            .and_then(|object| object.get("resourceType"))
+            .and_then(Value::as_str)
+            != Some("Bundle")
+        {
+            return Err(CpgError::InvalidResource(
+                "expected a FHIR Bundle object".to_string(),
+            ));
+        }
+
+        let mut resolver = Self::default();
+        for resource in bundle
+            .get("entry")
+            .and_then(Value::as_array)
+            .into_iter()
+            .flatten()
+            .filter_map(|entry| entry.get("resource"))
+            .filter(|resource| resource.is_object())
+        {
+            let Some(resource_type) = resource
+                .get("resourceType")
+                .and_then(Value::as_str)
+                .map(str::to_string)
+            else {
+                continue;
+            };
+
+            if let (Some(url), Some(version)) = (
+                resource.get("url").and_then(Value::as_str),
+                resource.get("version").and_then(Value::as_str),
+            ) {
+                resolver
+                    .canonical
+                    .insert(format!("{url}|{version}"), resource.clone());
+            }
+            if let Some(url) = resource.get("url").and_then(Value::as_str) {
+                resolver.canonical.insert(url.to_string(), resource.clone());
+            }
+
+            if let Some(id) = resource.get("id").and_then(Value::as_str) {
+                resolver
+                    .references
+                    .insert(format!("{resource_type}/{id}"), resource.clone());
+            }
+
+            resolver
+                .by_type
+                .entry(resource_type)
+                .or_default()
+                .push(resource.clone());
+        }
+
+        Ok(resolver)
+    }
+}
+
+impl ContentResolver for BundleResolver {
+    fn resolve_canonical(&self, canonical: &str) -> CpgResult<Option<Value>> {
+        if let Some(resource) = self.canonical.get(canonical) {
+            return Ok(Some(resource.clone()));
+        }
+
+        if let Some((url, _version)) = canonical.split_once('|') {
+            return Ok(self.canonical.get(url).cloned());
+        }
+
+        Ok(None)
+    }
+
+    fn resolve_reference(&self, reference: &str) -> CpgResult<Option<Value>> {
+        let normalized = normalize_reference(reference);
+        Ok(self.references.get(&normalized).cloned())
+    }
+
+    fn all_by_type(&self, resource_type: &str) -> CpgResult<Vec<Value>> {
+        Ok(self.by_type.get(resource_type).cloned().unwrap_or_default())
+    }
+
+    fn find_value_set(&self, url: &str) -> CpgResult<Option<Value>> {
+        self.resolve_canonical(url)
+    }
+}
+
+fn normalize_reference(reference: &str) -> String {
+    let reference = reference.split(['?', '#']).next().unwrap_or(reference);
+    let mut parts = reference
+        .split('/')
+        .filter(|part| !part.is_empty())
+        .collect::<Vec<_>>();
+
+    if parts.len() >= 2 {
+        parts.drain(..parts.len() - 2);
+    }
+    parts.join("/")
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn bundle() -> Value {
+        json!({
+            "resourceType": "Bundle",
+            "entry": [
+                {"resource": {
+                    "resourceType": "Library",
+                    "id": "library-1",
+                    "url": "http://example.org/Library/library-1",
+                    "version": "1.0"
+                }},
+                {"resource": {
+                    "resourceType": "Patient",
+                    "id": "123"
+                }},
+                {"resource": {
+                    "resourceType": "ValueSet",
+                    "id": "valueset-1",
+                    "url": "http://example.org/ValueSet/valueset-1"
+                }}
+            ]
+        })
+    }
+
+    fn resolver() -> BundleResolver {
+        BundleResolver::new(&bundle()).expect("valid bundle")
+    }
+
+    #[test]
+    fn resolves_canonical_exact_match() {
+        let resolver = resolver();
+        let resource = resolver
+            .resolve_canonical("http://example.org/Library/library-1")
+            .unwrap();
+        assert_eq!(resource.unwrap().get("id").unwrap(), "library-1");
+    }
+
+    #[test]
+    fn resolves_canonical_with_version_suffix() {
+        let resolver = resolver();
+        let resource = resolver
+            .resolve_canonical("http://example.org/Library/library-1|1.0")
+            .unwrap();
+        assert_eq!(resource.unwrap().get("id").unwrap(), "library-1");
+    }
+
+    #[test]
+    fn resolves_canonical_fallback_without_resource_version() {
+        let resolver = resolver();
+        let resource = resolver
+            .resolve_canonical("http://example.org/ValueSet/valueset-1|1.0")
+            .unwrap();
+        assert_eq!(resource.unwrap().get("id").unwrap(), "valueset-1");
+    }
+
+    #[test]
+    fn resolves_relative_reference() {
+        let resolver = resolver();
+        let resource = resolver.resolve_reference("Patient/123").unwrap();
+        assert_eq!(resource.unwrap().get("id").unwrap(), "123");
+    }
+
+    #[test]
+    fn resolves_absolute_reference() {
+        let resolver = resolver();
+        let resource = resolver
+            .resolve_reference("https://server.example.org/Patient/123")
+            .unwrap();
+        assert_eq!(resource.unwrap().get("id").unwrap(), "123");
+    }
+
+    #[test]
+    fn returns_all_by_type() {
+        let resolver = resolver();
+        let libraries = resolver.all_by_type("Library").unwrap();
+        assert_eq!(libraries.len(), 1);
+        assert_eq!(libraries[0].get("id").unwrap(), "library-1");
+    }
+
+    #[test]
+    fn finds_value_set_by_url() {
+        let resolver = resolver();
+        let value_set = resolver
+            .find_value_set("http://example.org/ValueSet/valueset-1")
+            .unwrap();
+        assert_eq!(value_set.unwrap().get("id").unwrap(), "valueset-1");
+    }
+
+    #[test]
+    fn misses_return_none_or_empty_without_error() {
+        let resolver = resolver();
+        assert!(resolver
+            .resolve_canonical("http://example.org/missing")
+            .unwrap()
+            .is_none());
+        assert!(resolver
+            .resolve_reference("Observation/missing")
+            .unwrap()
+            .is_none());
+        assert!(resolver.all_by_type("Organization").unwrap().is_empty());
+        assert!(resolver
+            .find_value_set("http://example.org/missing")
+            .unwrap()
+            .is_none());
+    }
+
+    #[test]
+    fn constructor_rejects_non_bundle() {
+        let error = BundleResolver::new(&json!({"resourceType": "Patient"})).unwrap_err();
+        assert!(matches!(error, CpgError::InvalidResource(_)));
+    }
+}

--- a/crates/rh-cpg/tests/apply_plan_definition.rs
+++ b/crates/rh-cpg/tests/apply_plan_definition.rs
@@ -1,0 +1,234 @@
+use std::sync::Arc;
+
+use rh_cpg::apply::plan_definition::apply_plan_definition;
+use rh_cpg::context::ApplyContext;
+use rh_cpg::resolver::BundleResolver;
+use serde_json::{json, Value};
+
+fn fixture(name: &str) -> Value {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests/fixtures")
+        .join(name);
+    let contents = std::fs::read_to_string(path).expect("fixture should exist");
+    serde_json::from_str(&contents).expect("fixture should be valid JSON")
+}
+
+fn content_bundle(entries: Vec<Value>) -> Value {
+    json!({
+        "resourceType": "Bundle",
+        "type": "collection",
+        "entry": entries.into_iter().map(|resource| json!({"resource": resource})).collect::<Vec<_>>(),
+    })
+}
+
+fn context(bundle: &Value) -> ApplyContext {
+    ApplyContext::new(
+        Arc::new(BundleResolver::new(bundle).expect("bundle should be valid")),
+        "Patient/123",
+    )
+}
+
+fn resource_of(result: &Value, index: usize) -> &Value {
+    result
+        .get("entry")
+        .and_then(Value::as_array)
+        .and_then(|entries| entries.get(index))
+        .and_then(|entry| entry.get("resource"))
+        .expect("expected bundle entry resource")
+}
+
+fn resources(result: &Value) -> Vec<&Value> {
+    result
+        .get("entry")
+        .and_then(Value::as_array)
+        .map(|entries| {
+            entries
+                .iter()
+                .filter_map(|entry| entry.get("resource"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+#[test]
+fn simple_plan_definition() {
+    let plan = fixture("PlanDefinition-SimplePlanDefinition.json");
+    let ctx = context(&content_bundle(Vec::new()));
+    let result = apply_plan_definition(&plan, &ctx).expect("apply should succeed");
+
+    let request_group = resource_of(&result, 0);
+    assert_eq!(
+        request_group.get("resourceType").and_then(Value::as_str),
+        Some("RequestGroup")
+    );
+    assert_eq!(
+        request_group
+            .get("subject")
+            .and_then(|subject| subject.get("reference"))
+            .and_then(Value::as_str),
+        Some("Patient/123")
+    );
+    assert_eq!(
+        request_group.get("status").and_then(Value::as_str),
+        Some("draft")
+    );
+    assert_eq!(
+        request_group.get("intent").and_then(Value::as_str),
+        Some("proposal")
+    );
+    assert_eq!(
+        request_group
+            .get("instantiatesCanonical")
+            .and_then(Value::as_array),
+        Some(&vec![json!(
+            "http://example.org/PlanDefinition/SimplePlanDefinition|0.1.0"
+        )])
+    );
+}
+
+#[test]
+fn plan_definition_with_goal() {
+    let plan = fixture("PlanDefinition-SimplePlanDefinitionWithGoal.json");
+    let ctx = context(&content_bundle(Vec::new()));
+    let result = apply_plan_definition(&plan, &ctx).expect("apply should succeed");
+
+    let request_group = resource_of(&result, 0);
+    assert_eq!(
+        request_group.get("resourceType").and_then(Value::as_str),
+        Some("RequestGroup")
+    );
+
+    let goal = resources(&result)
+        .into_iter()
+        .find(|resource| resource.get("resourceType").and_then(Value::as_str) == Some("Goal"))
+        .expect("expected Goal resource");
+    assert_eq!(
+        goal.pointer("/description/text").and_then(Value::as_str),
+        Some("to improve")
+    );
+
+    let goal_id = goal.get("id").and_then(Value::as_str).expect("goal id");
+    let extension = request_group
+        .get("extension")
+        .and_then(Value::as_array)
+        .expect("goal extension")
+        .iter()
+        .find(|extension| {
+            extension.get("url").and_then(Value::as_str)
+                == Some("http://hl7.org/fhir/StructureDefinition/resource-pertainsToGoal")
+        })
+        .expect("pertains-to-goal extension");
+    assert_eq!(
+        extension
+            .pointer("/valueReference/reference")
+            .and_then(Value::as_str),
+        Some(format!("Goal/{goal_id}").as_str())
+    );
+}
+
+#[test]
+fn plan_definition_with_action() {
+    let plan = fixture("PlanDefinition-PlanDefinitionWithAction.json");
+    let ctx = context(&content_bundle(Vec::new()));
+    let result = apply_plan_definition(&plan, &ctx).expect("apply should succeed");
+
+    let request_group = resource_of(&result, 0);
+    let action = request_group
+        .pointer("/action/0")
+        .expect("first request group action");
+    assert_eq!(action.get("id").and_then(Value::as_str), Some("action-1"));
+    assert_eq!(
+        action.get("prefix").and_then(Value::as_str),
+        Some("action-1 prefix")
+    );
+    assert_eq!(
+        action.get("title").and_then(Value::as_str),
+        Some("action-1 title")
+    );
+    assert_eq!(
+        action.get("description").and_then(Value::as_str),
+        Some("action-1 description")
+    );
+    assert_eq!(
+        action.get("textEquivalent").and_then(Value::as_str),
+        Some("action-1 textEquivalent")
+    );
+    assert_eq!(
+        action.get("priority").and_then(Value::as_str),
+        Some("routine")
+    );
+    assert_eq!(
+        action.pointer("/code/0/text").and_then(Value::as_str),
+        Some("action-1 code")
+    );
+    assert_eq!(
+        action
+            .pointer("/relatedAction/0/actionId")
+            .and_then(Value::as_str),
+        Some("action-1 relatedActionId")
+    );
+    assert_eq!(
+        action
+            .pointer("/relatedAction/0/relationship")
+            .and_then(Value::as_str),
+        Some("before")
+    );
+}
+
+#[test]
+fn activity_definition_application() {
+    let mut plan = fixture("PlanDefinition-PlanDefinitionWithAction.json");
+    plan.pointer_mut("/action/0")
+        .expect("action")
+        .as_object_mut()
+        .expect("action object")
+        .insert(
+            "definitionCanonical".to_string(),
+            json!("http://example.org/ActivityDefinition/SimpleActivityDefinition"),
+        );
+    let bundle = content_bundle(vec![
+        plan.clone(),
+        fixture("ActivityDefinition-SimpleActivityDefinition.json"),
+    ]);
+    let ctx = context(&bundle);
+    let result = apply_plan_definition(&plan, &ctx).expect("apply should succeed");
+
+    let request_group = resource_of(&result, 0);
+    let action = request_group
+        .pointer("/action/0")
+        .expect("first request group action");
+
+    let medication_request = resources(&result)
+        .into_iter()
+        .find(|resource| {
+            resource.get("resourceType").and_then(Value::as_str) == Some("MedicationRequest")
+        })
+        .expect("expected MedicationRequest");
+    assert_eq!(
+        medication_request.get("status").and_then(Value::as_str),
+        Some("draft")
+    );
+    assert_eq!(
+        medication_request
+            .pointer("/medicationCodeableConcept/coding/0/code")
+            .and_then(Value::as_str),
+        Some("1946772")
+    );
+
+    let medication_id = medication_request
+        .get("id")
+        .and_then(Value::as_str)
+        .expect("medication id");
+    assert_eq!(
+        action
+            .pointer("/resource/reference")
+            .and_then(Value::as_str),
+        Some(format!("MedicationRequest/{medication_id}").as_str())
+    );
+    assert_eq!(
+        action
+            .pointer("/type/coding/0/code")
+            .and_then(Value::as_str),
+        Some("create")
+    );
+}

--- a/crates/rh-cpg/tests/fixtures/ActivityDefinition-CommunicationRequestActivity.json
+++ b/crates/rh-cpg/tests/fixtures/ActivityDefinition-CommunicationRequestActivity.json
@@ -1,0 +1,25 @@
+{
+  "resourceType" : "ActivityDefinition",
+  "id" : "CommunicationRequestActivity",
+  "url" : "http://example.org/ActivityDefinition/CommunicationRequestActivity",
+  "version" : "0.1.0",
+  "status" : "draft",
+  "date" : "2023-01-23T15:45:25-05:00",
+  "publisher" : "Example Publisher",
+  "contact" : [{
+    "name" : "Example Publisher",
+    "telecom" : [{
+      "system" : "url",
+      "value" : "http://example.org/example-publisher"
+    }]
+  }],
+  "library" : ["http://example.org/Library/ExampleLibrary"],
+  "kind" : "CommunicationRequest",
+  "dynamicValue" : [{
+    "path" : "payload[0].contentString",
+    "expression" : {
+      "language" : "text/cql-identifier",
+      "expression" : "example message"
+    }
+  }]
+}

--- a/crates/rh-cpg/tests/fixtures/ActivityDefinition-SimpleActivityDefinition.json
+++ b/crates/rh-cpg/tests/fixtures/ActivityDefinition-SimpleActivityDefinition.json
@@ -1,0 +1,24 @@
+{
+  "resourceType" : "ActivityDefinition",
+  "id" : "SimpleActivityDefinition",
+  "url" : "http://example.org/ActivityDefinition/SimpleActivityDefinition",
+  "version" : "0.1.0",
+  "status" : "draft",
+  "date" : "2023-01-23T15:45:25-05:00",
+  "publisher" : "Example Publisher",
+  "contact" : [{
+    "name" : "Example Publisher",
+    "telecom" : [{
+      "system" : "url",
+      "value" : "http://example.org/example-publisher"
+    }]
+  }],
+  "kind" : "MedicationRequest",
+  "productCodeableConcept" : {
+    "coding" : [{
+      "system" : "http://www.nlm.nih.gov/research/umls/rxnorm",
+      "code" : "1946772",
+      "display" : "methotrexate 25 MG/ML Injectable Solution"
+    }]
+  }
+}

--- a/crates/rh-cpg/tests/fixtures/PlanDefinition-PlanDefinitionWithAction.json
+++ b/crates/rh-cpg/tests/fixtures/PlanDefinition-PlanDefinitionWithAction.json
@@ -1,0 +1,32 @@
+{
+  "resourceType" : "PlanDefinition",
+  "id" : "PlanDefinitionWithAction",
+  "url" : "http://example.org/PlanDefinition/PlanDefinitionWithAction",
+  "version" : "0.1.0",
+  "name" : "PlanDefinitionWithAction",
+  "status" : "active",
+  "date" : "2023-01-23T15:45:25-05:00",
+  "publisher" : "Example Publisher",
+  "contact" : [{
+    "name" : "Example Publisher",
+    "telecom" : [{
+      "system" : "url",
+      "value" : "http://example.org/example-publisher"
+    }]
+  }],
+  "action" : [{
+    "id" : "action-1",
+    "prefix" : "action-1 prefix",
+    "title" : "action-1 title",
+    "description" : "action-1 description",
+    "textEquivalent" : "action-1 textEquivalent",
+    "priority" : "routine",
+    "code" : [{
+      "text" : "action-1 code"
+    }],
+    "relatedAction" : [{
+      "actionId" : "action-1 relatedActionId",
+      "relationship" : "before"
+    }]
+  }]
+}

--- a/crates/rh-cpg/tests/fixtures/PlanDefinition-SimplePlanDefinition.json
+++ b/crates/rh-cpg/tests/fixtures/PlanDefinition-SimplePlanDefinition.json
@@ -1,0 +1,17 @@
+{
+  "resourceType" : "PlanDefinition",
+  "id" : "SimplePlanDefinition",
+  "url" : "http://example.org/PlanDefinition/SimplePlanDefinition",
+  "version" : "0.1.0",
+  "name" : "SimplePlanDefinition",
+  "status" : "active",
+  "date" : "2023-01-23T15:45:25-05:00",
+  "publisher" : "Example Publisher",
+  "contact" : [{
+    "name" : "Example Publisher",
+    "telecom" : [{
+      "system" : "url",
+      "value" : "http://example.org/example-publisher"
+    }]
+  }]
+}

--- a/crates/rh-cpg/tests/fixtures/PlanDefinition-SimplePlanDefinitionWithGoal.json
+++ b/crates/rh-cpg/tests/fixtures/PlanDefinition-SimplePlanDefinitionWithGoal.json
@@ -1,0 +1,22 @@
+{
+  "resourceType" : "PlanDefinition",
+  "id" : "SimplePlanDefinitionWithGoal",
+  "url" : "http://example.org/PlanDefinition/SimplePlanDefinitionWithGoal",
+  "version" : "0.1.0",
+  "name" : "SimplePlanDefinitionWithGoal",
+  "status" : "active",
+  "date" : "2023-01-23T15:45:25-05:00",
+  "publisher" : "Example Publisher",
+  "contact" : [{
+    "name" : "Example Publisher",
+    "telecom" : [{
+      "system" : "url",
+      "value" : "http://example.org/example-publisher"
+    }]
+  }],
+  "goal" : [{
+    "description" : {
+      "text" : "to improve"
+    }
+  }]
+}


### PR DESCRIPTION
## Summary

Adds the `rh-cpg` crate with a Rust-native Phase 1 implementation of PlanDefinition `$apply`, plus the `rh cpg apply` CLI command. CQL evaluation uses `rh-cql`, FHIRPath uses `rh-fhirpath`, and content resolution uses a Bundle-backed `ContentResolver`.

## Included

- PlanDefinition orchestration into a RequestGroup and collection Bundle
- Applicability conditions, nested actions, goals, dynamic values, and definition resolution
- Exact and ambiguity-safe canonical resolution, including `url|version`
- CQL identifier evaluation with patient-scoped Bundle data
- CLI support for content/data Bundles, subject/encounter/practitioner/organization, and deterministic `--evaluation-date`
- R4-valid ActivityDefinition output for Appointment, CarePlan, CommunicationRequest, DeviceRequest, ImmunizationRecommendation, MedicationRequest, NutritionOrder, ServiceRequest, SupplyRequest, and Task

## Safety boundaries

- Missing referenced definitions fail instead of silently dropping actions.
- Patient-context retrieves support Patient, Encounter, Observation, and QuestionnaireResponse. Other resource relationships fail closed until an explicit compartment mapping is implemented.
- ActivityDefinition application validates target-specific intent and required fields after dynamic values; empty synthetic dosage instructions are omitted.
- AppointmentResponse, Claim, Contract, EnrollmentRequest, and VisionPrescription are intentionally unsupported rather than emitting incomplete FHIR skeletons.
- StructureMap transforms and `definitionUri` remain deferred.

## Validation

- `cargo test -p rh-cpg` — 40 unit and 4 integration tests
- `cargo test -p rh-cli --test cpg_apply_test`
- `cargo clippy -p rh-cpg -p rh-cli --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `scripts/check-docs-sync.sh`
- Validator-backed coverage for every supported ActivityDefinition target kind
